### PR TITLE
Add open-in-new-tab support to repo titles across the UI

### DIFF
--- a/src/kohaku-hub-ui/src/components/repo/RepoList.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoList.vue
@@ -11,10 +11,14 @@
         <div class="flex-1 w-full">
           <div class="flex items-center gap-2 mb-2 flex-wrap">
             <div :class="getIconClass(type)" />
-            <h3
-              class="text-base sm:text-lg font-semibold text-blue-600 dark:text-blue-400 hover:underline break-all"
-            >
-              {{ repo.id }}
+            <h3 class="text-base sm:text-lg font-semibold">
+              <RouterLink
+                :to="getRepoPath(repo)"
+                class="block text-blue-600 dark:text-blue-400 hover:underline break-all"
+                @click.stop
+              >
+                {{ repo.id }}
+              </RouterLink>
             </h3>
             <el-tag v-if="repo.private" size="small" type="warning">
               Private
@@ -107,8 +111,12 @@ function formatDate(date) {
   return dayjs(date).fromNow();
 }
 
-function goToRepo(repo) {
+function getRepoPath(repo) {
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${props.type}s/${namespace}/${name}`);
+  return `/${props.type}s/${namespace}/${name}`;
+}
+
+function goToRepo(repo) {
+  router.push(getRepoPath(repo));
 }
 </script>

--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -2,14 +2,38 @@
 <template>
   <div class="container-main">
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s` }">
-        {{ repoTypeLabel }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: namespaceLink }">
-        {{ namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ repoTypeLabel }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item>{{ name }}</el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="namespaceLink"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s/${namespace}/${name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ name }}
+        </RouterLink>
+      </el-breadcrumb-item>
     </el-breadcrumb>
 
     <div v-if="loading" class="text-center py-20">
@@ -529,10 +553,14 @@
                     class="i-carbon-commit text-2xl text-blue-500 flex-shrink-0 mt-1"
                   />
                   <div class="flex-1 min-w-0">
-                    <div
-                      class="font-medium text-sm mb-1 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                    >
-                      {{ commit.title }}
+                    <div class="font-medium text-sm mb-1">
+                      <RouterLink
+                        :to="getCommitPath(commit.id)"
+                        class="block text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                        @click.stop
+                      >
+                        {{ commit.title }}
+                      </RouterLink>
                     </div>
                     <div
                       class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400"
@@ -1031,10 +1059,12 @@ function navigateToUpload() {
   );
 }
 
+function getCommitPath(commitId) {
+  return `/${props.repoType}s/${props.namespace}/${props.name}/commit/${commitId}`;
+}
+
 function viewCommit(commitId) {
-  router.push(
-    `/${props.repoType}s/${props.namespace}/${props.name}/commit/${commitId}`,
-  );
+  router.push(getCommitPath(commitId));
 }
 
 function handleBranchChange() {

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/blob/[branch]/[...file].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/blob/[branch]/[...file].vue
@@ -3,15 +3,37 @@
   <div class="container-main">
     <!-- Breadcrumb -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s` }">
-        {{ repoTypeLabel }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${namespace}` }">
-        {{ namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ repoTypeLabel }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s/${namespace}/${name}` }">
-        {{ name }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${namespace}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s/${namespace}/${name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ name }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>{{ fileName }}</el-breadcrumb-item>
     </el-breadcrumb>
@@ -112,15 +134,13 @@
                 v-for="(segment, idx) in pathSegments"
                 :key="idx"
               >
-                <a
+                <RouterLink
                   v-if="idx < pathSegments.length - 1"
-                  @click="
-                    navigateToFolder(pathSegments.slice(0, idx + 1).join('/'))
-                  "
-                  class="cursor-pointer text-blue-600 dark:text-blue-400 hover:underline"
+                  :to="getFolderPath(pathSegments.slice(0, idx + 1).join('/'))"
+                  class="text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   {{ segment }}
-                </a>
+                </RouterLink>
                 <span v-else class="text-gray-700 dark:text-gray-300">{{
                   segment
                 }}</span>
@@ -582,11 +602,8 @@ async function copyContent() {
   }
 }
 
-function navigateToFolder(folderPath) {
-  // Navigate back to tree viewer with the folder path
-  router.push(
-    `/${repoType.value}s/${namespace.value}/${name.value}/tree/${branch.value}/${folderPath}`,
-  );
+function getFolderPath(folderPath) {
+  return `/${repoType.value}s/${namespace.value}/${name.value}/tree/${branch.value}/${folderPath}`;
 }
 
 function editFile() {

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
@@ -3,21 +3,43 @@
   <div class="container-main">
     <!-- Breadcrumb Navigation -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${type}s` }">
-        {{
-          type === "model"
-            ? "Models"
-            : type === "dataset"
-              ? "Datasets"
-              : "Spaces"
-        }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${namespace}` }">
-        {{ namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${type}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{
+            type === "model"
+              ? "Models"
+              : type === "dataset"
+                ? "Datasets"
+                : "Spaces"
+          }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${type}s/${namespace}/${name}` }">
-        {{ name }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${namespace}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${type}s/${namespace}/${name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ name }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item
         >Commit {{ commitId?.substring(0, 8) }}</el-breadcrumb-item

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/edit/[branch]/[...file].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/edit/[branch]/[...file].vue
@@ -3,15 +3,37 @@
   <div class="container-main">
     <!-- Breadcrumb -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s` }">
-        {{ repoTypeLabel }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${namespace}` }">
-        {{ namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ repoTypeLabel }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s/${namespace}/${name}` }">
-        {{ name }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${namespace}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s/${namespace}/${name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ name }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>
         <span class="text-gray-500">Edit:</span> {{ fileName }}

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
@@ -3,25 +3,43 @@
   <div class="container-main">
     <!-- Breadcrumb Navigation -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s` }">
-        {{
-          repoType === "model"
-            ? "Models"
-            : repoType === "dataset"
-              ? "Datasets"
-              : "Spaces"
-        }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${route.params.namespace}` }">
-        {{ route.params.namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{
+            repoType === "model"
+              ? "Models"
+              : repoType === "dataset"
+                ? "Datasets"
+                : "Spaces"
+          }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item
-        :to="{
-          path: `/${repoType}s/${route.params.namespace}/${route.params.name}`,
-        }"
-      >
-        {{ route.params.name }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${route.params.namespace}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ route.params.namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s/${route.params.namespace}/${route.params.name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ route.params.name }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>Settings</el-breadcrumb-item>
     </el-breadcrumb>

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/upload/[branch].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/upload/[branch].vue
@@ -3,15 +3,37 @@
   <div class="container-main">
     <!-- Breadcrumb -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s` }">
-        {{ repoTypeLabel }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${namespace}` }">
-        {{ namespace }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ repoTypeLabel }}
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${repoType}s/${namespace}/${name}` }">
-        {{ name }}
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${namespace}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ namespace }}
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${repoType}s/${namespace}/${name}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ name }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>Upload Files</el-breadcrumb-item>
     </el-breadcrumb>

--- a/src/kohaku-hub-ui/src/pages/[username]/[type].vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/[type].vue
@@ -218,10 +218,14 @@
                   class="i-carbon-model text-blue-500 text-xl flex-shrink-0"
                 />
                 <div class="flex-1 min-w-0">
-                  <h3
-                    class="font-semibold text-blue-600 dark:text-blue-400 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h3 class="font-semibold">
+                    <RouterLink
+                      :to="getRepoPath('model', repo)"
+                      class="block text-blue-600 dark:text-blue-400 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h3>
                   <div class="text-xs text-gray-600 dark:text-gray-400 mt-1">
                     Updated {{ formatDate(repo.lastModified) }}
@@ -327,10 +331,14 @@
                   class="i-carbon-data-table text-green-500 text-xl flex-shrink-0"
                 />
                 <div class="flex-1 min-w-0">
-                  <h3
-                    class="font-semibold text-green-600 dark:text-green-400 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h3 class="font-semibold">
+                    <RouterLink
+                      :to="getRepoPath('dataset', repo)"
+                      class="block text-green-600 dark:text-green-400 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h3>
                   <div class="text-xs text-gray-600 mt-1">
                     Updated {{ formatDate(repo.lastModified) }}
@@ -423,10 +431,14 @@
                   class="i-carbon-application text-purple-500 text-xl flex-shrink-0"
                 />
                 <div class="flex-1 min-w-0">
-                  <h3
-                    class="font-semibold text-purple-600 dark:text-purple-400 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h3 class="font-semibold">
+                    <RouterLink
+                      :to="getRepoPath('space', repo)"
+                      class="block text-purple-600 dark:text-purple-400 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h3>
                   <div class="text-xs text-gray-600 mt-1">
                     Updated {{ formatDate(repo.lastModified) }}
@@ -527,9 +539,13 @@ function formatDate(date) {
   return date ? dayjs(date).fromNow() : "never";
 }
 
-function goToRepo(type, repo) {
+function getRepoPath(type, repo) {
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${type}s/${namespace}/${name}`);
+  return `/${type}s/${namespace}/${name}`;
+}
+
+function goToRepo(type, repo) {
+  router.push(getRepoPath(type, repo));
 }
 
 function openExternalRepo(repo) {

--- a/src/kohaku-hub-ui/src/pages/[username]/index.vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/index.vue
@@ -416,10 +416,14 @@
                       class="i-carbon-model text-blue-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-blue-600 dark:text-blue-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('model', repo)"
+                          class="block text-blue-600 dark:text-blue-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div
                         class="text-xs text-gray-600 dark:text-gray-400 mt-1"
@@ -521,10 +525,14 @@
                       class="i-carbon-data-table text-green-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-green-600 dark:text-green-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('dataset', repo)"
+                          class="block text-green-600 dark:text-green-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div
                         class="text-xs text-gray-600 dark:text-gray-400 mt-1"
@@ -626,10 +634,14 @@
                       class="i-carbon-application text-purple-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-purple-600 dark:text-purple-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('space', repo)"
+                          class="block text-purple-600 dark:text-purple-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div
                         class="text-xs text-gray-600 dark:text-gray-400 mt-1"
@@ -830,9 +842,13 @@ function getQuotaStatus(percentage) {
   return "success";
 }
 
-function goToRepo(type, repo) {
+function getRepoPath(type, repo) {
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${type}s/${namespace}/${name}`);
+  return `/${type}s/${namespace}/${name}`;
+}
+
+function goToRepo(type, repo) {
+  router.push(getRepoPath(type, repo));
 }
 
 function openExternalRepo(repo, type) {

--- a/src/kohaku-hub-ui/src/pages/[username]/storage.vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/storage.vue
@@ -3,9 +3,21 @@
   <div class="container-main">
     <!-- Breadcrumb Navigation -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/${username}` }">
-        {{ username }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/${username}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ username }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>Storage</el-breadcrumb-item>
     </el-breadcrumb>

--- a/src/kohaku-hub-ui/src/pages/index.vue
+++ b/src/kohaku-hub-ui/src/pages/index.vue
@@ -59,10 +59,14 @@
               <div class="flex items-start gap-2 mb-2">
                 <div class="i-carbon-model text-blue-500 flex-shrink-0" />
                 <div class="flex-1 min-w-0">
-                  <h4
-                    class="font-semibold text-sm text-blue-600 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h4 class="font-semibold text-sm">
+                    <RouterLink
+                      :to="getRepoPath('model', repo)"
+                      class="block text-blue-600 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h4>
                   <div class="text-xs text-gray-600 dark:text-gray-400 mt-1">
                     {{ formatDate(repo.lastModified) }}
@@ -112,10 +116,14 @@
               <div class="flex items-start gap-2 mb-2">
                 <div class="i-carbon-data-table text-green-500 flex-shrink-0" />
                 <div class="flex-1 min-w-0">
-                  <h4
-                    class="font-semibold text-sm text-green-600 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h4 class="font-semibold text-sm">
+                    <RouterLink
+                      :to="getRepoPath('dataset', repo)"
+                      class="block text-green-600 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h4>
                   <div class="text-xs text-gray-600 dark:text-gray-400 mt-1">
                     {{ formatDate(repo.lastModified) }}
@@ -167,10 +175,14 @@
                   class="i-carbon-application text-purple-500 flex-shrink-0"
                 />
                 <div class="flex-1 min-w-0">
-                  <h4
-                    class="font-semibold text-sm text-purple-600 hover:underline truncate"
-                  >
-                    {{ repo.id }}
+                  <h4 class="font-semibold text-sm">
+                    <RouterLink
+                      :to="getRepoPath('space', repo)"
+                      class="block text-purple-600 hover:underline truncate"
+                      @click.stop
+                    >
+                      {{ repo.id }}
+                    </RouterLink>
                   </h4>
                   <div class="text-xs text-gray-600 dark:text-gray-400 mt-1">
                     {{ formatDate(repo.lastModified) }}
@@ -225,9 +237,13 @@ function formatDate(date) {
   return dayjs(date).fromNow();
 }
 
-function goToRepo(type, repo) {
+function getRepoPath(type, repo) {
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${type}s/${namespace}/${name}`);
+  return `/${type}s/${namespace}/${name}`;
+}
+
+function goToRepo(type, repo) {
+  router.push(getRepoPath(type, repo));
 }
 
 async function loadStats() {

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/[type].vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/[type].vue
@@ -202,11 +202,15 @@
                 <div class="flex items-start gap-2 mb-2">
                   <div :class="iconClass" class="text-xl flex-shrink-0" />
                   <div class="flex-1 min-w-0">
-                    <h3
-                      class="font-semibold hover:underline truncate"
-                      :class="titleColor"
-                    >
-                      {{ repo.id }}
+                    <h3 class="font-semibold">
+                      <RouterLink
+                        :to="getRepoPath(repo)"
+                        class="block hover:underline truncate"
+                        :class="titleColor"
+                        @click.stop
+                      >
+                        {{ repo.id }}
+                      </RouterLink>
                     </h3>
                     <div class="text-xs text-gray-600 dark:text-gray-400 mt-1">
                       Updated {{ formatDate(repo.lastModified) }}
@@ -365,10 +369,14 @@ function formatDate(date) {
   return date ? dayjs(date).fromNow() : "never";
 }
 
-function goToRepo(repo) {
+function getRepoPath(repo) {
   const type = typeMapping[currentType.value] || "model";
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${type}s/${namespace}/${name}`);
+  return `/${type}s/${namespace}/${name}`;
+}
+
+function goToRepo(repo) {
+  router.push(getRepoPath(repo));
 }
 
 function goToUser(username) {

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/index.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/index.vue
@@ -477,10 +477,14 @@
                       class="i-carbon-model text-blue-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-blue-600 dark:text-blue-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('model', repo)"
+                          class="block text-blue-600 dark:text-blue-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div
                         class="text-xs text-gray-600 dark:text-gray-400 mt-1"
@@ -582,10 +586,14 @@
                       class="i-carbon-data-table text-green-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-green-600 dark:text-green-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('dataset', repo)"
+                          class="block text-green-600 dark:text-green-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div class="text-xs text-gray-600 mt-1">
                         Updated {{ formatDate(repo.lastModified) }}
@@ -685,10 +693,14 @@
                       class="i-carbon-application text-purple-500 text-xl flex-shrink-0"
                     />
                     <div class="flex-1 min-w-0">
-                      <h3
-                        class="font-semibold text-purple-600 dark:text-purple-400 hover:underline truncate"
-                      >
-                        {{ repo.id }}
+                      <h3 class="font-semibold">
+                        <RouterLink
+                          :to="getRepoPath('space', repo)"
+                          class="block text-purple-600 dark:text-purple-400 hover:underline truncate"
+                          @click.stop
+                        >
+                          {{ repo.id }}
+                        </RouterLink>
                       </h3>
                       <div class="text-xs text-gray-600 mt-1">
                         Updated {{ formatDate(repo.lastModified) }}
@@ -847,9 +859,13 @@ function getQuotaStatus(percentage) {
   return "success";
 }
 
-function goToRepo(type, repo) {
+function getRepoPath(type, repo) {
   const [namespace, name] = repo.id.split("/");
-  router.push(`/${type}s/${namespace}/${name}`);
+  return `/${type}s/${namespace}/${name}`;
+}
+
+function goToRepo(type, repo) {
+  router.push(getRepoPath(type, repo));
 }
 
 function goToUser(username) {

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/storage.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/storage.vue
@@ -3,12 +3,29 @@
   <div class="container-main">
     <!-- Breadcrumb Navigation -->
     <el-breadcrumb separator="/" class="mb-6 text-gray-700 dark:text-gray-300">
-      <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: '/organizations' }">
-        Organizations
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Home
+        </RouterLink>
       </el-breadcrumb-item>
-      <el-breadcrumb-item :to="{ path: `/organizations/${orgname}` }">
-        {{ orgname }}
+      <el-breadcrumb-item>
+        <RouterLink
+          to="/organizations"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Organizations
+        </RouterLink>
+      </el-breadcrumb-item>
+      <el-breadcrumb-item>
+        <RouterLink
+          :to="`/organizations/${orgname}`"
+          class="text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {{ orgname }}
+        </RouterLink>
       </el-breadcrumb-item>
       <el-breadcrumb-item>Storage</el-breadcrumb-item>
     </el-breadcrumb>

--- a/src/kohaku-hub-ui/src/pages/organizations/index.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/index.vue
@@ -58,10 +58,14 @@
               style="display: none"
             />
             <div class="flex-1 min-w-0">
-              <h3
-                class="text-lg font-semibold text-blue-600 dark:text-blue-400 truncate"
-              >
-                {{ org.name }}
+              <h3 class="text-lg font-semibold truncate">
+                <RouterLink
+                  :to="getOrganizationPath(org.name)"
+                  class="block text-blue-600 dark:text-blue-400 hover:underline"
+                  @click.stop
+                >
+                  {{ org.name }}
+                </RouterLink>
               </h3>
               <p
                 class="text-sm text-gray-600 dark:text-gray-400 mt-1"
@@ -154,8 +158,12 @@ function getRoleType(role) {
   }
 }
 
+function getOrganizationPath(orgName) {
+  return `/organizations/${orgName}`;
+}
+
 function goToOrganization(orgName) {
-  router.push(`/organizations/${orgName}`);
+  router.push(getOrganizationPath(orgName));
 }
 
 async function loadOrganizations() {


### PR DESCRIPTION
## Summary
- turn repo titles into real links across the main repo card surfaces
- allow right-click, middle-click, and browser open-in-new-tab behavior on repo titles
- keep the existing card click-to-navigate behavior for the rest of each card

## Scope
- homepage trending repo cards
- shared repository list cards
- user profile repository sections
- user repository listing pages
- organization profile repository sections
- organization repository listing pages

## Testing
- npm run build
