### PR TITLE
Add session-scoped repo sorting and browser-aware timestamps

### DIFF
--- a/src/kohaku-hub-ui/src/components/pages/RepoListPage.vue
+++ b/src/kohaku-hub-ui/src/components/pages/RepoListPage.vue
@@ -26,29 +26,33 @@
     <!-- Filters -->
     <div class="card mb-6">
       <div
-        class="flex flex-col sm:flex-row items-stretch sm:items-center gap-4"
+        class="flex flex-col gap-4 md:flex-row md:items-center"
       >
-        <el-input
-          v-model="searchQuery"
-          :placeholder="`Search ${repoType}s...`"
-          clearable
-          class="flex-1"
-        >
-          <template #prefix>
-            <div class="i-carbon-search" />
-          </template>
-        </el-input>
+        <div class="w-full md:flex-1 md:min-w-0">
+          <el-input
+            v-model="searchQuery"
+            :placeholder="`Search ${repoType}s...`"
+            clearable
+            class="w-full"
+          >
+            <template #prefix>
+              <div class="i-carbon-search" />
+            </template>
+          </el-input>
+        </div>
 
-        <el-select
-          v-model="sortBy"
-          placeholder="Sort by"
-          class="w-full sm:w-50"
-        >
-          <el-option label="Recently Updated" value="updated" />
-          <el-option label="Recently Created" value="created" />
-          <el-option label="Most Downloads" value="downloads" />
-          <el-option label="Most Likes" value="likes" />
-        </el-select>
+        <div class="w-full md:w-72 md:flex-none md:shrink-0">
+          <el-select
+            v-model="sortBy"
+            placeholder="Sort by"
+            class="w-full"
+          >
+            <el-option label="Recently Created" value="recent" />
+            <el-option label="Recently Updated" value="updated" />
+            <el-option label="Most Downloads" value="downloads" />
+            <el-option label="Most Likes" value="likes" />
+          </el-select>
+        </div>
       </div>
     </div>
 
@@ -108,6 +112,10 @@
 import { repoAPI, orgAPI } from "@/utils/api";
 import { useAuthStore } from "@/stores/auth";
 import RepoList from "@/components/repo/RepoList.vue";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 import { ElMessage } from "element-plus";
 
 const props = defineProps({
@@ -144,7 +152,14 @@ const pageDescription = computed(() => {
 const loading = ref(true);
 const repos = ref([]);
 const searchQuery = ref("");
-const sortBy = ref("updated");
+const sortBy = ref(
+  getRepoSortPreference({
+    scope: "repo",
+    repoType: props.repoType,
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+);
 const showCreateDialog = ref(false);
 const creating = ref(false);
 const userOrgs = ref([]);
@@ -190,24 +205,9 @@ const filteredRepos = computed(() => {
 async function loadRepos() {
   loading.value = true;
   try {
-    // Map frontend sort values to backend API values
-    let apiSort = "recent"; // default
-    switch (sortBy.value) {
-      case "updated":
-      case "created":
-        apiSort = "recent";
-        break;
-      case "downloads":
-        apiSort = "downloads";
-        break;
-      case "likes":
-        apiSort = "likes";
-        break;
-    }
-
     const { data } = await repoAPI.listRepos(props.repoType, {
       limit: 100,
-      sort: apiSort,
+      sort: sortBy.value,
       fallback: false, // Don't aggregate external repos on main list pages
     });
     repos.value = data;
@@ -274,6 +274,11 @@ watch(showCreateDialog, (val) => {
 
 // Reload repos when sort changes
 watch(sortBy, () => {
+  setRepoSortPreference({
+    scope: "repo",
+    repoType: props.repoType,
+    value: sortBy.value,
+  });
   loadRepos();
 });
 

--- a/src/kohaku-hub-ui/src/components/repo/RepoList.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoList.vue
@@ -74,10 +74,7 @@
 </template>
 
 <script setup>
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import { formatRelativeTime } from "@/utils/datetime";
 
 /**
  * @typedef {Object} Props
@@ -108,7 +105,7 @@ function getIconClass(type) {
 }
 
 function formatDate(date) {
-  return dayjs(date).fromNow();
+  return formatRelativeTime(date, "never");
 }
 
 function getRepoPath(repo) {

--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -808,8 +808,10 @@ huggingface-cli download {{ repoInfo?.id }}</pre
 <script setup>
 import { ElMessage, ElMessageBox } from "element-plus";
 import axios from "axios";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
+import {
+  formatRelativeTime,
+  formatUnixRelativeTime,
+} from "@/utils/datetime";
 
 import { useAuthStore } from "@/stores/auth";
 import { copyToClipboard } from "@/utils/clipboard";
@@ -822,8 +824,6 @@ import DetailedMetadataPanel from "@/components/repo/metadata/DetailedMetadataPa
 import ReferencedDatasetsCard from "@/components/repo/metadata/ReferencedDatasetsCard.vue";
 import SidebarRelationshipsCard from "@/components/repo/metadata/SidebarRelationshipsCard.vue";
 import DatasetViewerTab from "@/components/repo/DatasetViewerTab.vue";
-
-dayjs.extend(relativeTime);
 
 /**
  * @typedef {Object} Props
@@ -994,7 +994,7 @@ function openExternalRepo() {
 }
 
 function formatDate(date) {
-  return date ? dayjs(date).fromNow() : "Unknown";
+  return formatRelativeTime(date, "Unknown");
 }
 
 function formatSize(bytes) {
@@ -1007,12 +1007,7 @@ function formatSize(bytes) {
 }
 
 function formatLastModified(dateString) {
-  if (!dateString) return "-";
-  try {
-    return dayjs(dateString).fromNow();
-  } catch (e) {
-    return "-";
-  }
+  return formatRelativeTime(dateString, "-");
 }
 
 function getFileName(path) {
@@ -1295,8 +1290,7 @@ function downloadRepo() {
 }
 
 function formatCommitDate(timestamp) {
-  if (!timestamp) return "Unknown";
-  return dayjs.unix(timestamp).fromNow();
+  return formatUnixRelativeTime(timestamp, "Unknown");
 }
 
 function getProgressColor(percentage) {

--- a/src/kohaku-hub-ui/src/main.js
+++ b/src/kohaku-hub-ui/src/main.js
@@ -4,6 +4,7 @@ import { createPinia } from "pinia";
 import { createRouter, createWebHistory } from "vue-router";
 import { routes } from "vue-router/auto-routes";
 import App from "./App.vue";
+import { initializeBrowserTimezone } from "./utils/datetime";
 
 // Import UnoCSS
 import "virtual:uno.css";
@@ -22,6 +23,8 @@ import "./style.css";
 
 const app = createApp(App);
 const pinia = createPinia();
+
+initializeBrowserTimezone();
 
 // Create router
 const router = createRouter({

--- a/src/kohaku-hub-ui/src/pages/[username]/[type].vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/[type].vue
@@ -184,13 +184,16 @@
 
             <div class="flex gap-3">
               <el-select
-                v-model="sortBy"
+                v-model="selectedSort"
                 placeholder="Sort by"
                 style="width: 200px"
               >
-                <el-option label="Recently Updated" value="recent" />
-                <el-option label="Most Downloads" value="downloads" />
-                <el-option label="Most Likes" value="likes" />
+                <el-option
+                  v-for="option in sortOptions"
+                  :key="option.value"
+                  :label="option.label"
+                  :value="option.value"
+                />
               </el-select>
 
               <el-input
@@ -297,13 +300,16 @@
 
             <div class="flex gap-3">
               <el-select
-                v-model="sortBy"
+                v-model="selectedSort"
                 placeholder="Sort by"
                 style="width: 200px"
               >
-                <el-option label="Recently Updated" value="recent" />
-                <el-option label="Most Downloads" value="downloads" />
-                <el-option label="Most Likes" value="likes" />
+                <el-option
+                  v-for="option in sortOptions"
+                  :key="option.value"
+                  :label="option.label"
+                  :value="option.value"
+                />
               </el-select>
 
               <el-input
@@ -397,13 +403,16 @@
 
             <div class="flex gap-3">
               <el-select
-                v-model="sortBy"
+                v-model="selectedSort"
                 placeholder="Sort by"
                 style="width: 200px"
               >
-                <el-option label="Recently Updated" value="recent" />
-                <el-option label="Most Downloads" value="downloads" />
-                <el-option label="Most Likes" value="likes" />
+                <el-option
+                  v-for="option in sortOptions"
+                  :key="option.value"
+                  :label="option.label"
+                  :value="option.value"
+                />
               </el-select>
 
               <el-input
@@ -491,10 +500,11 @@
 <script setup>
 import { repoAPI, orgAPI } from "@/utils/api";
 import axios from "axios";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import { formatRelativeTime } from "@/utils/datetime";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 
 const route = useRoute();
 const router = useRouter();
@@ -507,7 +517,6 @@ const userNotFound = ref(false);
 const userInfo = ref(null);
 const repos = ref({ model: [], dataset: [], space: [] });
 const searchQuery = ref("");
-const sortBy = ref("recent");
 
 // Map route type to API type
 const repoType = computed(() => {
@@ -516,6 +525,22 @@ const repoType = computed(() => {
   if (currentType.value === "spaces") return "space";
   return "model";
 });
+
+const selectedSort = ref(
+  getRepoSortPreference({
+    scope: "user",
+    repoType: repoType.value,
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+);
+
+const sortOptions = [
+  { label: "Recently Created", value: "recent" },
+  { label: "Recently Updated", value: "updated" },
+  { label: "Most Downloads", value: "downloads" },
+  { label: "Most Likes", value: "likes" },
+];
 
 const filteredRepos = computed(() => {
   const query = searchQuery.value.toLowerCase();
@@ -536,7 +561,7 @@ function getCount(type) {
 }
 
 function formatDate(date) {
-  return date ? dayjs(date).fromNow() : "never";
+  return formatRelativeTime(date, "never");
 }
 
 function getRepoPath(type, repo) {
@@ -617,17 +642,41 @@ async function loadRepos() {
     const [models, datasets, spaces] = await Promise.all([
       repoAPI.listRepos("model", {
         author: username.value,
-        sort: sortBy.value,
+        sort:
+          repoType.value === "model"
+            ? selectedSort.value
+            : getRepoSortPreference({
+                scope: "user",
+                repoType: "model",
+                allowedValues: ["recent", "updated", "downloads", "likes"],
+                fallback: "recent",
+              }),
         limit: 100000, // Very high limit to get all repos
       }),
       repoAPI.listRepos("dataset", {
         author: username.value,
-        sort: sortBy.value,
+        sort:
+          repoType.value === "dataset"
+            ? selectedSort.value
+            : getRepoSortPreference({
+                scope: "user",
+                repoType: "dataset",
+                allowedValues: ["recent", "updated", "downloads", "likes"],
+                fallback: "recent",
+              }),
         limit: 100000,
       }),
       repoAPI.listRepos("space", {
         author: username.value,
-        sort: sortBy.value,
+        sort:
+          repoType.value === "space"
+            ? selectedSort.value
+            : getRepoSortPreference({
+                scope: "user",
+                repoType: "space",
+                allowedValues: ["recent", "updated", "downloads", "likes"],
+                fallback: "recent",
+              }),
         limit: 100000,
       }),
     ]);
@@ -643,13 +692,30 @@ async function loadRepos() {
 }
 
 // Reload when sort changes
-watch(sortBy, () => {
-  loadRepos();
+watch(selectedSort, () => {
+  setRepoSortPreference({
+    scope: "user",
+    repoType: repoType.value,
+    value: selectedSort.value,
+  });
+
+  if (!loading.value && !userNotFound.value) {
+    loadRepos();
+  }
 });
 
 // Reset search when type changes
 watch(currentType, () => {
   searchQuery.value = "";
+});
+
+watch(repoType, (type) => {
+  selectedSort.value = getRepoSortPreference({
+    scope: "user",
+    repoType: type,
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  });
 });
 
 onMounted(async () => {

--- a/src/kohaku-hub-ui/src/pages/[username]/index.vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/index.vue
@@ -370,19 +370,6 @@
 
         <!-- Main Content -->
         <main class="space-y-8">
-          <!-- Sort Dropdown (applies to all sections) -->
-          <div class="card">
-            <el-select
-              v-model="sortBy"
-              placeholder="Sort by"
-              class="w-full sm:w-50"
-            >
-              <el-option label="Recently Updated" value="recent" />
-              <el-option label="Most Downloads" value="downloads" />
-              <el-option label="Most Likes" value="likes" />
-            </el-select>
-          </div>
-
           <!-- User Card (from Username/Username space repo if exists) -->
           <section v-if="userCard" class="card">
             <div class="markdown-body">
@@ -393,13 +380,29 @@
           <!-- Models Section -->
           <section class="mb-8">
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-blue-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-blue-500"
             >
               <div class="flex items-center gap-2">
                 <div class="i-carbon-model text-blue-500 text-xl md:text-2xl" />
                 <h2 class="text-xl md:text-2xl font-bold">Models</h2>
               </div>
-              <el-tag type="info" size="large">{{ getCount("model") }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.model"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="info" size="large">{{ getCount("model") }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('model') > 0" class="space-y-4">
@@ -498,7 +501,7 @@
           <!-- Datasets Section -->
           <section class="mb-8">
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-green-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-green-500"
             >
               <div class="flex items-center gap-2">
                 <div
@@ -506,9 +509,25 @@
                 />
                 <h2 class="text-xl md:text-2xl font-bold">Datasets</h2>
               </div>
-              <el-tag type="success" size="large">{{
-                getCount("dataset")
-              }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.dataset"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="success" size="large">{{
+                  getCount("dataset")
+                }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('dataset') > 0" class="space-y-4">
@@ -607,7 +626,7 @@
           <!-- Spaces Section -->
           <section>
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-purple-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-purple-500"
             >
               <div class="flex items-center gap-2">
                 <div
@@ -615,9 +634,25 @@
                 />
                 <h2 class="text-xl md:text-2xl font-bold">Spaces</h2>
               </div>
-              <el-tag type="warning" size="large">{{
-                getCount("space")
-              }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.space"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="warning" size="large">{{
+                  getCount("space")
+                }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('space') > 0" class="space-y-4">
@@ -722,11 +757,12 @@
 import { repoAPI, orgAPI, settingsAPI } from "@/utils/api";
 import MarkdownViewer from "@/components/common/MarkdownViewer.vue";
 import SocialLinks from "@/components/profile/SocialLinks.vue";
+import { formatRelativeTime } from "@/utils/datetime";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 import axios from "axios";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
 
 const route = useRoute();
 const router = useRouter();
@@ -740,9 +776,34 @@ const userCard = ref("");
 const userNotFound = ref(false);
 const quotaInfo = ref(null);
 const hasAvatar = ref(true); // Assume avatar exists, will be set to false on error
-const sortBy = ref("recent"); // Sort option
+const selectedSorts = reactive({
+  model: getRepoSortPreference({
+    scope: "user",
+    repoType: "model",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+  dataset: getRepoSortPreference({
+    scope: "user",
+    repoType: "dataset",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+  space: getRepoSortPreference({
+    scope: "user",
+    repoType: "space",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+});
 
 const MAX_DISPLAYED = 6; // 2 per row × 3 rows
+const sortOptions = [
+  { label: "Recently Created", value: "recent" },
+  { label: "Recently Updated", value: "updated" },
+  { label: "Most Downloads", value: "downloads" },
+  { label: "Most Likes", value: "likes" },
+];
 
 // External user detection (check both profile and repos)
 const isExternalUser = computed(() => {
@@ -823,7 +884,7 @@ function hasMoreRepos(type) {
 }
 
 function formatDate(date) {
-  return date ? dayjs(date).fromNow() : "never";
+  return formatRelativeTime(date, "never");
 }
 
 function formatBytes(bytes) {
@@ -914,13 +975,17 @@ async function checkUserExists() {
 
 async function loadUserData() {
   try {
-    // Get user overview which returns all repos (use very high limit to get all repos)
-    const response = await repoAPI.getUserOverview(
-      username.value,
-      sortBy.value,
-      100000, // Very high limit to get all repos
-    );
-    repos.value = response.data;
+    const [models, datasets, spaces] = await Promise.all([
+      loadRepoType("model"),
+      loadRepoType("dataset"),
+      loadRepoType("space"),
+    ]);
+
+    repos.value = {
+      models,
+      datasets,
+      spaces,
+    };
     return true;
   } catch (err) {
     // Even if repos fail to load, if user exists we show empty state
@@ -930,10 +995,59 @@ async function loadUserData() {
   }
 }
 
-// Watch sortBy changes and reload
-watch(sortBy, () => {
-  loadUserData();
-});
+async function loadRepoType(type) {
+  const { data } = await repoAPI.listRepos(type, {
+    author: username.value,
+    sort: selectedSorts[type],
+    limit: 100000,
+  });
+  return data;
+}
+
+watch(
+  () => selectedSorts.model,
+  async () => {
+    setRepoSortPreference({
+      scope: "user",
+      repoType: "model",
+      value: selectedSorts.model,
+    });
+
+    if (!loading.value && !userNotFound.value) {
+      repos.value.models = await loadRepoType("model");
+    }
+  },
+);
+
+watch(
+  () => selectedSorts.dataset,
+  async () => {
+    setRepoSortPreference({
+      scope: "user",
+      repoType: "dataset",
+      value: selectedSorts.dataset,
+    });
+
+    if (!loading.value && !userNotFound.value) {
+      repos.value.datasets = await loadRepoType("dataset");
+    }
+  },
+);
+
+watch(
+  () => selectedSorts.space,
+  async () => {
+    setRepoSortPreference({
+      scope: "user",
+      repoType: "space",
+      value: selectedSorts.space,
+    });
+
+    if (!loading.value && !userNotFound.value) {
+      repos.value.spaces = await loadRepoType("space");
+    }
+  },
+);
 
 async function loadUserCard() {
   try {

--- a/src/kohaku-hub-ui/src/pages/[username]/storage.vue
+++ b/src/kohaku-hub-ui/src/pages/[username]/storage.vue
@@ -213,11 +213,8 @@
 
 <script setup>
 import { quotaAPI } from "@/utils/api";
+import { formatRelativeTime } from "@/utils/datetime";
 import { ElMessage } from "element-plus";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
 
 const route = useRoute();
 const router = useRouter();
@@ -269,7 +266,7 @@ function formatSize(bytes) {
 
 function formatDate(dateStr) {
   if (!dateStr) return "Unknown";
-  return dayjs(dateStr).fromNow();
+  return formatRelativeTime(dateStr, "Unknown");
 }
 
 function getRepoIcon(type) {

--- a/src/kohaku-hub-ui/src/pages/index.vue
+++ b/src/kohaku-hub-ui/src/pages/index.vue
@@ -34,7 +34,27 @@
 
     <!-- Recent Repos - Three Columns -->
     <div class="container-main py-8">
-      <h2 class="text-2xl md:text-3xl font-bold mb-6 md:mb-8">🔥 Trending</h2>
+      <div
+        class="flex flex-col gap-4 mb-6 md:mb-8 md:flex-row md:items-center"
+      >
+        <h2 class="text-2xl md:text-3xl font-bold">
+          {{ repoSectionTitle }}
+        </h2>
+
+        <div class="w-full md:w-80 md:ml-auto md:flex-none">
+          <el-select
+            v-model="selectedSort"
+            placeholder="Sort repositories"
+            class="w-full"
+          >
+            <el-option label="Trending" value="trending" />
+            <el-option label="Recently Created" value="recent" />
+            <el-option label="Recently Updated" value="updated" />
+            <el-option label="Most Downloads" value="downloads" />
+            <el-option label="Most Likes" value="likes" />
+          </el-select>
+        </div>
+      </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- Models Column -->
@@ -217,11 +237,12 @@
 <script setup>
 import { repoAPI } from "@/utils/api";
 import { useAuthStore } from "@/stores/auth";
+import { formatRelativeTime } from "@/utils/datetime";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 import { ElMessage } from "element-plus";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
 
 const router = useRouter();
 const route = useRoute();
@@ -232,9 +253,32 @@ const stats = ref({ models: 0, datasets: 0, spaces: 0 });
 const recentModels = ref([]);
 const recentDatasets = ref([]);
 const recentSpaces = ref([]);
+const selectedSort = ref(
+  getRepoSortPreference({
+    scope: "home",
+    repoType: "all",
+    allowedValues: ["trending", "recent", "updated", "downloads", "likes"],
+    fallback: "trending",
+  }),
+);
+
+const repoSectionTitle = computed(() => {
+  switch (selectedSort.value) {
+    case "recent":
+      return "🆕 Recently Created";
+    case "updated":
+      return "🕒 Recently Updated";
+    case "downloads":
+      return "⬇️ Most Downloaded";
+    case "likes":
+      return "❤️ Most Liked";
+    default:
+      return "🔥 Trending";
+  }
+});
 
 function formatDate(date) {
-  return dayjs(date).fromNow();
+  return formatRelativeTime(date, "never");
 }
 
 function getRepoPath(type, repo) {
@@ -251,17 +295,17 @@ async function loadStats() {
     const [models, datasets, spaces] = await Promise.all([
       repoAPI.listRepos("model", {
         limit: 100,
-        sort: "trending",
+        sort: selectedSort.value,
         fallback: false,
       }),
       repoAPI.listRepos("dataset", {
         limit: 100,
-        sort: "trending",
+        sort: selectedSort.value,
         fallback: false,
       }),
       repoAPI.listRepos("space", {
         limit: 100,
-        sort: "trending",
+        sort: selectedSort.value,
         fallback: false,
       }),
     ]);
@@ -272,7 +316,7 @@ async function loadStats() {
       spaces: spaces.data.length,
     };
 
-    // Get top 3 trending repos for each type (already sorted by backend)
+    // Get top 3 repos for each type (already sorted by backend)
     recentModels.value = models.data.slice(0, 3);
     recentDatasets.value = datasets.data.slice(0, 3);
     recentSpaces.value = spaces.data.slice(0, 3);
@@ -280,6 +324,15 @@ async function loadStats() {
     console.error("Failed to load stats:", err);
   }
 }
+
+watch(selectedSort, () => {
+  setRepoSortPreference({
+    scope: "home",
+    repoType: "all",
+    value: selectedSort.value,
+  });
+  loadStats();
+});
 
 onMounted(() => {
   // Check for verification error messages in query params

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/[type].vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/[type].vue
@@ -181,14 +181,28 @@
       <main class="space-y-8">
         <section>
           <div
-            class="flex items-center justify-between mb-4 pb-3 border-b-2"
+            class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2"
             :class="borderColor"
           >
             <div class="flex items-center gap-2">
               <div :class="iconClass" class="text-xl md:text-2xl" />
               <h2 class="text-xl md:text-2xl font-bold">{{ typeTitle }}</h2>
             </div>
-            <el-tag :type="tagType" size="large">{{ repoCount }}</el-tag>
+            <div class="flex items-center gap-3 ml-auto">
+              <el-select
+                v-model="selectedSort"
+                placeholder="Sort repositories"
+                class="w-44 sm:w-56"
+              >
+                <el-option
+                  v-for="option in sortOptions"
+                  :key="option.value"
+                  :label="option.label"
+                  :value="option.value"
+                />
+              </el-select>
+              <el-tag :type="tagType" size="large">{{ repoCount }}</el-tag>
+            </div>
           </div>
 
           <div v-if="repoCount > 0" class="space-y-4">
@@ -280,27 +294,45 @@
 <script setup>
 import { repoAPI, orgAPI } from "@/utils/api";
 import axios from "axios";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
+import { formatRelativeTime } from "@/utils/datetime";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 
 const route = useRoute();
 const router = useRouter();
 const orgname = computed(() => route.params.orgname);
 const currentType = computed(() => route.params.type);
 
-const loading = ref(true);
-const orgNotFound = ref(false);
-const orgInfo = ref(null);
-const members = ref([]);
-const repos = ref({ model: [], dataset: [], space: [] });
-
 const typeMapping = {
   models: "model",
   datasets: "dataset",
   spaces: "space",
 };
+
+const currentRepoType = computed(() => typeMapping[currentType.value] || "model");
+
+const loading = ref(true);
+const orgNotFound = ref(false);
+const orgInfo = ref(null);
+const members = ref([]);
+const repos = ref({ model: [], dataset: [], space: [] });
+const selectedSort = ref(
+  getRepoSortPreference({
+    scope: "org",
+    repoType: currentRepoType.value,
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+);
+
+const sortOptions = [
+  { label: "Recently Created", value: "recent" },
+  { label: "Recently Updated", value: "updated" },
+  { label: "Most Downloads", value: "downloads" },
+  { label: "Most Likes", value: "likes" },
+];
 
 const currentRepos = computed(() => {
   const type = typeMapping[currentType.value] || "model";
@@ -366,7 +398,7 @@ const tagType = computed(() => {
 });
 
 function formatDate(date) {
-  return date ? dayjs(date).fromNow() : "never";
+  return formatRelativeTime(date, "never");
 }
 
 function getRepoPath(repo) {
@@ -446,20 +478,60 @@ async function loadMembers() {
 async function loadRepos() {
   try {
     const [models, datasets, spaces] = await Promise.all([
-      repoAPI.listRepos("model", { author: orgname.value, limit: 100000 }),
-      repoAPI.listRepos("dataset", { author: orgname.value, limit: 100000 }),
-      repoAPI.listRepos("space", { author: orgname.value, limit: 100000 }),
+      loadRepoType("model"),
+      loadRepoType("dataset"),
+      loadRepoType("space"),
     ]);
 
     repos.value = {
-      model: models.data,
-      dataset: datasets.data,
-      space: spaces.data,
+      model: models,
+      dataset: datasets,
+      space: spaces,
     };
   } catch (err) {
     console.error("Failed to load repos:", err);
   }
 }
+
+async function loadRepoType(repoType) {
+  const { data } = await repoAPI.listRepos(repoType, {
+    author: orgname.value,
+    limit: 100000,
+    sort:
+      repoType === currentRepoType.value
+        ? selectedSort.value
+        : getRepoSortPreference({
+            scope: "org",
+            repoType,
+            allowedValues: ["recent", "updated", "downloads", "likes"],
+            fallback: "recent",
+          }),
+  });
+  return data;
+}
+
+watch(selectedSort, () => {
+  setRepoSortPreference({
+    scope: "org",
+    repoType: currentRepoType.value,
+    value: selectedSort.value,
+  });
+
+  if (!loading.value && !orgNotFound.value) {
+    loadRepoType(currentRepoType.value).then((data) => {
+      repos.value[currentRepoType.value] = data;
+    });
+  }
+});
+
+watch(currentRepoType, (repoType) => {
+  selectedSort.value = getRepoSortPreference({
+    scope: "org",
+    repoType,
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  });
+});
 
 onMounted(async () => {
   try {

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/index.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/index.vue
@@ -454,13 +454,29 @@
           <!-- Models Section -->
           <section class="mb-8">
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-blue-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-blue-500"
             >
               <div class="flex items-center gap-2">
                 <div class="i-carbon-model text-blue-500 text-xl md:text-2xl" />
                 <h2 class="text-xl md:text-2xl font-bold">Models</h2>
               </div>
-              <el-tag type="info" size="large">{{ getCount("model") }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.model"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="info" size="large">{{ getCount("model") }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('model') > 0" class="space-y-4">
@@ -559,7 +575,7 @@
           <!-- Datasets Section -->
           <section class="mb-8">
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-green-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-green-500"
             >
               <div class="flex items-center gap-2">
                 <div
@@ -567,9 +583,25 @@
                 />
                 <h2 class="text-xl md:text-2xl font-bold">Datasets</h2>
               </div>
-              <el-tag type="success" size="large">{{
-                getCount("dataset")
-              }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.dataset"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="success" size="large">{{
+                  getCount("dataset")
+                }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('dataset') > 0" class="space-y-4">
@@ -666,7 +698,7 @@
           <!-- Spaces Section -->
           <section>
             <div
-              class="flex items-center justify-between mb-4 pb-3 border-b-2 border-purple-500"
+              class="flex items-center justify-between gap-3 flex-wrap mb-4 pb-3 border-b-2 border-purple-500"
             >
               <div class="flex items-center gap-2">
                 <div
@@ -674,9 +706,25 @@
                 />
                 <h2 class="text-xl md:text-2xl font-bold">Spaces</h2>
               </div>
-              <el-tag type="warning" size="large">{{
-                getCount("space")
-              }}</el-tag>
+              <div class="flex items-center gap-3 ml-auto shrink-0">
+                <div class="w-56 sm:w-64 lg:w-72 shrink-0">
+                  <el-select
+                    v-model="selectedSorts.space"
+                    placeholder="Sort repositories"
+                    class="w-full"
+                  >
+                    <el-option
+                      v-for="option in sortOptions"
+                      :key="option.value"
+                      :label="option.label"
+                      :value="option.value"
+                    />
+                  </el-select>
+                </div>
+                <el-tag type="warning" size="large">{{
+                  getCount("space")
+                }}</el-tag>
+              </div>
             </div>
 
             <div v-if="getCount('space') > 0" class="space-y-4">
@@ -777,13 +825,14 @@
 
 <script setup>
 import { repoAPI, orgAPI, settingsAPI } from "@/utils/api";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import MarkdownViewer from "@/components/common/MarkdownViewer.vue";
 import SocialLinks from "@/components/profile/SocialLinks.vue";
+import { formatRelativeTime } from "@/utils/datetime";
+import {
+  getRepoSortPreference,
+  setRepoSortPreference,
+} from "@/utils/repoSortPreference";
 import axios from "axios";
-
-dayjs.extend(relativeTime);
 
 const route = useRoute();
 const router = useRouter();
@@ -799,8 +848,35 @@ const quotaInfo = ref(null);
 const userRole = ref(null);
 const hasAvatar = ref(true); // Assume avatar exists, will be set to false on error
 const orgNotFound = ref(false);
+const selectedSorts = reactive({
+  model: getRepoSortPreference({
+    scope: "org",
+    repoType: "model",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+  dataset: getRepoSortPreference({
+    scope: "org",
+    repoType: "dataset",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+  space: getRepoSortPreference({
+    scope: "org",
+    repoType: "space",
+    allowedValues: ["recent", "updated", "downloads", "likes"],
+    fallback: "recent",
+  }),
+});
 
 const MAX_DISPLAYED = 6; // 2 per row × 3 rows
+
+const sortOptions = [
+  { label: "Recently Created", value: "recent" },
+  { label: "Recently Updated", value: "updated" },
+  { label: "Most Downloads", value: "downloads" },
+  { label: "Most Likes", value: "likes" },
+];
 
 // External org detection
 const isExternalOrg = computed(() => {
@@ -840,7 +916,7 @@ function hasMoreRepos(type) {
 }
 
 function formatDate(date) {
-  return date ? dayjs(date).fromNow() : "never";
+  return formatRelativeTime(date, "never");
 }
 
 function formatBytes(bytes) {
@@ -928,15 +1004,15 @@ async function loadMembers() {
 async function loadRepos() {
   try {
     const [models, datasets, spaces] = await Promise.all([
-      repoAPI.listRepos("model", { author: orgname.value, limit: 100000 }),
-      repoAPI.listRepos("dataset", { author: orgname.value, limit: 100000 }),
-      repoAPI.listRepos("space", { author: orgname.value, limit: 100000 }),
+      loadRepoType("model"),
+      loadRepoType("dataset"),
+      loadRepoType("space"),
     ]);
 
     repos.value = {
-      model: models.data,
-      dataset: datasets.data,
-      space: spaces.data,
+      model: models,
+      dataset: datasets,
+      space: spaces,
     };
 
     return true;
@@ -946,6 +1022,60 @@ async function loadRepos() {
     return true; // Continue on error
   }
 }
+
+async function loadRepoType(repoType) {
+  const { data } = await repoAPI.listRepos(repoType, {
+    author: orgname.value,
+    limit: 100000,
+    sort: selectedSorts[repoType],
+  });
+  return data;
+}
+
+watch(
+  () => selectedSorts.model,
+  async () => {
+    setRepoSortPreference({
+      scope: "org",
+      repoType: "model",
+      value: selectedSorts.model,
+    });
+
+    if (!loading.value && !orgNotFound.value) {
+      repos.value.model = await loadRepoType("model");
+    }
+  },
+);
+
+watch(
+  () => selectedSorts.dataset,
+  async () => {
+    setRepoSortPreference({
+      scope: "org",
+      repoType: "dataset",
+      value: selectedSorts.dataset,
+    });
+
+    if (!loading.value && !orgNotFound.value) {
+      repos.value.dataset = await loadRepoType("dataset");
+    }
+  },
+);
+
+watch(
+  () => selectedSorts.space,
+  async () => {
+    setRepoSortPreference({
+      scope: "org",
+      repoType: "space",
+      value: selectedSorts.space,
+    });
+
+    if (!loading.value && !orgNotFound.value) {
+      repos.value.space = await loadRepoType("space");
+    }
+  },
+);
 
 async function loadOrgCard() {
   try {

--- a/src/kohaku-hub-ui/src/pages/organizations/[orgname]/storage.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/[orgname]/storage.vue
@@ -221,11 +221,8 @@
 
 <script setup>
 import { quotaAPI } from "@/utils/api";
+import { formatRelativeTime } from "@/utils/datetime";
 import { ElMessage } from "element-plus";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
 
 const route = useRoute();
 const router = useRouter();
@@ -277,7 +274,7 @@ function formatSize(bytes) {
 
 function formatDate(dateStr) {
   if (!dateStr) return "Unknown";
-  return dayjs(dateStr).fromNow();
+  return formatRelativeTime(dateStr, "Unknown");
 }
 
 function getRepoIcon(type) {

--- a/src/kohaku-hub-ui/src/stores/auth.js
+++ b/src/kohaku-hub-ui/src/stores/auth.js
@@ -1,6 +1,7 @@
 // src/kohaku-hub-ui/src/stores/auth.js
 import { defineStore } from "pinia";
 import { authAPI, settingsAPI } from "@/utils/api";
+import { clearRepoSortPreference } from "@/utils/repoSortPreference";
 
 export const useAuthStore = defineStore("auth", {
   state: () => ({
@@ -30,6 +31,7 @@ export const useAuthStore = defineStore("auth", {
       try {
         const { data } = await authAPI.login(credentials);
         // Session cookie is set automatically
+        clearRepoSortPreference();
         await this.fetchUserInfo();
         return data;
       } finally {
@@ -61,6 +63,7 @@ export const useAuthStore = defineStore("auth", {
         this.user = null;
         this.token = null;
         localStorage.removeItem("hf_token");
+        clearRepoSortPreference();
       }
     },
 
@@ -75,6 +78,7 @@ export const useAuthStore = defineStore("auth", {
       } catch (err) {
         this.user = null;
         this.userOrganizations = [];
+        clearRepoSortPreference();
         throw err;
       }
     },
@@ -96,6 +100,7 @@ export const useAuthStore = defineStore("auth", {
       } catch (err) {
         this.user = null;
         this.userOrganizations = [];
+        clearRepoSortPreference();
         throw err;
       }
     },
@@ -107,6 +112,7 @@ export const useAuthStore = defineStore("auth", {
     async setToken(token) {
       this.token = token;
       localStorage.setItem("hf_token", token);
+      clearRepoSortPreference();
       await this.fetchUserInfo();
     },
 
@@ -149,6 +155,7 @@ export const useAuthStore = defineStore("auth", {
         this.token = null;
         this.externalTokens = [];
         localStorage.removeItem("hf_token");
+        clearRepoSortPreference();
       }
     },
 

--- a/src/kohaku-hub-ui/src/utils/datetime.js
+++ b/src/kohaku-hub-ui/src/utils/datetime.js
@@ -1,0 +1,71 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(relativeTime);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+let browserTimeZone = "UTC";
+
+export function initializeBrowserTimezone() {
+  if (typeof Intl !== "undefined") {
+    browserTimeZone =
+      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+      dayjs.tz.guess() ||
+      "UTC";
+  }
+
+  return browserTimeZone;
+}
+
+function parseBrowserTime(value) {
+  const timeZone = initializeBrowserTimezone();
+
+  if (typeof value === "number") {
+    return dayjs.unix(value).tz(timeZone);
+  }
+
+  if (value instanceof Date) {
+    return dayjs(value).tz(timeZone);
+  }
+
+  if (typeof value === "string") {
+    if (value.endsWith("Z")) {
+      const utcParsed = dayjs(value).tz(timeZone);
+      const localParsed = dayjs.tz(value.slice(0, -1), timeZone);
+
+      if (
+        utcParsed.isValid() &&
+        localParsed.isValid() &&
+        utcParsed.isAfter(dayjs()) &&
+        !localParsed.isAfter(dayjs())
+      ) {
+        return localParsed;
+      }
+
+      if (utcParsed.isValid()) {
+        return utcParsed;
+      }
+    }
+
+    return dayjs.tz(value, timeZone);
+  }
+
+  return dayjs(value).tz(timeZone);
+}
+
+export function formatRelativeTime(value, fallback = "never") {
+  if (!value) return fallback;
+
+  const parsed = parseBrowserTime(value);
+  return parsed.isValid() ? parsed.fromNow() : fallback;
+}
+
+export function formatUnixRelativeTime(value, fallback = "Unknown") {
+  if (!value) return fallback;
+
+  const parsed = parseBrowserTime(value);
+  return parsed.isValid() ? parsed.fromNow() : fallback;
+}

--- a/src/kohaku-hub-ui/src/utils/repoSortPreference.js
+++ b/src/kohaku-hub-ui/src/utils/repoSortPreference.js
@@ -1,0 +1,59 @@
+const REPO_SORT_PREFERENCE_KEY_PREFIX = "kohakuhub:repo-sort-preference";
+const ALLOWED_REPO_SORT_PREFERENCES = new Set([
+  "trending",
+  "recent",
+  "updated",
+  "downloads",
+  "likes",
+]);
+
+function buildRepoSortPreferenceKey(scope, repoType) {
+  return `${REPO_SORT_PREFERENCE_KEY_PREFIX}:${scope}:${repoType}`;
+}
+
+export function getRepoSortPreference({
+  scope,
+  repoType,
+  allowedValues = [],
+  fallback = "recent",
+}) {
+  const allowedSet = new Set(allowedValues);
+
+  if (typeof window === "undefined") return fallback;
+
+  const value = window.sessionStorage.getItem(
+    buildRepoSortPreferenceKey(scope, repoType),
+  );
+  if (!ALLOWED_REPO_SORT_PREFERENCES.has(value)) return fallback;
+  if (allowedSet.size > 0 && !allowedSet.has(value)) return fallback;
+
+  return value;
+}
+
+export function setRepoSortPreference({ scope, repoType, value }) {
+  if (typeof window === "undefined") return;
+
+  if (!ALLOWED_REPO_SORT_PREFERENCES.has(value)) {
+    window.sessionStorage.removeItem(buildRepoSortPreferenceKey(scope, repoType));
+    return;
+  }
+
+  window.sessionStorage.setItem(
+    buildRepoSortPreferenceKey(scope, repoType),
+    value,
+  );
+}
+
+export function clearRepoSortPreference() {
+  if (typeof window === "undefined") return;
+
+  const keysToRemove = [];
+  for (let i = 0; i < window.sessionStorage.length; i += 1) {
+    const key = window.sessionStorage.key(i);
+    if (key?.startsWith(`${REPO_SORT_PREFERENCE_KEY_PREFIX}:`)) {
+      keysToRemove.push(key);
+    }
+  }
+
+  keysToRemove.forEach((key) => window.sessionStorage.removeItem(key));
+}

--- a/src/kohakuhub/api/fallback/decorators.py
+++ b/src/kohakuhub/api/fallback/decorators.py
@@ -30,6 +30,14 @@ OperationType = Literal["resolve", "tree", "info", "revision", "paths_info"]
 UserOperationType = Literal["profile", "repos", "avatar"]
 
 
+def _repo_sort_key(item: dict) -> tuple[str, str, str]:
+    return (
+        item.get("lastModified") or "",
+        item.get("createdAt") or "",
+        item.get("id") or "",
+    )
+
+
 def with_repo_fallback(operation: OperationType):
     """Decorator for endpoints that access individual repositories.
 
@@ -364,6 +372,10 @@ def with_list_aggregation(repo_type: str):
                     if item_id and item_id not in seen_ids:
                         all_results.append(item)
                         seen_ids.add(item_id)
+
+            sort = kwargs.get("sort", args[2] if len(args) > 2 else "recent")
+            if sort == "updated":
+                all_results.sort(key=_repo_sort_key, reverse=True)
 
             # Get limit from kwargs (if None or very large, return all)
             limit = kwargs.get("limit")

--- a/src/kohakuhub/api/repo/routers/info.py
+++ b/src/kohakuhub/api/repo/routers/info.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, Query, Request
+from peewee import JOIN, fn
 
 from kohakuhub.config import cfg
 from kohakuhub.constants import DATETIME_FORMAT_ISO
-from kohakuhub.db import Repository, User, UserOrganization
+from kohakuhub.db import Commit, Repository, User, UserOrganization
 from kohakuhub.db_operations import (
     get_file,
     get_organization,
@@ -40,6 +41,40 @@ logger = get_logger("REPO")
 router = APIRouter()
 
 RepoType = Literal["model", "dataset", "space"]
+
+
+def _apply_repo_sorting(q, repo_type: str, sort: str):
+    """Apply repository sorting while preserving existing API semantics."""
+    if sort == "likes":
+        return q.order_by(Repository.likes_count.desc())
+
+    if sort == "downloads":
+        return q.order_by(Repository.downloads.desc())
+
+    if sort == "updated":
+        latest_commit_subq = (
+            Commit.select(
+                Commit.repository.alias("repository_id"),
+                fn.MAX(Commit.created_at).alias("last_commit_at"),
+            )
+            .where((Commit.repo_type == repo_type) & (Commit.branch == "main"))
+            .group_by(Commit.repository)
+            .alias("latest_commit_subq")
+        )
+
+        return q.join(
+            latest_commit_subq,
+            JOIN.LEFT_OUTER,
+            on=(Repository.id == latest_commit_subq.c.repository_id),
+        ).order_by(
+            fn.COALESCE(
+                latest_commit_subq.c.last_commit_at,
+                Repository.created_at,
+            ).desc(),
+            Repository.created_at.desc(),
+        )
+
+    return q.order_by(Repository.created_at.desc())
 
 
 @router.get("/models/{namespace}/{repo_name}")
@@ -338,15 +373,7 @@ async def _list_repos_internal(
 
         rows = get_trending_repositories(rt, limit=limit, days=7)
     else:
-        # Standard sorting
-        if sort == "likes":
-            q = q.order_by(Repository.likes_count.desc())
-        elif sort == "downloads":
-            q = q.order_by(Repository.downloads.desc())
-        else:  # recent (default)
-            q = q.order_by(Repository.created_at.desc())
-
-        rows = list(q.limit(limit))
+        rows = list(_apply_repo_sorting(q, rt, sort).limit(limit))
 
     # Format response with lastModified from LakeFS
     client = get_lakefs_client()
@@ -416,7 +443,7 @@ async def list_repos(
     limit: int = Query(
         50, ge=1, le=100000
     ),  # Very high limit to support "get all repos"
-    sort: str = Query("recent", regex="^(recent|likes|downloads|trending)$"),
+    sort: str = Query("recent", regex="^(recent|updated|likes|downloads|trending)$"),
     fallback: bool = Query(True, description="Enable fallback to external sources"),
     request: Request = None,
     user: User | None = Depends(get_optional_user),
@@ -426,7 +453,7 @@ async def list_repos(
     Args:
         author: Filter by author/namespace
         limit: Maximum number of results
-        sort: Sort order (recent, likes, downloads, trending) - default: recent
+        sort: Sort order (recent, updated, likes, downloads, trending) - default: recent
         fallback: Enable fallback to external sources (default: True)
         request: FastAPI request object
         user: Current authenticated user (optional)


### PR DESCRIPTION
## Summary
- add session-scoped repository sort preferences on the homepage, user pages, organization pages, and repo list pages
- add browser-aware relative time formatting so timestamps render from the client timezone instead of the server timezone
- expand and realign sorting controls so selected option text stays visible across desktop and mobile layouts
- add backend support for updated-time ordering while preserving existing API behavior for unchanged callers

## Verification
- `npm run build` in `src/kohaku-hub-ui`
- manual browser verification on a dedicated dev server port with real interaction and screenshots for homepage, organization overview, and models list layouts

## Notes
- sort preferences are stored in `sessionStorage` and cleared together with the current authenticated session state
- the new backend sorting path is backward compatible because existing requests keep their previous behavior unless the new sort value is explicitly used
