### PR TITLE
Raise the LFS version history input limit to 9999

### DIFF
--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
@@ -366,7 +366,7 @@
                   <el-input-number
                     v-model="lfsSettings.keep_versions"
                     :min="2"
-                    :max="100"
+                    :max="9999"
                     :step="1"
                   />
                   <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">


### PR DESCRIPTION
## Summary
- raise the repository LFS version history input limit from 100 to 9999 in the main UI settings page
- keep the existing backend behavior unchanged

## Testing
- npm run build in src/kohaku-hub-ui
