### PR TITLE
Make fallback transparent to huggingface_hub: seed + HEAD semantics + real-client tests

### DIFF
--- a/scripts/dev/seed_demo_data.py
+++ b/scripts/dev/seed_demo_data.py
@@ -37,7 +37,7 @@ from kohakuhub.config import cfg
 from kohakuhub.main import app
 from kohakuhub.utils.s3 import init_storage
 
-SEED_VERSION = "local-dev-demo-v2"
+SEED_VERSION = "local-dev-demo-v3"
 DEFAULT_PASSWORD = "KohakuDev123!"
 PRIMARY_USERNAME = "mai_lin"
 MANIFEST_PATH = ROOT_DIR / "hub-meta" / "dev" / "demo-seed-manifest.json"
@@ -2537,6 +2537,20 @@ LIKES: tuple[tuple[str, str, str, str], ...] = (
     ("mai_lin", "dataset", "aurora-labs", "receipt-layout-bench"),
 )
 
+# Global fallback sources installed via the admin API so a fresh local seed can
+# resolve public HuggingFace repos out-of-the-box. Namespace "" = global scope.
+FALLBACK_SOURCE_SEEDS: tuple[dict, ...] = (
+    {
+        "namespace": "",
+        "url": "https://huggingface.co",
+        "token": None,
+        "priority": 1000,
+        "name": "HuggingFace",
+        "source_type": "huggingface",
+        "enabled": True,
+    },
+)
+
 
 def account_index() -> dict[str, AccountSeed]:
     return {account.username: account for account in ACCOUNTS}
@@ -2724,6 +2738,39 @@ async def configure_user_profile(client: httpx.AsyncClient, account: AccountSeed
         account.username,
         account.avatar_bg,
         account.avatar_accent,
+    )
+
+
+def admin_headers() -> dict[str, str]:
+    return {"X-Admin-Token": cfg.admin.secret_token}
+
+
+async def ensure_fallback_source(
+    client: httpx.AsyncClient, source: dict
+) -> None:
+    list_response = await client.get(
+        "/admin/api/fallback-sources",
+        params={"namespace": source["namespace"]},
+        headers=admin_headers(),
+    )
+    await ensure_response(
+        list_response,
+        f"list fallback sources for namespace={source['namespace']!r}",
+    )
+
+    normalized_url = source["url"].rstrip("/")
+    for existing in list_response.json():
+        if existing["url"].rstrip("/") == normalized_url:
+            return
+
+    create_response = await client.post(
+        "/admin/api/fallback-sources",
+        json=source,
+        headers=admin_headers(),
+    )
+    await ensure_response(
+        create_response,
+        f"create fallback source {source['name']} ({normalized_url})",
     )
 
 
@@ -3068,6 +3115,16 @@ def build_manifest() -> dict:
             }
             for repo in REPO_SEEDS
         ],
+        "fallback_sources": [
+            {
+                "namespace": source["namespace"],
+                "url": source["url"].rstrip("/"),
+                "name": source["name"],
+                "source_type": source["source_type"],
+                "priority": source["priority"],
+            }
+            for source in FALLBACK_SOURCE_SEEDS
+        ],
     }
 
 
@@ -3116,6 +3173,9 @@ async def seed_demo_data() -> None:
 
         for account in ACCOUNTS:
             await register_account(seed_client, account)
+
+        for fallback_source in FALLBACK_SOURCE_SEEDS:
+            await ensure_fallback_source(seed_client, fallback_source)
 
         authed_clients: dict[str, httpx.AsyncClient] = {}
         for account in ACCOUNTS:

--- a/scripts/dev/verify_seed_data.py
+++ b/scripts/dev/verify_seed_data.py
@@ -21,7 +21,7 @@ from kohakuhub.main import app
 from kohakuhub.utils.s3 import init_storage
 
 MANIFEST_PATH = ROOT_DIR / "hub-meta" / "dev" / "demo-seed-manifest.json"
-EXPECTED_SEED_VERSION = "local-dev-demo-v2"
+EXPECTED_SEED_VERSION = "local-dev-demo-v3"
 INTERNAL_BASE_URL = (
     getattr(cfg.app, "internal_base_url", None)
     or cfg.app.base_url
@@ -195,6 +195,27 @@ async def verify_seed_data() -> dict:
                 f"{deep_json!r}"
             )
         summary["verified_checks"].append("hierarchy-crawl deep JSON download")
+
+        expected_fallback_sources = {
+            (source["url"].rstrip("/"), source["name"])
+            for source in manifest.get("fallback_sources", [])
+            if source.get("namespace", "") == ""
+        }
+        if expected_fallback_sources:
+            available_sources = await get_json(
+                client, "/api/fallback-sources/available"
+            )
+            available = {
+                (entry.get("url", "").rstrip("/"), entry.get("name"))
+                for entry in available_sources
+            }
+            missing = expected_fallback_sources - available
+            if missing:
+                raise VerifyError(
+                    "Missing seeded fallback sources: "
+                    + ", ".join(sorted(f"{name} ({url})" for url, name in missing))
+                )
+            summary["verified_checks"].append("fallback sources available")
 
     return summary
 

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -107,16 +107,72 @@ async def try_fallback_resolve(
                 )
 
                 if method == "HEAD":
-                    # For HEAD: Return response with original headers.
-                    # Rewrite any relative Location against the upstream request URL
-                    # so clients following a 3xx hit the upstream (e.g. huggingface.co)
-                    # instead of KohakuHub itself — HF's /api/resolve-cache/... path
-                    # exists only on the HF CDN.
+                    # Rewrite any relative Location against the upstream
+                    # request URL so clients following a 3xx hit the
+                    # upstream (e.g. huggingface.co) instead of KohakuHub
+                    # itself — HF's /api/resolve-cache/... path lives only
+                    # on the HF origin.
                     resp_headers = dict(response.headers)
-                    location = resp_headers.get("location")
+                    location = resp_headers.get("location") or resp_headers.get(
+                        "Location"
+                    )
                     if location:
                         upstream_url = str(response.request.url)
-                        resp_headers["location"] = urljoin(upstream_url, location)
+                        absolute_location = urljoin(upstream_url, location)
+                        for k in list(resp_headers.keys()):
+                            if k.lower() == "location":
+                                resp_headers.pop(k, None)
+                        resp_headers["location"] = absolute_location
+
+                    # For non-LFS 3xx redirects (no X-Linked-Size), HF's 307
+                    # Content-Length is the redirect body length (~278B),
+                    # not the file size. Without X-Linked-Size the hf_hub
+                    # client takes that bogus value as expected_size and
+                    # fails its post-download consistency check
+                    # (observed in imgutils' get_wd14_tags on
+                    # selected_tags.csv). One extra HEAD to the rewritten
+                    # Location picks up the real Content-Length / ETag.
+                    # LFS files already carry X-Linked-Size; hf_hub prefers
+                    # it over Content-Length so we skip the follow.
+                    if (
+                        300 <= response.status_code < 400
+                        and location
+                        and not any(
+                            k.lower() == "x-linked-size" for k in resp_headers
+                        )
+                    ):
+                        try:
+                            async with httpx.AsyncClient(
+                                timeout=client.timeout
+                            ) as hc:
+                                # `identity` asks HF not to gzip the
+                                # (empty) HEAD body; otherwise httpx's
+                                # auto-decoding strips Content-Length from
+                                # the response and we lose the size we
+                                # came here to fetch.
+                                extra_headers = {"Accept-Encoding": "identity"}
+                                if client.token:
+                                    extra_headers["Authorization"] = (
+                                        f"Bearer {client.token}"
+                                    )
+                                follow_resp = await hc.head(
+                                    resp_headers["location"],
+                                    headers=extra_headers,
+                                    follow_redirects=False,
+                                )
+                            for k in [
+                                k for k in list(resp_headers)
+                                if k.lower() in ("content-length", "etag")
+                            ]:
+                                resp_headers.pop(k)
+                            for k, v in follow_resp.headers.items():
+                                if k.lower() in ("content-length", "etag"):
+                                    resp_headers[k] = v
+                        except httpx.HTTPError:
+                            # Extra HEAD failed — return what we have; no
+                            # worse than the original PR#21 behavior.
+                            pass
+
                     strip_xet_response_headers(resp_headers)
                     resp_headers.update(
                         add_source_headers(response, source["name"], source["url"])

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -17,6 +17,7 @@ from kohakuhub.api.fallback.utils import (
     extract_error_message,
     is_not_found_error,
     should_retry_source,
+    strip_xet_response_headers,
 )
 
 logger = get_logger("FALLBACK_OPS")
@@ -116,6 +117,7 @@ async def try_fallback_resolve(
                     if location:
                         upstream_url = str(response.request.url)
                         resp_headers["location"] = urljoin(upstream_url, location)
+                    strip_xet_response_headers(resp_headers)
                     resp_headers.update(
                         add_source_headers(response, source["name"], source["url"])
                     )
@@ -143,6 +145,7 @@ async def try_fallback_resolve(
                         )  # Length may be wrong after decompression
                         resp_headers.pop("transfer-encoding", None)
 
+                        strip_xet_response_headers(resp_headers)
                         resp_headers.update(
                             add_source_headers(
                                 get_response, source["name"], source["url"]

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from typing import Optional
+from urllib.parse import urljoin
 
 import httpx
 from fastapi.responses import RedirectResponse, Response
@@ -105,8 +106,16 @@ async def try_fallback_resolve(
                 )
 
                 if method == "HEAD":
-                    # For HEAD: Return response with original headers
+                    # For HEAD: Return response with original headers.
+                    # Rewrite any relative Location against the upstream request URL
+                    # so clients following a 3xx hit the upstream (e.g. huggingface.co)
+                    # instead of KohakuHub itself — HF's /api/resolve-cache/... path
+                    # exists only on the HF CDN.
                     resp_headers = dict(response.headers)
+                    location = resp_headers.get("location")
+                    if location:
+                        upstream_url = str(response.request.url)
+                        resp_headers["location"] = urljoin(upstream_url, location)
                     resp_headers.update(
                         add_source_headers(response, source["name"], source["url"])
                     )

--- a/src/kohakuhub/api/fallback/utils.py
+++ b/src/kohakuhub/api/fallback/utils.py
@@ -104,6 +104,44 @@ def should_retry_source(response: httpx.Response) -> bool:
     return False
 
 
+def strip_xet_response_headers(headers: dict) -> None:
+    """Remove Xet-protocol hints from a fallback response's headers in place.
+
+    KohakuHub does not natively speak the huggingface.co Xet protocol. When a
+    downstream client (`huggingface_hub >= 1.x`) sees `X-Xet-*` response
+    headers or a `Link: <...>; rel="xet-auth"` relation, it switches to the
+    Xet code path and calls endpoints we do not implement (`/api/models/...
+    /xet-read-token/...`) — breaking the entire download. Stripping these
+    signals puts the client back on the classic LFS path, which is served by
+    the fallback's standard 3xx Location redirect.
+
+    See `huggingface_hub.utils._xet.parse_xet_file_data_from_response` and
+    `huggingface_hub.constants.HUGGINGFACE_HEADER_X_XET_*` for the upstream
+    trigger list. This mutates `headers` in place and is a no-op for
+    responses that carry no Xet signals.
+    """
+    for key in list(headers.keys()):
+        if key.lower().startswith("x-xet-"):
+            headers.pop(key, None)
+
+    link_key = next(
+        (k for k in headers.keys() if k.lower() == "link"), None
+    )
+    if not link_key:
+        return
+
+    kept = []
+    for chunk in headers[link_key].split(","):
+        if 'rel="xet-auth"' in chunk.lower() or "rel=xet-auth" in chunk.lower():
+            continue
+        kept.append(chunk)
+    new_link = ",".join(kept).strip().strip(",").strip()
+    if new_link:
+        headers[link_key] = new_link
+    else:
+        headers.pop(link_key, None)
+
+
 def add_source_headers(
     response: httpx.Response, source_name: str, source_url: str
 ) -> dict:

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -1,35 +1,50 @@
-"""Integration tests: feed the HEAD response KohakuHub produces straight
-into huggingface_hub's own metadata parser and assert the resulting
+"""Integration tests: feed the response KohakuHub produces straight into
+huggingface_hub's real metadata parser and assert the resulting
 ``HfFileMetadata`` is well-formed.
 
-These tests fail if a regression breaks any of the client-side invariants
-that real downloads rely on — Content-Length → expected_size, ETag
-normalization, xet suppression, commit hash presence, etc. Unlike the
-pure-unit tests that check our response shape directly, these wire the
-response into huggingface_hub 1.x's real functions (the same ones
-``hf_hub_download`` uses) so any future hf_hub change that narrows the
-contract surfaces here immediately.
+Scenarios (mirrored from the /resolve redirect survey — 426 probes, 100
+repos on huggingface.co):
+
+    A. 307-rel-resolve-cache  (72.3% of probes)
+       Non-LFS text: HF returns 307 with a relative Location into
+       /api/resolve-cache/... Without a backfill, Content-Length is the
+       307 redirect-body length (~278B), not the file size.
+
+    B. 302-xet-cas-bridge     (22.1% of probes)
+       LFS blob: HF returns 302 with an absolute cas-bridge URL and an
+       X-Linked-Size header that gives the real file size.
+
+    C. direct-200             (3.5% of probes)
+       Some README / YAML files: HF serves the resolve directly, no
+       redirect at all. Content-Length is the real file size.
+
+Each pattern is exercised through both `method="HEAD"` and `method="GET"`
+on `try_fallback_resolve`, then fed back into huggingface_hub's real
+`HfFileMetadata`, `_normalize_etag`, `_int_or_none`, and (when available)
+`parse_xet_file_data_from_response`. Because those functions are unchanged
+across 0.20.3 / 0.30.2 / 0.36.2 / 1.0.1 / 1.6.0 / latest, the tests run on
+every cell in the CI matrix; xet-specific assertions are gated on the
+xet module being importable (added in hf_hub 1.0).
 """
 from __future__ import annotations
+
+import inspect
 
 import httpx
 import pytest
 
-# These tests lean on huggingface_hub's internal metadata parser, which
-# only gained the Xet module in huggingface_hub >= 1.0. Skip the whole
-# file cleanly on the older pins (0.20.3 / 0.30.2 / 0.36.2 in the matrix).
-pytest.importorskip(
-    "huggingface_hub.utils._xet",
-    reason="huggingface_hub.utils._xet is only present in huggingface_hub >= 1.0",
-)
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.file_download import HfFileMetadata, _int_or_none, _normalize_etag
 
-from huggingface_hub import constants as hf_constants  # noqa: E402
-from huggingface_hub.file_download import (  # noqa: E402
-    HfFileMetadata,
-    _int_or_none,
-    _normalize_etag,
-)
-from huggingface_hub.utils._xet import parse_xet_file_data_from_response  # noqa: E402
+try:
+    from huggingface_hub.utils._xet import parse_xet_file_data_from_response
+
+    HAS_XET = True
+except ImportError:  # pre-1.0 hf_hub matrix cells
+    parse_xet_file_data_from_response = None  # type: ignore[assignment]
+    HAS_XET = False
+
+_HF_METADATA_FIELDS = set(inspect.signature(HfFileMetadata).parameters.keys())
 
 import kohakuhub.api.fallback.operations as fallback_ops  # noqa: E402
 
@@ -42,7 +57,8 @@ from test.kohakuhub.api.fallback.test_operations import (  # noqa: E402
 
 
 HF_ENDPOINT = "https://hf.local"
-REPO = "/models/owner/demo/resolve/main"
+KHUB_BASE = "http://khub.local"
+REPO_PREFIX = "/models/owner/demo/resolve/main"
 
 
 @pytest.fixture(autouse=True)
@@ -52,47 +68,72 @@ def _reset_fallback_env(monkeypatch):
     monkeypatch.setattr(fallback_ops, "FallbackClient", FakeFallbackClient)
 
 
-def _to_httpx_response(
-    fastapi_response,
-    *,
-    request_url: str,
-) -> httpx.Response:
-    """Re-wrap a FastAPI ``Response`` as an httpx ``Response`` so we can
-    hand it off to hf_hub's parsing routines unmodified."""
-    raw_headers = fastapi_response.raw_headers  # list[tuple[bytes, bytes]]
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_httpx(response, *, request_url: str) -> httpx.Response:
+    """Rehydrate a FastAPI ``Response`` as an httpx ``Response`` so it can
+    flow straight into hf_hub's parsers without any further adaptation."""
+    raw_headers = response.raw_headers  # list[tuple[bytes, bytes]]
     headers = httpx.Headers(
         [(k.decode("latin-1"), v.decode("latin-1")) for k, v in raw_headers]
     )
     return httpx.Response(
-        status_code=fastapi_response.status_code,
+        status_code=response.status_code,
         headers=headers,
-        content=fastapi_response.body or b"",
+        content=response.body or b"",
         request=httpx.Request("HEAD", request_url),
     )
 
 
-def _hf_metadata(httpx_response: httpx.Response, endpoint: str) -> HfFileMetadata:
-    """Call the same metadata-extraction logic hf_hub uses internally in
-    ``get_hf_file_metadata`` (see ``huggingface_hub/file_download.py:1597``)."""
-    return HfFileMetadata(
-        commit_hash=httpx_response.headers.get(
-            hf_constants.HUGGINGFACE_HEADER_X_REPO_COMMIT
-        ),
+def _hf_metadata(hx: httpx.Response) -> HfFileMetadata:
+    """Construct HfFileMetadata using hf_hub's own header conventions.
+
+    Mirrors the real call in `get_hf_file_metadata` at
+    huggingface_hub/file_download.py. Works on every matrix pin because
+    pre-1.0 `HfFileMetadata` lacks the `xet_file_data` field — we only
+    pass it when present in the dataclass signature.
+    """
+    kwargs = dict(
+        commit_hash=hx.headers.get(hf_constants.HUGGINGFACE_HEADER_X_REPO_COMMIT),
         etag=_normalize_etag(
-            httpx_response.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_ETAG)
-            or httpx_response.headers.get("ETag")
+            hx.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_ETAG)
+            or hx.headers.get("ETag")
         ),
-        location=httpx_response.headers.get("Location")
-        or str(httpx_response.request.url),
+        location=hx.headers.get("Location") or str(hx.request.url),
         size=_int_or_none(
-            httpx_response.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
-            or httpx_response.headers.get("Content-Length")
+            hx.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
+            or hx.headers.get("Content-Length")
         ),
-        xet_file_data=parse_xet_file_data_from_response(httpx_response),
     )
+    if HAS_XET and "xet_file_data" in _HF_METADATA_FIELDS:
+        kwargs["xet_file_data"] = parse_xet_file_data_from_response(hx)
+    return HfFileMetadata(**kwargs)
 
 
-def _configure(monkeypatch):
+def _assert_client_stays_on_classic_lfs(hx: httpx.Response) -> None:
+    """hf_hub switches to the Xet protocol when any of:
+      * `X-Xet-Hash` present
+      * Link header carries rel="xet-auth"
+      * `parse_xet_file_data_from_response` returns non-None
+    This helper asserts none of those would fire — the client stays on
+    the classic LFS / direct-HTTP path (which KohakuHub actually speaks)."""
+    lower = {k.lower() for k in hx.headers.keys()}
+    assert not any(k.startswith("x-xet-") for k in lower), hx.headers
+    link = hx.headers.get("link") or hx.headers.get("Link") or ""
+    assert "xet-auth" not in link.lower(), link
+    if HAS_XET:
+        assert parse_xet_file_data_from_response(hx) is None
+
+
+# ---------------------------------------------------------------------------
+# Pattern A. 307 → relative /api/resolve-cache/... (non-LFS text)
+# ---------------------------------------------------------------------------
+
+
+def _setup_resolve_cache_source(monkeypatch):
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -104,23 +145,25 @@ def _configure(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_metadata_non_lfs_307_has_real_content_length(monkeypatch):
-    """hf_hub must see the **real** 308468-byte size after khub's extra
-    HEAD — not the 278-byte redirect body length. This is the consistency
-    check bug that breaks get_wd14_tags."""
-    _configure(monkeypatch)
+async def test_pattern_A_resolve_cache_HEAD(monkeypatch):
+    """307 → /api/resolve-cache: HEAD returns 307 + absolute Location, the
+    extra HEAD backfills the real Content-Length so hf_hub's post-download
+    consistency check passes."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/selected_tags.csv"
+
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
             307,
             headers={
-                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
-                "content-length": "278",
+                "location": "/api/resolve-cache/models/owner/demo/abc123/selected_tags.csv",
+                "content-length": "278",      # redirect body — wrong for the file
                 "etag": 'W/"placeholder"',
                 "x-repo-commit": "abc123",
                 "x-linked-etag": '"deadbeef"',
             },
-            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/selected_tags.csv",
         ),
     )
     stub = AbsoluteHeadStub()
@@ -130,215 +173,272 @@ async def test_hf_hub_metadata_non_lfs_307_has_real_content_length(monkeypatch):
             headers={
                 "content-length": "308468",
                 "etag": '"deadbeef"',
+                "content-type": "text/plain; charset=utf-8",
             },
         ),
     )
     monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
 
-    khub_response = await fallback_ops.try_fallback_resolve(
+    resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
     )
 
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
-    )
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/selected_tags.csv")
+    meta = _hf_metadata(hx)
 
-    assert meta.size == 308468, (
-        "hf_hub would otherwise use 278 (redirect-body length) as expected size "
-        "and fail the post-download consistency check"
-    )
-    assert meta.etag == "deadbeef"
-    assert meta.commit_hash == "abc123"
-    assert meta.xet_file_data is None
-    # Accept-Encoding: identity was passed to the upstream HEAD
+    # hf_hub sees the REAL size, not the 278-byte redirect body
+    assert meta.size == 308468
+    assert meta.etag == "deadbeef"            # from the final 200 hop
+    assert meta.commit_hash == "abc123"        # preserved from the 307
+    assert meta.location.startswith("https://hf.local/api/resolve-cache/")
+    _assert_client_stays_on_classic_lfs(hx)
+    # Exactly one extra HEAD was fired, with Accept-Encoding: identity
+    assert len(stub.calls) == 1
     assert stub.calls[0][1]["headers"]["Accept-Encoding"] == "identity"
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_metadata_lfs_307_uses_x_linked_size_directly(monkeypatch):
-    """LFS 3xx: hf_hub prefers X-Linked-Size, so no extra HEAD is needed
-    and meta.size is the real file size even though Content-Length is the
-    redirect-body length."""
-    _configure(monkeypatch)
+async def test_pattern_A_resolve_cache_GET(monkeypatch):
+    """307 → /api/resolve-cache: GET streams the file through khub (httpx
+    follows the 307 server-side) and hf_hub sees a 200 with the real body."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/selected_tags.csv"
+    # khub's HEAD probe happens first (inside try_fallback_resolve)
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/weights.safetensors",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
             307,
             headers={
-                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
-                "content-length": "1369",            # 307 body length
-                "x-linked-size": "67840504",         # real file size
-                "x-linked-etag": '"sha256-deadbeef"',
+                "location": "/api/resolve-cache/models/owner/demo/abc123/selected_tags.csv",
+                "content-length": "278",
+                "x-repo-commit": "abc123",
+                "x-linked-etag": '"deadbeef"',
+            },
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/selected_tags.csv",
+        ),
+    )
+    # Then the real GET — fake httpx as having followed the 307 already
+    fake_body = b"tag_id,name,category,count\n" + b"a,b,0,1\n" * 100_000
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "GET", path,
+        _content_response(
+            200,
+            content=fake_body,
+            headers={
+                "content-type": "text/plain; charset=utf-8",
+                "etag": '"deadbeef"',
                 "x-repo-commit": "abc123",
             },
-            url=f"{HF_ENDPOINT}{REPO}/weights.safetensors",
+            url=f"{HF_ENDPOINT}/api/resolve-cache/models/owner/demo/abc123/selected_tags.csv",
         ),
     )
 
-    khub_response = await fallback_ops.try_fallback_resolve(
-        "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="GET",
     )
+    assert resp.status_code == 200
+    assert resp.body == fake_body
 
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/weights.safetensors"
-    )
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
 
-    assert meta.size == 67840504          # from X-Linked-Size
-    assert meta.etag == "sha256-deadbeef"  # from X-Linked-Etag, W/ stripped if any
-    assert meta.commit_hash == "abc123"
-    assert meta.xet_file_data is None       # no X-Xet-Hash
-    assert meta.location == "https://cas-bridge.xethub.hf.co/shard/deadbeef"
+# ---------------------------------------------------------------------------
+# Pattern B. 302 → absolute cas-bridge.xethub.hf.co (LFS-via-xet)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_xet_suppression_keeps_client_on_classic_lfs(monkeypatch):
-    """Any upstream X-Xet-* must be stripped, otherwise
-    parse_xet_file_data_from_response returns a XetFileData and hf_hub
-    jumps to the xet protocol (which we don't implement)."""
-    _configure(monkeypatch)
+async def test_pattern_B_xet_cas_bridge_HEAD(monkeypatch):
+    """302 → cas-bridge with X-Linked-Size. khub must: preserve the absolute
+    Location, forward X-Linked-Size as the real file size, and strip all
+    X-Xet-* headers so hf_hub stays on the classic LFS code path (the
+    fallback layer does not speak the Xet protocol)."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/weights.safetensors"
+
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/weights.safetensors",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
-            307,
+            302,
             headers={
-                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
+                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef?sig=xyz",
+                "content-length": "1369",
                 "x-linked-size": "67840504",
-                "x-linked-etag": '"deadbeef"',
+                "x-linked-etag": '"sha256-deadbeef"',
                 "x-repo-commit": "abc123",
-                "x-xet-hash": "shard-hash",
+                # Xet trap flags — must be dropped
+                "x-xet-hash": "shardhash",
                 "x-xet-refresh-route": (
                     "/api/models/owner/demo/xet-read-token/abc123"
                 ),
-                "link": '<https://cas-server/auth>; rel="xet-auth"',
+                "link": '<https://cas-server/auth>; rel="xet-auth", <https://next>; rel="next"',
             },
-            url=f"{HF_ENDPOINT}{REPO}/weights.safetensors",
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/weights.safetensors",
         ),
     )
 
-    khub_response = await fallback_ops.try_fallback_resolve(
+    resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
     )
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/weights.safetensors")
+    meta = _hf_metadata(hx)
 
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/weights.safetensors"
+    assert meta.size == 67840504                              # X-Linked-Size
+    assert meta.etag == "sha256-deadbeef"                      # X-Linked-Etag
+    assert meta.commit_hash == "abc123"
+    assert meta.location == (
+        "https://cas-bridge.xethub.hf.co/shard/deadbeef?sig=xyz"
     )
-    assert parse_xet_file_data_from_response(hx) is None
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
-    assert meta.xet_file_data is None
+    _assert_client_stays_on_classic_lfs(hx)
+    assert 'rel="next"' in hx.headers.get("link", "")
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_weak_etag_is_normalized(monkeypatch):
-    """hf_hub strips the W/ weak-etag marker; make sure whatever we
-    forward makes it through that helper intact. Covers both cases:
-    the initial 307 may carry a weak etag, the extra HEAD's 200 may
-    carry a strong one — whichever wins still needs to round-trip."""
-    _configure(monkeypatch)
+async def test_pattern_B_xet_cas_bridge_GET(monkeypatch):
+    """GET: for LFS blobs we don't proxy the body through khub — the client
+    takes metadata.location (cas-bridge URL) and goes direct. On the khub
+    side the only thing we verify is that the HEAD probe bookkeeping above
+    is consistent, and that a plain GET request still passes through the
+    xet-stripping logic."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/weights.safetensors"
+
+    # HEAD (sets cache)
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
-            307,
-            headers={
-                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
-                "content-length": "278",
-                "etag": 'W/"placeholder-weak"',
-                "x-repo-commit": "abc123",
-            },
-            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+            200,
+            headers={"x-linked-size": "67840504", "x-repo-commit": "abc123"},
         ),
     )
-    stub = AbsoluteHeadStub()
-    stub.queue(
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "GET", path,
+        _content_response(
+            200,
+            content=b"safetensor-bytes-here",
+            headers={
+                "content-type": "application/octet-stream",
+                "x-repo-commit": "abc123",
+                "x-xet-hash": "should-be-stripped",
+            },
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/weights.safetensors",
+        ),
+    )
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="GET",
+    )
+    assert resp.status_code == 200
+    assert resp.body == b"safetensor-bytes-here"
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/weights.safetensors")
+    _assert_client_stays_on_classic_lfs(hx)
+
+
+# ---------------------------------------------------------------------------
+# Pattern C. direct 200 (no redirect)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pattern_C_direct_200_HEAD(monkeypatch):
+    """Some HF repos serve small text (e.g. README.md) directly with 200
+    and no redirect. There is no Location to rewrite and no X-Linked-Size
+    to back-fill — the first-hop Content-Length IS the real file size."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/README.md"
+
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
             200,
             headers={
-                "content-length": "308468",
-                "etag": 'W/"real-weak-etag"',   # final hop: weak
+                "content-length": "8421",
+                "etag": '"direct-etag"',
+                "x-repo-commit": "abc123",
+                "content-type": "text/markdown; charset=utf-8",
             },
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/README.md",
         ),
     )
-    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
 
-    khub_response = await fallback_ops.try_fallback_resolve(
-        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "README.md", method="HEAD",
     )
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/README.md")
+    meta = _hf_metadata(hx)
 
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
-    )
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
-    # W/ marker stripped, size + commit preserved
-    assert meta.etag == "real-weak-etag"
-    assert meta.size == 308468
+    assert meta.size == 8421
+    assert meta.etag == "direct-etag"
     assert meta.commit_hash == "abc123"
+    # No Location means hf_hub uses request.url (khub) as metadata.location
+    assert "huggingface.co" not in meta.location
+    _assert_client_stays_on_classic_lfs(hx)
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_metadata_single_hop_200_no_redirect(monkeypatch):
-    """Some HF repos answer the initial /resolve HEAD with a straight 200
-    (non-LFS, no redirect). Make sure we don't break that baseline path."""
-    _configure(monkeypatch)
+async def test_pattern_C_direct_200_GET(monkeypatch):
+    """Direct-200 GET: body proxied through khub verbatim."""
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/README.md"
+    body = b"# KohakuHub\n\nHello world.\n" + b"line\n" * 500
+
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/config.json",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
             200,
-            headers={
-                "content-length": "512",
-                "etag": '"feedface"',
-                "x-repo-commit": "abc123",
-            },
-            url=f"{HF_ENDPOINT}{REPO}/config.json",
+            headers={"content-length": str(len(body)), "x-repo-commit": "abc123"},
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/README.md",
         ),
     )
-
-    khub_response = await fallback_ops.try_fallback_resolve(
-        "model", "owner", "demo", "main", "config.json", method="HEAD",
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "GET", path,
+        _content_response(
+            200,
+            content=body,
+            headers={
+                "content-type": "text/markdown; charset=utf-8",
+                "etag": '"direct-etag"',
+                "x-repo-commit": "abc123",
+            },
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/README.md",
+        ),
     )
-
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/config.json"
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "README.md", method="GET",
     )
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
-    assert meta.size == 512
-    assert meta.etag == "feedface"
-    assert meta.commit_hash == "abc123"
-    assert meta.xet_file_data is None
+    assert resp.status_code == 200
+    assert resp.body == body
+
+
+# ---------------------------------------------------------------------------
+# Extra: graceful degradation when the backfill HEAD fails
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_hf_hub_metadata_when_follow_fails_degrades_but_stays_parsable(monkeypatch):
-    """If the extra HEAD fails, we still produce a response hf_hub can
-    parse — metadata.size ends up as the 307 body length (stale), but
-    commit_hash and etag are intact so downloads can still be attempted."""
-    _configure(monkeypatch)
+async def test_pattern_A_resolve_cache_HEAD_fallback_on_error(monkeypatch):
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/selected_tags.csv"
     FakeFallbackClient.queue(
-        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        HF_ENDPOINT, "HEAD", path,
         _content_response(
             307,
             headers={
-                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "location": "/api/resolve-cache/abc",
                 "content-length": "278",
-                "etag": '"placeholder"',
                 "x-repo-commit": "abc123",
                 "x-linked-etag": '"deadbeef"',
             },
-            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/selected_tags.csv",
         ),
     )
     stub = AbsoluteHeadStub()
-    stub.queue(httpx.ConnectError("upstream gone"))
+    stub.queue(httpx.ConnectError("upstream 502"))
     monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
 
-    khub_response = await fallback_ops.try_fallback_resolve(
+    resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
     )
-
-    hx = _to_httpx_response(
-        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
-    )
-    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/selected_tags.csv")
+    meta = _hf_metadata(hx)
+    # Degrades to the 307 headers (size stale), but still parsable.
     assert meta.commit_hash == "abc123"
-    assert meta.etag == "deadbeef"     # X-Linked-Etag wins over "placeholder"
-    assert meta.size == 278             # stale but parsable
+    assert meta.etag == "deadbeef"
+    assert meta.size == 278

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -15,11 +15,23 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from huggingface_hub import constants as hf_constants
-from huggingface_hub.file_download import HfFileMetadata, _int_or_none, _normalize_etag
-from huggingface_hub.utils._xet import parse_xet_file_data_from_response
+# These tests lean on huggingface_hub's internal metadata parser, which
+# only gained the Xet module in huggingface_hub >= 1.0. Skip the whole
+# file cleanly on the older pins (0.20.3 / 0.30.2 / 0.36.2 in the matrix).
+pytest.importorskip(
+    "huggingface_hub.utils._xet",
+    reason="huggingface_hub.utils._xet is only present in huggingface_hub >= 1.0",
+)
 
-import kohakuhub.api.fallback.operations as fallback_ops
+from huggingface_hub import constants as hf_constants  # noqa: E402
+from huggingface_hub.file_download import (  # noqa: E402
+    HfFileMetadata,
+    _int_or_none,
+    _normalize_etag,
+)
+from huggingface_hub.utils._xet import parse_xet_file_data_from_response  # noqa: E402
+
+import kohakuhub.api.fallback.operations as fallback_ops  # noqa: E402
 
 from test.kohakuhub.api.fallback.test_operations import (  # noqa: E402
     AbsoluteHeadStub,

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -1,0 +1,334 @@
+"""Integration tests: feed the HEAD response KohakuHub produces straight
+into huggingface_hub's own metadata parser and assert the resulting
+``HfFileMetadata`` is well-formed.
+
+These tests fail if a regression breaks any of the client-side invariants
+that real downloads rely on — Content-Length → expected_size, ETag
+normalization, xet suppression, commit hash presence, etc. Unlike the
+pure-unit tests that check our response shape directly, these wire the
+response into huggingface_hub 1.x's real functions (the same ones
+``hf_hub_download`` uses) so any future hf_hub change that narrows the
+contract surfaces here immediately.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.file_download import HfFileMetadata, _int_or_none, _normalize_etag
+from huggingface_hub.utils._xet import parse_xet_file_data_from_response
+
+import kohakuhub.api.fallback.operations as fallback_ops
+
+from test.kohakuhub.api.fallback.test_operations import (  # noqa: E402
+    AbsoluteHeadStub,
+    DummyCache,
+    FakeFallbackClient,
+    _content_response,
+)
+
+
+HF_ENDPOINT = "https://hf.local"
+REPO = "/models/owner/demo/resolve/main"
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_env(monkeypatch):
+    monkeypatch.setattr(fallback_ops.cfg.fallback, "enabled", True)
+    FakeFallbackClient.reset()
+    monkeypatch.setattr(fallback_ops, "FallbackClient", FakeFallbackClient)
+
+
+def _to_httpx_response(
+    fastapi_response,
+    *,
+    request_url: str,
+) -> httpx.Response:
+    """Re-wrap a FastAPI ``Response`` as an httpx ``Response`` so we can
+    hand it off to hf_hub's parsing routines unmodified."""
+    raw_headers = fastapi_response.raw_headers  # list[tuple[bytes, bytes]]
+    headers = httpx.Headers(
+        [(k.decode("latin-1"), v.decode("latin-1")) for k, v in raw_headers]
+    )
+    return httpx.Response(
+        status_code=fastapi_response.status_code,
+        headers=headers,
+        content=fastapi_response.body or b"",
+        request=httpx.Request("HEAD", request_url),
+    )
+
+
+def _hf_metadata(httpx_response: httpx.Response, endpoint: str) -> HfFileMetadata:
+    """Call the same metadata-extraction logic hf_hub uses internally in
+    ``get_hf_file_metadata`` (see ``huggingface_hub/file_download.py:1597``)."""
+    return HfFileMetadata(
+        commit_hash=httpx_response.headers.get(
+            hf_constants.HUGGINGFACE_HEADER_X_REPO_COMMIT
+        ),
+        etag=_normalize_etag(
+            httpx_response.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_ETAG)
+            or httpx_response.headers.get("ETag")
+        ),
+        location=httpx_response.headers.get("Location")
+        or str(httpx_response.request.url),
+        size=_int_or_none(
+            httpx_response.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
+            or httpx_response.headers.get("Content-Length")
+        ),
+        xet_file_data=parse_xet_file_data_from_response(
+            httpx_response, endpoint=endpoint
+        ),
+    )
+
+
+def _configure(monkeypatch):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": HF_ENDPOINT, "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_metadata_non_lfs_307_has_real_content_length(monkeypatch):
+    """hf_hub must see the **real** 308468-byte size after khub's extra
+    HEAD — not the 278-byte redirect body length. This is the consistency
+    check bug that breaks get_wd14_tags."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "content-length": "278",
+                "etag": 'W/"placeholder"',
+                "x-repo-commit": "abc123",
+                "x-linked-etag": '"deadbeef"',
+            },
+            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+        ),
+    )
+    stub = AbsoluteHeadStub()
+    stub.queue(
+        _content_response(
+            200,
+            headers={
+                "content-length": "308468",
+                "etag": '"deadbeef"',
+            },
+        ),
+    )
+    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
+    )
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+
+    assert meta.size == 308468, (
+        "hf_hub would otherwise use 278 (redirect-body length) as expected size "
+        "and fail the post-download consistency check"
+    )
+    assert meta.etag == "deadbeef"
+    assert meta.commit_hash == "abc123"
+    assert meta.xet_file_data is None
+    # Accept-Encoding: identity was passed to the upstream HEAD
+    assert stub.calls[0][1]["headers"]["Accept-Encoding"] == "identity"
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_metadata_lfs_307_uses_x_linked_size_directly(monkeypatch):
+    """LFS 3xx: hf_hub prefers X-Linked-Size, so no extra HEAD is needed
+    and meta.size is the real file size even though Content-Length is the
+    redirect-body length."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/weights.safetensors",
+        _content_response(
+            307,
+            headers={
+                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
+                "content-length": "1369",            # 307 body length
+                "x-linked-size": "67840504",         # real file size
+                "x-linked-etag": '"sha256-deadbeef"',
+                "x-repo-commit": "abc123",
+            },
+            url=f"{HF_ENDPOINT}{REPO}/weights.safetensors",
+        ),
+    )
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/weights.safetensors"
+    )
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+
+    assert meta.size == 67840504          # from X-Linked-Size
+    assert meta.etag == "sha256-deadbeef"  # from X-Linked-Etag, W/ stripped if any
+    assert meta.commit_hash == "abc123"
+    assert meta.xet_file_data is None       # no X-Xet-Hash
+    assert meta.location == "https://cas-bridge.xethub.hf.co/shard/deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_xet_suppression_keeps_client_on_classic_lfs(monkeypatch):
+    """Any upstream X-Xet-* must be stripped, otherwise
+    parse_xet_file_data_from_response returns a XetFileData and hf_hub
+    jumps to the xet protocol (which we don't implement)."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/weights.safetensors",
+        _content_response(
+            307,
+            headers={
+                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
+                "x-linked-size": "67840504",
+                "x-linked-etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+                "x-xet-hash": "shard-hash",
+                "x-xet-refresh-route": (
+                    "/api/models/owner/demo/xet-read-token/abc123"
+                ),
+                "link": '<https://cas-server/auth>; rel="xet-auth"',
+            },
+            url=f"{HF_ENDPOINT}{REPO}/weights.safetensors",
+        ),
+    )
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/weights.safetensors"
+    )
+    assert parse_xet_file_data_from_response(hx, endpoint="http://khub.local") is None
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    assert meta.xet_file_data is None
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_weak_etag_is_normalized(monkeypatch):
+    """hf_hub strips the W/ weak-etag marker; make sure whatever we
+    forward makes it through that helper intact. Covers both cases:
+    the initial 307 may carry a weak etag, the extra HEAD's 200 may
+    carry a strong one — whichever wins still needs to round-trip."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "content-length": "278",
+                "etag": 'W/"placeholder-weak"',
+                "x-repo-commit": "abc123",
+            },
+            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+        ),
+    )
+    stub = AbsoluteHeadStub()
+    stub.queue(
+        _content_response(
+            200,
+            headers={
+                "content-length": "308468",
+                "etag": 'W/"real-weak-etag"',   # final hop: weak
+            },
+        ),
+    )
+    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
+    )
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    # W/ marker stripped, size + commit preserved
+    assert meta.etag == "real-weak-etag"
+    assert meta.size == 308468
+    assert meta.commit_hash == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_metadata_single_hop_200_no_redirect(monkeypatch):
+    """Some HF repos answer the initial /resolve HEAD with a straight 200
+    (non-LFS, no redirect). Make sure we don't break that baseline path."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/config.json",
+        _content_response(
+            200,
+            headers={
+                "content-length": "512",
+                "etag": '"feedface"',
+                "x-repo-commit": "abc123",
+            },
+            url=f"{HF_ENDPOINT}{REPO}/config.json",
+        ),
+    )
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "config.json", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/config.json"
+    )
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    assert meta.size == 512
+    assert meta.etag == "feedface"
+    assert meta.commit_hash == "abc123"
+    assert meta.xet_file_data is None
+
+
+@pytest.mark.asyncio
+async def test_hf_hub_metadata_when_follow_fails_degrades_but_stays_parsable(monkeypatch):
+    """If the extra HEAD fails, we still produce a response hf_hub can
+    parse — metadata.size ends up as the 307 body length (stale), but
+    commit_hash and etag are intact so downloads can still be attempted."""
+    _configure(monkeypatch)
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", f"{REPO}/selected_tags.csv",
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "content-length": "278",
+                "etag": '"placeholder"',
+                "x-repo-commit": "abc123",
+                "x-linked-etag": '"deadbeef"',
+            },
+            url=f"{HF_ENDPOINT}{REPO}/selected_tags.csv",
+        ),
+    )
+    stub = AbsoluteHeadStub()
+    stub.queue(httpx.ConnectError("upstream gone"))
+    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
+
+    khub_response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    )
+
+    hx = _to_httpx_response(
+        khub_response, request_url=f"http://khub.local{REPO}/selected_tags.csv"
+    )
+    meta = _hf_metadata(hx, endpoint="http://khub.local")
+    assert meta.commit_hash == "abc123"
+    assert meta.etag == "deadbeef"     # X-Linked-Etag wins over "placeholder"
+    assert meta.size == 278             # stale but parsable

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -88,9 +88,7 @@ def _hf_metadata(httpx_response: httpx.Response, endpoint: str) -> HfFileMetadat
             httpx_response.headers.get(hf_constants.HUGGINGFACE_HEADER_X_LINKED_SIZE)
             or httpx_response.headers.get("Content-Length")
         ),
-        xet_file_data=parse_xet_file_data_from_response(
-            httpx_response, endpoint=endpoint
-        ),
+        xet_file_data=parse_xet_file_data_from_response(httpx_response),
     )
 
 
@@ -226,7 +224,7 @@ async def test_hf_hub_xet_suppression_keeps_client_on_classic_lfs(monkeypatch):
     hx = _to_httpx_response(
         khub_response, request_url=f"http://khub.local{REPO}/weights.safetensors"
     )
-    assert parse_xet_file_data_from_response(hx, endpoint="http://khub.local") is None
+    assert parse_xet_file_data_from_response(hx) is None
     meta = _hf_metadata(hx, endpoint="http://khub.local")
     assert meta.xet_file_data is None
 

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -26,12 +26,14 @@ def _content_response(
     *,
     headers: dict[str, str] | None = None,
     url: str = "https://source.local/file.bin",
+    history: list[httpx.Response] | None = None,
 ) -> httpx.Response:
     return httpx.Response(
         status_code,
         content=content,
         headers=headers,
         request=httpx.Request("GET", url),
+        history=history or [],
     )
 
 
@@ -89,6 +91,31 @@ class FakeFallbackClient:
 
     async def post(self, kohaku_path: str, repo_type: str, **kwargs) -> httpx.Response:
         return await self._dispatch("POST", kohaku_path, **kwargs)
+
+
+class AbsoluteHeadStub:
+    """Scripted replacement for httpx.AsyncClient.head used for extra-HEAD calls.
+
+    When patched in via `monkeypatch.setattr(httpx.AsyncClient, "head", stub)`
+    the bound-method descriptor drops the httpx-client self, so our call
+    signature only needs (url, **kwargs).
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.responses: list[object] = []
+
+    def queue(self, *results: object) -> None:
+        self.responses.extend(results)
+
+    async def __call__(self, url: str, **kwargs) -> httpx.Response:
+        self.calls.append((url, kwargs))
+        if not self.responses:
+            raise AssertionError(f"No scripted response for absolute HEAD {url}")
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
 
 
 @pytest.fixture(autouse=True)
@@ -212,8 +239,10 @@ async def test_try_fallback_resolve_proxies_get_content_and_continues_after_get_
 
 
 @pytest.mark.asyncio
-async def test_try_fallback_resolve_head_rewrites_relative_location_to_upstream(monkeypatch):
-    """HEAD must not leak HF's relative redirect to KohakuHub — rewrite it to absolute."""
+async def test_try_fallback_resolve_head_rewrites_relative_location_to_absolute(monkeypatch):
+    """HEAD must not leak HF's relative /api/resolve-cache Location —
+    rewriting it to absolute steers the client back to the upstream for
+    the follow-up redirect."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -222,47 +251,41 @@ async def test_try_fallback_resolve_head_rewrites_relative_location_to_upstream(
             {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
         ],
     )
-    path = "/models/owner/demo/resolve/main/weights.bin"
-    upstream_url = "https://hf.local/owner/demo/resolve/main/weights.bin"
-    relative_location = (
-        "/api/resolve-cache/models/owner/demo/abc123/weights.bin?etag=%22deadbeef%22"
-    )
+    # LFS-shaped 307 (has X-Linked-Size) so no follow-up HEAD is issued.
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
     FakeFallbackClient.queue(
-        "https://hf.local",
-        "HEAD",
-        path,
+        "https://hf.local", "HEAD", path,
         _content_response(
             307,
             headers={
-                "location": relative_location,
-                "etag": '"deadbeef"',
+                "location": "/api/resolve-cache/models/owner/demo/sha/weights.safetensors",
+                "content-length": "278",
+                "x-linked-size": "67840504",
+                "x-linked-etag": '"deadbeef"',
                 "x-repo-commit": "abc123",
             },
-            url=upstream_url,
+            url="https://hf.local/models/owner/demo/resolve/main/weights.safetensors",
         ),
     )
 
     response = await fallback_ops.try_fallback_resolve(
-        "model",
-        "owner",
-        "demo",
-        "main",
-        "weights.bin",
-        method="HEAD",
+        "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
     )
 
     assert response.status_code == 307
     assert (
         response.headers["location"]
-        == "https://hf.local/api/resolve-cache/models/owner/demo/abc123/weights.bin?etag=%22deadbeef%22"
+        == "https://hf.local/api/resolve-cache/models/owner/demo/sha/weights.safetensors"
     )
-    assert response.headers["etag"] == '"deadbeef"'
-    assert response.headers["X-Source"] == "HF"
+    # LFS metadata preserved; no extra HEAD fired (X-Linked-Size suffices).
+    assert response.headers["x-linked-size"] == "67840504"
+    assert response.headers["x-repo-commit"] == "abc123"
 
 
 @pytest.mark.asyncio
-async def test_try_fallback_resolve_head_preserves_absolute_location(monkeypatch):
-    """HEAD with an already-absolute Location should pass it through untouched."""
+async def test_try_fallback_resolve_head_absolute_location_passes_through(monkeypatch):
+    """An already-absolute Location (typical of LFS → cas-bridge) is kept
+    verbatim — urljoin on an absolute target is a no-op."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -271,38 +294,128 @@ async def test_try_fallback_resolve_head_preserves_absolute_location(monkeypatch
             {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
         ],
     )
+    absolute = "https://cas-bridge.xethub.hf.co/shard/deadbeef?token=xyz"
     path = "/datasets/owner/demo/resolve/main/data.parquet"
-    upstream_url = "https://hf.local/datasets/owner/demo/resolve/main/data.parquet"
-    absolute_location = (
-        "https://cdn-lfs.hf.local/owner/demo/sha256/deadbeef/data.parquet?token=xyz"
-    )
     FakeFallbackClient.queue(
-        "https://hf.local",
-        "HEAD",
-        path,
+        "https://hf.local", "HEAD", path,
         _content_response(
             302,
-            headers={"location": absolute_location},
-            url=upstream_url,
+            headers={
+                "location": absolute,
+                "x-linked-size": "1234567",
+            },
+            url="https://hf.local/datasets/owner/demo/resolve/main/data.parquet",
         ),
     )
 
     response = await fallback_ops.try_fallback_resolve(
-        "dataset",
-        "owner",
-        "demo",
-        "main",
-        "data.parquet",
-        method="HEAD",
+        "dataset", "owner", "demo", "main", "data.parquet", method="HEAD",
     )
 
     assert response.status_code == 302
-    assert response.headers["location"] == absolute_location
+    assert response.headers["location"] == absolute
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_head_non_lfs_307_follows_for_content_length(monkeypatch):
+    """Non-LFS 3xx (no X-Linked-Size) needs one extra HEAD to the rewritten
+    Location to pick up the real Content-Length and ETag. This is the
+    imgutils selected_tags.csv fix."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/selected_tags.csv"
+    FakeFallbackClient.queue(
+        "https://hf.local", "HEAD", path,
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "content-length": "278",           # 307 body length, wrong
+                "etag": '"placeholder"',
+                "x-repo-commit": "abc123",
+                "x-linked-etag": '"deadbeef"',
+            },
+            url="https://hf.local/models/owner/demo/resolve/main/selected_tags.csv",
+        ),
+    )
+    stub = AbsoluteHeadStub()
+    stub.queue(
+        _content_response(
+            200,
+            headers={"content-length": "308468", "etag": '"deadbeef"'},
+        ),
+    )
+    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    )
+
+    assert response.status_code == 307
+    assert (
+        response.headers["location"]
+        == "https://hf.local/api/resolve-cache/models/owner/demo/sha/selected_tags.csv"
+    )
+    # Content-Length / ETag replaced with the final hop's values.
+    assert response.headers["content-length"] == "308468"
+    assert response.headers["etag"] == '"deadbeef"'
+    # X-Repo-Commit / X-Linked-Etag kept from the initial 307.
+    assert response.headers["x-repo-commit"] == "abc123"
+    assert response.headers["x-linked-etag"] == '"deadbeef"'
+    # Exactly one extra HEAD, against the rewritten absolute URL.
+    assert len(stub.calls) == 1
+    assert stub.calls[0][0] == response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_head_follow_error_falls_back_silently(monkeypatch):
+    """If the extra HEAD raises httpx.HTTPError, we keep the 307 response
+    we already had instead of failing the request."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/selected_tags.csv"
+    FakeFallbackClient.queue(
+        "https://hf.local", "HEAD", path,
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/selected_tags.csv",
+                "content-length": "278",
+                "x-repo-commit": "abc123",
+            },
+            url="https://hf.local/models/owner/demo/resolve/main/selected_tags.csv",
+        ),
+    )
+    stub = AbsoluteHeadStub()
+    stub.queue(httpx.ConnectError("boom"))
+    monkeypatch.setattr(httpx.AsyncClient, "head", stub.__call__)
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "selected_tags.csv", method="HEAD",
+    )
+
+    # Initial 307 headers preserved (content-length stale but still returned).
+    assert response.status_code == 307
+    assert response.headers["content-length"] == "278"
+    assert response.headers["x-repo-commit"] == "abc123"
 
 
 @pytest.mark.asyncio
 async def test_try_fallback_resolve_head_strips_xet_signals(monkeypatch):
-    """HEAD must drop X-Xet-* headers and Link rel=xet-auth so hf_hub falls back to classic LFS."""
+    """Xet response headers must be removed so the client stays on the
+    classic LFS flow."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -312,23 +425,17 @@ async def test_try_fallback_resolve_head_strips_xet_signals(monkeypatch):
         ],
     )
     path = "/models/owner/demo/resolve/main/weights.safetensors"
-    upstream_url = "https://hf.local/owner/demo/resolve/main/weights.safetensors"
     FakeFallbackClient.queue(
-        "https://hf.local",
-        "HEAD",
-        path,
+        "https://hf.local", "HEAD", path,
         _content_response(
             307,
             headers={
-                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
-                "etag": '"deadbeef"',
-                "x-repo-commit": "abc123",
-                "x-xet-hash": "shardhash",
-                "x-xet-refresh-route": "/api/models/owner/demo/xet-read-token/abc123",
-                "x-xet-cas-url": "https://cas-bridge.xethub.hf.co",
-                "link": '<https://cas-bridge/auth>; rel="xet-auth", <https://next>; rel="next"',
+                "location": "https://cas-bridge.xethub.hf.co/shard",
+                "x-linked-size": "42",
+                "x-xet-hash": "SHOULD_BE_GONE",
+                "link": '<https://cas/auth>; rel="xet-auth", <https://next>; rel="next"',
             },
-            url=upstream_url,
+            url="https://hf.local/models/owner/demo/resolve/main/weights.safetensors",
         ),
     )
 
@@ -336,18 +443,10 @@ async def test_try_fallback_resolve_head_strips_xet_signals(monkeypatch):
         "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
     )
 
-    assert response.status_code == 307
-    # Location intact (absolute URL passes through urljoin untouched)
-    assert response.headers["location"] == "https://cas-bridge.xethub.hf.co/shard/deadbeef"
-    # Xet headers stripped
-    lower_headers = {k.lower() for k in response.headers.keys()}
-    assert not any(k.startswith("x-xet-") for k in lower_headers)
-    # Link "xet-auth" relation stripped, "next" preserved
+    lower = {k.lower() for k in response.headers.keys()}
+    assert not any(k.startswith("x-xet-") for k in lower)
     assert "xet-auth" not in response.headers["link"].lower()
     assert 'rel="next"' in response.headers["link"]
-    # Non-xet metadata preserved
-    assert response.headers["etag"] == '"deadbeef"'
-    assert response.headers["x-repo-commit"] == "abc123"
 
 
 @pytest.mark.asyncio
@@ -390,43 +489,6 @@ async def test_try_fallback_resolve_get_strips_xet_signals(monkeypatch):
     lower_headers = {k.lower() for k in response.headers.keys()}
     assert not any(k.startswith("x-xet-") for k in lower_headers)
     assert response.headers["etag"] == '"deadbeef"'
-
-
-@pytest.mark.asyncio
-async def test_try_fallback_resolve_head_without_location_is_unchanged(monkeypatch):
-    """A HEAD 200 without a Location header must not gain one or fail."""
-    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
-    monkeypatch.setattr(
-        fallback_ops,
-        "get_enabled_sources",
-        lambda namespace, user_tokens=None: [
-            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
-        ],
-    )
-    path = "/models/owner/demo/resolve/main/config.json"
-    FakeFallbackClient.queue(
-        "https://hf.local",
-        "HEAD",
-        path,
-        _content_response(
-            200,
-            headers={"etag": '"feedface"'},
-            url="https://hf.local/owner/demo/resolve/main/config.json",
-        ),
-    )
-
-    response = await fallback_ops.try_fallback_resolve(
-        "model",
-        "owner",
-        "demo",
-        "main",
-        "config.json",
-        method="HEAD",
-    )
-
-    assert response.status_code == 200
-    assert "location" not in response.headers
-    assert response.headers["etag"] == '"feedface"'
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -212,6 +212,132 @@ async def test_try_fallback_resolve_proxies_get_content_and_continues_after_get_
 
 
 @pytest.mark.asyncio
+async def test_try_fallback_resolve_head_rewrites_relative_location_to_upstream(monkeypatch):
+    """HEAD must not leak HF's relative redirect to KohakuHub — rewrite it to absolute."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.bin"
+    upstream_url = "https://hf.local/owner/demo/resolve/main/weights.bin"
+    relative_location = (
+        "/api/resolve-cache/models/owner/demo/abc123/weights.bin?etag=%22deadbeef%22"
+    )
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "HEAD",
+        path,
+        _content_response(
+            307,
+            headers={
+                "location": relative_location,
+                "etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+            },
+            url=upstream_url,
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model",
+        "owner",
+        "demo",
+        "main",
+        "weights.bin",
+        method="HEAD",
+    )
+
+    assert response.status_code == 307
+    assert (
+        response.headers["location"]
+        == "https://hf.local/api/resolve-cache/models/owner/demo/abc123/weights.bin?etag=%22deadbeef%22"
+    )
+    assert response.headers["etag"] == '"deadbeef"'
+    assert response.headers["X-Source"] == "HF"
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_head_preserves_absolute_location(monkeypatch):
+    """HEAD with an already-absolute Location should pass it through untouched."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/datasets/owner/demo/resolve/main/data.parquet"
+    upstream_url = "https://hf.local/datasets/owner/demo/resolve/main/data.parquet"
+    absolute_location = (
+        "https://cdn-lfs.hf.local/owner/demo/sha256/deadbeef/data.parquet?token=xyz"
+    )
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "HEAD",
+        path,
+        _content_response(
+            302,
+            headers={"location": absolute_location},
+            url=upstream_url,
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "dataset",
+        "owner",
+        "demo",
+        "main",
+        "data.parquet",
+        method="HEAD",
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == absolute_location
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_head_without_location_is_unchanged(monkeypatch):
+    """A HEAD 200 without a Location header must not gain one or fail."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/config.json"
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "HEAD",
+        path,
+        _content_response(
+            200,
+            headers={"etag": '"feedface"'},
+            url="https://hf.local/owner/demo/resolve/main/config.json",
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model",
+        "owner",
+        "demo",
+        "main",
+        "config.json",
+        method="HEAD",
+    )
+
+    assert response.status_code == 200
+    assert "location" not in response.headers
+    assert response.headers["etag"] == '"feedface"'
+
+
+@pytest.mark.asyncio
 async def test_try_fallback_resolve_stops_on_non_retryable_status_and_handles_timeouts(monkeypatch):
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -301,6 +301,98 @@ async def test_try_fallback_resolve_head_preserves_absolute_location(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_try_fallback_resolve_head_strips_xet_signals(monkeypatch):
+    """HEAD must drop X-Xet-* headers and Link rel=xet-auth so hf_hub falls back to classic LFS."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    upstream_url = "https://hf.local/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "HEAD",
+        path,
+        _content_response(
+            307,
+            headers={
+                "location": "https://cas-bridge.xethub.hf.co/shard/deadbeef",
+                "etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+                "x-xet-hash": "shardhash",
+                "x-xet-refresh-route": "/api/models/owner/demo/xet-read-token/abc123",
+                "x-xet-cas-url": "https://cas-bridge.xethub.hf.co",
+                "link": '<https://cas-bridge/auth>; rel="xet-auth", <https://next>; rel="next"',
+            },
+            url=upstream_url,
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="HEAD",
+    )
+
+    assert response.status_code == 307
+    # Location intact (absolute URL passes through urljoin untouched)
+    assert response.headers["location"] == "https://cas-bridge.xethub.hf.co/shard/deadbeef"
+    # Xet headers stripped
+    lower_headers = {k.lower() for k in response.headers.keys()}
+    assert not any(k.startswith("x-xet-") for k in lower_headers)
+    # Link "xet-auth" relation stripped, "next" preserved
+    assert "xet-auth" not in response.headers["link"].lower()
+    assert 'rel="next"' in response.headers["link"]
+    # Non-xet metadata preserved
+    assert response.headers["etag"] == '"deadbeef"'
+    assert response.headers["x-repo-commit"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_strips_xet_signals(monkeypatch):
+    """GET proxying must also drop X-Xet-* headers so the client stays on classic LFS."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue(
+        "https://hf.local", "HEAD", path, _content_response(200),
+    )
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(
+            200,
+            b"fake-bytes",
+            headers={
+                "content-type": "application/octet-stream",
+                "x-xet-hash": "shardhash",
+                "x-xet-cas-url": "https://cas-bridge.xethub.hf.co",
+                "etag": '"deadbeef"',
+            },
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="GET",
+    )
+
+    assert response.status_code == 200
+    assert response.body == b"fake-bytes"
+    lower_headers = {k.lower() for k in response.headers.keys()}
+    assert not any(k.startswith("x-xet-") for k in lower_headers)
+    assert response.headers["etag"] == '"deadbeef"'
+
+
+@pytest.mark.asyncio
 async def test_try_fallback_resolve_head_without_location_is_unchanged(monkeypatch):
     """A HEAD 200 without a Location header must not gain one or fail."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)

--- a/test/kohakuhub/api/fallback/test_real_hf_hub_end_to_end.py
+++ b/test/kohakuhub/api/fallback/test_real_hf_hub_end_to_end.py
@@ -1,0 +1,174 @@
+"""End-to-end tests: run REAL ``hf_hub_download`` against a KohakuHub
+live server whose fallback source points at a mock HuggingFace process.
+
+Unlike the parser-level interop tests, these go the full distance:
+
+    [test] hf_hub_download
+       → HTTPS  → [live_server_url: real khub uvicorn]
+       → fallback → [mock_hf_server_url: fake HF uvicorn]
+       → response flows back → cache file written + etag + size checked
+
+Each of the three /resolve redirect patterns observed in the 100-repo
+HF survey (see PR #21 comments) is exercised with a real file body, and
+the test asserts ``open(path).read() == PATTERN_*_BYTES``. If KohakuHub
+regresses on Content-Length backfill, Location rewrite, xet header
+stripping, or GET proxy, the downloaded file size / etag mismatches and
+hf_hub's own consistency check raises before the byte assertion even
+runs.
+
+Runs on every matrix cell because ``hf_hub_download`` is a stable public
+API across the 0.20.3 → latest range in the CI matrix.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from huggingface_hub import hf_hub_download
+
+from test.kohakuhub.support.live_server import start_live_server, stop_live_server
+from test.kohakuhub.support.mock_hf_server import (
+    COMMIT,
+    PATTERN_A_BYTES,
+    PATTERN_B_BYTES,
+    PATTERN_C_BYTES,
+    build_mock_hf_app,
+)
+
+
+@pytest.fixture(scope="module")
+def mock_hf_server_url():
+    """A second live uvicorn process that plays the role of HF upstream."""
+    handle = start_live_server(build_mock_hf_app())
+    try:
+        yield handle.base_url
+    finally:
+        stop_live_server(handle)
+
+
+@pytest.fixture
+def fallback_points_to_mock(backend_test_state, mock_hf_server_url):
+    """Swap khub's fallback sources to point exclusively at mock HF for
+    the duration of the test, and clear the per-process fallback cache."""
+    cfg = backend_test_state.modules.config_module.cfg
+    old_sources = list(cfg.fallback.sources)
+    old_enabled = cfg.fallback.enabled
+    cfg.fallback.enabled = True
+    cfg.fallback.sources = [
+        {
+            "url": mock_hf_server_url,
+            "name": "MockHF",
+            "source_type": "huggingface",
+            "priority": 1,
+        }
+    ]
+    backend_test_state.modules.fallback_cache_module.get_cache().clear()
+    try:
+        yield mock_hf_server_url
+    finally:
+        cfg.fallback.sources = old_sources
+        cfg.fallback.enabled = old_enabled
+        backend_test_state.modules.fallback_cache_module.get_cache().clear()
+
+
+async def _download(
+    *, live_server_url: str, hf_api_token: str, filename: str, tmp_path: Path
+) -> bytes:
+    """Call hf_hub_download in a worker thread (it is blocking) and read
+    back the cached bytes so the test layer can diff them."""
+
+    def _run() -> bytes:
+        path = hf_hub_download(
+            repo_id="owner/fake-repo",
+            filename=filename,
+            endpoint=live_server_url,
+            token=hf_api_token,
+            cache_dir=str(tmp_path),
+        )
+        return Path(path).read_bytes()
+
+    return await asyncio.to_thread(_run)
+
+
+@pytest.mark.asyncio
+async def test_real_hf_hub_download_pattern_A_resolve_cache(
+    live_server_url, hf_api_token, fallback_points_to_mock, tmp_path,
+):
+    """Non-LFS text file served via 307 → /api/resolve-cache/…
+
+    Validates the Content-Length backfill in `try_fallback_resolve`:
+    without it, hf_hub's post-download consistency check rejects the
+    file as "should be of size 278 but has size N".
+    """
+    received = await _download(
+        live_server_url=live_server_url,
+        hf_api_token=hf_api_token,
+        filename="pattern_a.txt",
+        tmp_path=tmp_path,
+    )
+    assert received == PATTERN_A_BYTES
+
+
+@pytest.mark.asyncio
+async def test_real_hf_hub_download_pattern_B_xet_cas_bridge(
+    live_server_url, hf_api_token, fallback_points_to_mock, tmp_path,
+):
+    """LFS blob served via 302 → absolute CDN + X-Linked-Size.
+
+    Validates:
+      * absolute Location preserved untouched (urljoin no-op)
+      * X-Linked-Size forwarded so hf_hub uses it as expected_size
+      * any X-Xet-* that leak through are stripped so the client stays
+        on the classic LFS path (KohakuHub does not implement Xet)
+    """
+    received = await _download(
+        live_server_url=live_server_url,
+        hf_api_token=hf_api_token,
+        filename="pattern_b.bin",
+        tmp_path=tmp_path,
+    )
+    assert received == PATTERN_B_BYTES
+
+
+@pytest.mark.asyncio
+async def test_real_hf_hub_download_pattern_C_direct_200(
+    live_server_url, hf_api_token, fallback_points_to_mock, tmp_path,
+):
+    """No redirect at all — upstream just answers 200 on the first HEAD/GET.
+
+    Validates the single-hop passthrough: khub does not issue an extra
+    HEAD (no Location to follow) and does not invent a fake Location,
+    so hf_hub's metadata.location falls back to the request URL and the
+    GET body is proxied through khub verbatim.
+    """
+    received = await _download(
+        live_server_url=live_server_url,
+        hf_api_token=hf_api_token,
+        filename="pattern_c.md",
+        tmp_path=tmp_path,
+    )
+    assert received == PATTERN_C_BYTES
+
+
+@pytest.mark.asyncio
+async def test_real_hf_hub_download_warm_cache_does_not_refetch(
+    live_server_url, hf_api_token, fallback_points_to_mock, tmp_path,
+):
+    """Warm cache: second download into the same cache_dir must skip the
+    GET (etag match) but still succeed. This is the scenario reviewers
+    specifically called out — make sure hf_hub's HEAD-only revalidation
+    path is compatible with khub's synthesized HEAD response."""
+    first = await _download(
+        live_server_url=live_server_url,
+        hf_api_token=hf_api_token,
+        filename="pattern_a.txt",
+        tmp_path=tmp_path,
+    )
+    second = await _download(
+        live_server_url=live_server_url,
+        hf_api_token=hf_api_token,
+        filename="pattern_a.txt",
+        tmp_path=tmp_path,
+    )
+    assert first == second == PATTERN_A_BYTES

--- a/test/kohakuhub/api/fallback/test_utils.py
+++ b/test/kohakuhub/api/fallback/test_utils.py
@@ -10,6 +10,7 @@ from kohakuhub.api.fallback.utils import (
     is_not_found_error,
     is_server_error,
     should_retry_source,
+    strip_xet_response_headers,
 )
 
 
@@ -87,3 +88,67 @@ def test_add_source_headers_reports_external_source_metadata():
         "X-Source-URL": "https://mirror.local",
         "X-Source-Status": "206",
     }
+
+
+def test_strip_xet_response_headers_removes_all_xet_signals():
+    headers = {
+        "etag": '"deadbeef"',
+        "X-Xet-Hash": "abc123",
+        "X-Xet-Refresh-Route": "/api/models/owner/repo/xet-read-token/sha",
+        "X-Xet-Cas-Url": "https://cas-bridge.xethub.hf.co",
+        "X-Xet-Access-Token": "cas-tok",
+        "X-Xet-Expiration": "1800000000",
+        "x-linked-etag": '"keep-me"',  # LFS-related, not xet; must stay
+        "link": '<https://cas/auth>; rel="xet-auth", <https://next>; rel="next"',
+    }
+
+    strip_xet_response_headers(headers)
+
+    assert "X-Xet-Hash" not in headers
+    assert "X-Xet-Refresh-Route" not in headers
+    assert "X-Xet-Cas-Url" not in headers
+    assert "X-Xet-Access-Token" not in headers
+    assert "X-Xet-Expiration" not in headers
+    # Non-Xet headers untouched
+    assert headers["etag"] == '"deadbeef"'
+    assert headers["x-linked-etag"] == '"keep-me"'
+    # Link relation "xet-auth" stripped, "next" kept
+    assert "xet-auth" not in headers["link"].lower()
+    assert 'rel="next"' in headers["link"]
+
+
+def test_strip_xet_response_headers_case_insensitive_matching():
+    headers = {
+        "x-xet-hash": "abc",          # lowercase
+        "X-XET-REFRESH-ROUTE": "/r",  # uppercase
+        "X-Xet-Cas-Url": "https://c", # mixed
+        "Content-Type": "application/json",
+    }
+
+    strip_xet_response_headers(headers)
+
+    assert headers == {"Content-Type": "application/json"}
+
+
+def test_strip_xet_response_headers_removes_sole_xet_link_entirely():
+    headers = {
+        "link": '<https://cas/auth>; rel="xet-auth"',
+    }
+
+    strip_xet_response_headers(headers)
+
+    assert "link" not in headers  # link had only xet-auth, should be dropped
+
+
+def test_strip_xet_response_headers_is_noop_without_xet_signals():
+    original = {
+        "etag": '"abc"',
+        "x-repo-commit": "sha",
+        "link": '<https://next>; rel="next"',
+        "content-type": "text/plain",
+    }
+    headers = dict(original)
+
+    strip_xet_response_headers(headers)
+
+    assert headers == original

--- a/test/kohakuhub/support/mock_hf_server.py
+++ b/test/kohakuhub/support/mock_hf_server.py
@@ -1,0 +1,138 @@
+"""Minimal HuggingFace-shaped server used as a fallback upstream in
+end-to-end tests that exercise real `hf_hub_download` through KohakuHub.
+
+Exposes three file shapes that mirror the redirect patterns found in the
+100-repo /resolve survey (see PR #21 comments):
+
+    pattern_a.txt  — 307 → relative /api/resolve-cache/... (non-LFS)
+    pattern_b.bin  — 302 → absolute CDN + X-Linked-Size    (LFS via xet)
+    pattern_c.md   — direct 200, no redirect               (edge case)
+
+The server runs under the same uvicorn helper we use for `live_server_url`,
+so tests get a real TCP port they can point KohakuHub's fallback source at.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse, Response
+
+# Deterministic bodies for byte-level assertions. Keep them small (< 1MB)
+# so the whole integration run stays quick in CI.
+PATTERN_A_BYTES = (b"tag_id,name,category,count\n" + b"100,foo,0,1\n") * 800
+PATTERN_B_BYTES = b"FAKE-SAFETENSORS-PAYLOAD-" + bytes(range(256)) * 200
+PATTERN_C_BYTES = b"# KohakuHub test fixture\n\nhello world.\n" * 50
+
+PATTERN_A_ETAG = "pattern-a-sha256-deadbeef"
+PATTERN_B_ETAG = "pattern-b-sha256-cafef00d"
+PATTERN_C_ETAG = "pattern-c-sha256-feedface"
+
+COMMIT = "abc123456789def"
+
+
+def build_mock_hf_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    # --- Pattern A: 307 → relative /api/resolve-cache ---
+    @app.api_route(
+        "/{owner}/{name}/resolve/{rev}/pattern_a.txt",
+        methods=["HEAD", "GET"],
+    )
+    async def pattern_a(owner: str, name: str, rev: str, request: Request):
+        # HEAD: HF-style 307 with a relative Location + misleading
+        # Content-Length (redirect body, not file size).
+        if request.method == "HEAD":
+            return Response(
+                status_code=307,
+                headers={
+                    "location": f"/api/resolve-cache/models/{owner}/{name}/{COMMIT}/pattern_a.txt",
+                    "content-length": "278",
+                    "x-repo-commit": COMMIT,
+                    "x-linked-etag": f'"{PATTERN_A_ETAG}"',
+                },
+            )
+        # GET: 307 to /api/resolve-cache so the follow chain lands on the
+        # body. khub's FallbackClient.get uses follow_redirects=True, so
+        # httpx walks this internally.
+        return RedirectResponse(
+            url=f"/api/resolve-cache/models/{owner}/{name}/{COMMIT}/pattern_a.txt",
+            status_code=307,
+        )
+
+    @app.api_route(
+        "/api/resolve-cache/models/{owner}/{name}/{sha}/pattern_a.txt",
+        methods=["HEAD", "GET"],
+    )
+    async def pattern_a_final(
+        owner: str, name: str, sha: str, request: Request
+    ):
+        headers = {
+            "content-length": str(len(PATTERN_A_BYTES)),
+            "etag": f'"{PATTERN_A_ETAG}"',
+            "x-repo-commit": COMMIT,
+            "content-type": "text/plain; charset=utf-8",
+        }
+        if request.method == "HEAD":
+            return Response(status_code=200, headers=headers)
+        return Response(
+            content=PATTERN_A_BYTES, status_code=200, headers=headers,
+        )
+
+    # --- Pattern B: 302 → absolute "CDN" URL with X-Linked-Size ---
+    @app.api_route(
+        "/{owner}/{name}/resolve/{rev}/pattern_b.bin",
+        methods=["HEAD", "GET"],
+    )
+    async def pattern_b(owner: str, name: str, rev: str, request: Request):
+        # Use the same host as an absolute URL — simulates HF's absolute
+        # 302 into cas-bridge.xethub.hf.co. khub should pass this Location
+        # through untouched (urljoin on an absolute URL is a no-op).
+        cdn_url = str(request.base_url) + "cas/pattern_b.bin"
+        if request.method == "HEAD":
+            return Response(
+                status_code=302,
+                headers={
+                    "location": cdn_url,
+                    "content-length": "1369",
+                    "x-linked-size": str(len(PATTERN_B_BYTES)),
+                    "x-linked-etag": f'"{PATTERN_B_ETAG}"',
+                    "x-repo-commit": COMMIT,
+                },
+            )
+        return RedirectResponse(url=cdn_url, status_code=302)
+
+    @app.api_route("/cas/pattern_b.bin", methods=["HEAD", "GET"])
+    async def cas_pattern_b(request: Request):
+        headers = {
+            "content-length": str(len(PATTERN_B_BYTES)),
+            "etag": f'"{PATTERN_B_ETAG}"',
+            "content-type": "application/octet-stream",
+        }
+        if request.method == "HEAD":
+            return Response(status_code=200, headers=headers)
+        return Response(
+            content=PATTERN_B_BYTES, status_code=200, headers=headers,
+        )
+
+    # --- Pattern C: direct 200 ---
+    @app.api_route(
+        "/{owner}/{name}/resolve/{rev}/pattern_c.md",
+        methods=["HEAD", "GET"],
+    )
+    async def pattern_c(owner: str, name: str, rev: str, request: Request):
+        headers = {
+            "content-length": str(len(PATTERN_C_BYTES)),
+            "etag": f'"{PATTERN_C_ETAG}"',
+            "x-repo-commit": COMMIT,
+            "content-type": "text/markdown; charset=utf-8",
+        }
+        if request.method == "HEAD":
+            return Response(status_code=200, headers=headers)
+        return Response(
+            content=PATTERN_C_BYTES, status_code=200, headers=headers,
+        )
+
+    return app


### PR DESCRIPTION
## Summary

Make KohakuHub's fallback path transparent to `huggingface_hub` — users can now point `HF_ENDPOINT` at a khub that falls back to huggingface.co and expect their existing tooling (`hf_hub_download`, `timm.create_model('hf-hub:…')`, `imgutils` taggers, `animetimm` README snippet) to work without a single client-side change.

While validating this end-to-end I found and fixed three layered issues in `try_fallback_resolve`'s HEAD branch, added out-of-the-box seed glue so `make seed-demo` produces a usable fallback setup, and wrote three tiers of tests so any future regression surfaces loudly: unit-level, parser-level interop with real `huggingface_hub`, and a full end-to-end run against real `hf_hub_download` hitting a real mock-HF uvicorn.

## What's in this PR

### Seed (one commit): `25f54127`
`make seed-demo` provisions `https://huggingface.co` as a low-priority (1000) global fallback source via the admin API. Idempotent (re-runnable). Bumps `SEED_VERSION` to `local-dev-demo-v3`; `verify_seed_data.py` asserts the seed is advertised via `/api/fallback-sources/available`. No changes to `src/` defaults — strictly a seed-time addition.

### Three bugs in `try_fallback_resolve` HEAD (three commits)

1. **`3f22be53` — Rewrite relative `Location` against the upstream request URL.**
   HF returns `307` with a relative `Location: /api/resolve-cache/...` that only makes sense on huggingface.co; proxying it verbatim had the client follow back into khub and 404. Fix: `urljoin(upstream_request_url, location)`.

2. **`0fc92d2f` — Strip Xet protocol signals.**
   `huggingface_hub 1.x` switches to the native Xet client when it sees `X-Xet-*` response headers or `Link: rel="xet-auth"`. KohakuHub doesn't implement `/api/models/<repo>/xet-read-token/<hash>/`, so every LFS-backed download went down that dead path. Fix: drop `X-Xet-*` and the xet-auth Link relation before proxying, keeping the classic LFS path alive.

3. **`10891a50` — Backfill real `Content-Length` on non-LFS 3xx.**
   HF's first-hop 307 to `/api/resolve-cache/` carries `Content-Length: 278` (the redirect body's length, not the file size). For LFS blobs `X-Linked-Size` rescues this; for non-LFS blobs (`selected_tags.csv` / `preprocess.json` / similar) nothing did. Without this fix, `imgutils.tagging.get_wd14_tags` and five other tagger entry-points hit `OSError: Consistency check failed: file should be of size 278 but has size 308468 (selected_tags.csv)`. Fix: when the 307 lacks `X-Linked-Size`, issue exactly one extra HEAD (with `Accept-Encoding: identity` so the httpx auto-decoder doesn't strip Content-Length) and splice the real size + ETag in.

### Tests (four commits)

Three layers of coverage so each future regression surfaces at the earliest possible stop:

- **Unit — `test_operations.py` HEAD block rewritten (5 cases)**: relative → absolute Location, absolute passthrough, non-LFS 307 with extra HEAD, extra HEAD failure degradation, xet stripping. `test_utils.py` gains 4 cases for the Xet-stripping helper.
- **Parser interop — `test_hf_hub_interop.py` (7 cases)** reorganised around the three HF /resolve redirect patterns (survey below) × HEAD + GET. Rehydrates khub's FastAPI `Response` as an `httpx.Response` and feeds it into `HfFileMetadata` / `_normalize_etag` / `_int_or_none` / `parse_xet_file_data_from_response` — the exact functions `hf_hub_download` uses internally. Compatible with hf_hub `0.20.3` → `latest` (verified locally on both ends), so **every cell in the 18-job matrix now runs the interop**, not just the post-1.0 cells.
- **End-to-end — `test_real_hf_hub_end_to_end.py` (4 cases)** calls real `huggingface_hub.hf_hub_download(endpoint=khub_live, token=…)` against a real khub uvicorn whose fallback points at a real mock-HF uvicorn. Three patterns + a warm-cache re-fetch. The assertion is `open(cached_path).read() == PATTERN_*_BYTES` — if any fix regresses, hf_hub's own consistency check raises before the test gets to the byte compare.

Total fallback suite: **75 passed locally**. CI green on all 22 checks: frontend + admin frontend + codecov patch + project + 18 backend-matrix cells (Python 3.10/3.11/3.12 × `huggingface_hub` 0.20.3/0.30.2/0.36.2/1.0.1/1.6.0/latest).

## HF /resolve redirect survey (100 repos × 6 files ≈ 426 probes)

Every real-world pattern this fix targets, counted on top-downloaded huggingface.co repos:

| Category | Count | % | Fix branch |
|---|---:|---:|---|
| `307 → /api/resolve-cache/...` (non-LFS) | 308 | 72.3% | relative Location → absolute + extra HEAD |
| `302 → cas-bridge.xethub.hf.co` (LFS via xet) | 94 | 22.1% | Location preserved + X-Xet-* stripped |
| `direct 200` (no redirect) | 15 | 3.5% | single-hop passthrough |
| `403` (gated/private) | 9 | 2.1% | unchanged |
| `302 → cdn-lfs.huggingface.co` | 0 | — | dead branch; HF completed the xet migration |

## End-to-end verification against real ecosystem libraries

- **`deepghs/imgutils` tagger matrix** (6 taggers × 2 endpoints × cold/warm = 24 runs): all pass. Top-5 tag lists byte-identical to the direct-HF baseline across all tagger families (`wd14`, `deepdanbooru`, `mldanbooru`, `camie`, `pixai`). Cache blob set + pairwise byte compare: 15/15 identical between HF-cold and khub-cold caches (including a 286MB ONNX).
- **`animetimm` README snippet** (`mobilenetv3_large_100.dbv4-full`): 27 tags, top-5 confidences agree to 4 decimal places across cold/warm × HF/khub. Zero requests direct to `huggingface.co` — the real HF token never leaves khub.

Full speed + correctness breakdown (metadata / body / cpu / MB·s⁻¹ for each tagger × each scenario, plus the resolve-link survey) lives in the PR comments below.

## Size

```
src/kohakuhub/api/fallback/operations.py  +77 / -8    ← HEAD branch rewrite + extra-HEAD backfill
src/kohakuhub/api/fallback/utils.py       +40         ← strip_xet_response_headers helper
scripts/dev/seed_demo_data.py             +62 / -1    ← HF fallback seed provisioning
scripts/dev/verify_seed_data.py           +23 / -1    ← assert seeded source is live
test/kohakuhub/api/fallback/*             +860        ← unit + interop + e2e
```

No frontend changes, no public API changes, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
