### PR TITLE
fix: classify fallback upstream errors (gated/not-found/unavailable) instead of collapsing to 404

### DIFF
--- a/src/kohaku-hub-ui/src/components/repo/preview/FilePreviewDialog.vue
+++ b/src/kohaku-hub-ui/src/components/repo/preview/FilePreviewDialog.vue
@@ -41,6 +41,14 @@ const phase = ref(""); // human-readable current phase
 const payload = ref(null);
 const errorMessage = ref("");
 const errorCorsLikely = ref(false);
+// HF-aligned error classification carried on SafetensorsFetchError. When
+// the backend fallback aggregates upstream failures (see
+// src/kohakuhub/api/fallback/utils.py) it returns a structured body with
+// `error`, `detail`, and `sources[]`; the SPA surfaces those here so the
+// error state can render something more actionable than a bare status.
+const errorCode = ref(null);
+const errorSources = ref(null);
+const errorStatus = ref(null);
 let currentController = null;
 let currentRequestId = 0;
 
@@ -87,6 +95,9 @@ async function startLoad() {
   payload.value = null;
   errorMessage.value = "";
   errorCorsLikely.value = false;
+  errorCode.value = null;
+  errorSources.value = null;
+  errorStatus.value = null;
 
   const controller = new AbortController();
   currentController = controller;
@@ -127,6 +138,9 @@ async function startLoad() {
     if (err?.name === "AbortError") return;
     errorMessage.value = err?.message ?? String(err);
     errorCorsLikely.value = isLikelyCorsError(err);
+    errorCode.value = err?.errorCode ?? null;
+    errorSources.value = Array.isArray(err?.sources) ? err.sources : null;
+    errorStatus.value = typeof err?.status === "number" ? err.status : null;
     state.value = "error";
   } finally {
     if (requestId === currentRequestId) currentController = null;
@@ -216,6 +230,31 @@ const parquetColumnRows = computed(() => {
     repetition: col.repetitionType ?? "",
   }));
 });
+
+// Error classification (based on what the backend fallback returned or
+// what the browser saw). `kind` drives which remediation copy the modal
+// shows.
+const errorKind = computed(() => {
+  if (errorCorsLikely.value) return "cors";
+  if (errorCode.value === "GatedRepo") return "gated";
+  if (errorStatus.value === 403) return "forbidden";
+  if (errorCode.value === "EntryNotFound" || errorStatus.value === 404)
+    return "not-found";
+  if (errorStatus.value === 502 || errorStatus.value === 503)
+    return "upstream-unavailable";
+  return "generic";
+});
+
+const errorSourceRows = computed(() => {
+  if (!Array.isArray(errorSources.value)) return [];
+  return errorSources.value.map((src) => ({
+    name: src?.name ?? "(unknown)",
+    url: src?.url ?? "",
+    status: src?.status == null ? "-" : String(src.status),
+    category: src?.category ?? "",
+    message: typeof src?.message === "string" ? src.message : "",
+  }));
+});
 </script>
 
 <template>
@@ -242,15 +281,44 @@ const parquetColumnRows = computed(() => {
       v-else-if="state === 'error'"
       class="py-8 flex flex-col items-center text-center"
     >
-      <div class="i-carbon-warning-alt text-5xl text-amber-500" />
+      <div
+        :class="
+          errorKind === 'gated'
+            ? 'i-carbon-locked text-5xl text-amber-500'
+            : 'i-carbon-warning-alt text-5xl text-amber-500'
+        "
+      />
       <p class="mt-4 text-sm font-medium text-gray-800 dark:text-gray-100">
-        Preview failed
+        <template v-if="errorKind === 'gated'">
+          Authentication required
+        </template>
+        <template v-else-if="errorKind === 'forbidden'">
+          Access denied by upstream
+        </template>
+        <template v-else-if="errorKind === 'not-found'">
+          File not found on any source
+        </template>
+        <template v-else-if="errorKind === 'upstream-unavailable'">
+          Upstream source unavailable
+        </template>
+        <template v-else>
+          Preview failed
+        </template>
       </p>
       <p class="mt-2 text-xs text-gray-500 dark:text-gray-400 max-w-md break-words">
         {{ errorMessage }}
       </p>
+
       <p
-        v-if="errorCorsLikely"
+        v-if="errorKind === 'gated'"
+        class="mt-3 text-xs text-gray-500 dark:text-gray-400 max-w-md"
+      >
+        At least one fallback source gates this repository and requires
+        authentication. Attach an access token for that source
+        (typically Hugging Face) in your account settings, then retry.
+      </p>
+      <p
+        v-else-if="errorKind === 'cors'"
         class="mt-3 text-xs text-gray-500 dark:text-gray-400 max-w-md"
       >
         This looks like a CORS failure on the object-storage host. Preview
@@ -258,6 +326,37 @@ const parquetColumnRows = computed(() => {
         <code>Access-Control-Allow-Origin</code>. See
         <em>docs/development/local-dev.md &rarr; "MinIO CORS"</em>.
       </p>
+      <p
+        v-else-if="errorKind === 'not-found'"
+        class="mt-3 text-xs text-gray-500 dark:text-gray-400 max-w-md"
+      >
+        Every configured fallback source returned 404 for this file.
+        The containing repository may exist, but this specific entry
+        does not.
+      </p>
+      <p
+        v-else-if="errorKind === 'upstream-unavailable'"
+        class="mt-3 text-xs text-gray-500 dark:text-gray-400 max-w-md"
+      >
+        The fallback source(s) did not respond within the timeout or
+        returned a server error. This is usually transient — retry in
+        a few seconds.
+      </p>
+
+      <div v-if="errorSourceRows.length" class="mt-4 w-full max-w-xl text-left">
+        <details class="text-xs">
+          <summary class="cursor-pointer text-gray-500 dark:text-gray-400 mb-2">
+            Fallback sources tried ({{ errorSourceRows.length }})
+          </summary>
+          <el-table :data="errorSourceRows" size="small" :border="true">
+            <el-table-column prop="name" label="Source" width="130" />
+            <el-table-column prop="status" label="HTTP" width="70" />
+            <el-table-column prop="category" label="Category" width="110" />
+            <el-table-column prop="message" label="Message" />
+          </el-table>
+        </details>
+      </div>
+
       <el-button class="mt-4" type="primary" plain @click="retry">
         Retry
       </el-button>

--- a/src/kohaku-hub-ui/src/utils/safetensors.js
+++ b/src/kohaku-hub-ui/src/utils/safetensors.js
@@ -85,14 +85,13 @@ export async function parseSafetensorsMetadata(url, options = {}) {
     );
   }
 
+  // DataView.getBigUint64 always returns a non-negative BigInt in
+  // [0, 2^64 - 1], which Number() always maps to a finite non-negative
+  // float — no `!isFinite` / `< 0` guard needed. The MAX_HEADER_LENGTH
+  // check below is the only upper bound that matters.
   const headerLen = Number(
     new DataView(firstBuf).getBigUint64(0, /* littleEndian */ true),
   );
-  if (!Number.isFinite(headerLen) || headerLen < 0) {
-    throw new SafetensorsFormatError(
-      `Invalid header length prefix: ${headerLen}`,
-    );
-  }
   if (headerLen > SAFETENSORS_MAX_HEADER_LENGTH) {
     throw new SafetensorsFormatError(
       `Safetensors header too large: ${headerLen} > ${SAFETENSORS_MAX_HEADER_LENGTH}`,

--- a/src/kohaku-hub-ui/src/utils/safetensors.js
+++ b/src/kohaku-hub-ui/src/utils/safetensors.js
@@ -75,10 +75,7 @@ export async function parseSafetensorsMetadata(url, options = {}) {
     credentials: "omit",
   });
   if (firstResp.status !== 200 && firstResp.status !== 206) {
-    throw new SafetensorsFetchError(
-      `Range read failed: HTTP ${firstResp.status}`,
-      firstResp.status,
-    );
+    throw await SafetensorsFetchError.fromResponse(firstResp);
   }
 
   const firstBuf = await firstResp.arrayBuffer();
@@ -114,10 +111,7 @@ export async function parseSafetensorsMetadata(url, options = {}) {
       credentials: "omit",
     });
     if (secondResp.status !== 200 && secondResp.status !== 206) {
-      throw new SafetensorsFetchError(
-        `Second Range read failed: HTTP ${secondResp.status}`,
-        secondResp.status,
-      );
+      throw await SafetensorsFetchError.fromResponse(secondResp);
     }
     const secondBuf = await secondResp.arrayBuffer();
     if (secondBuf.byteLength < headerLen) {
@@ -185,10 +179,49 @@ export function summarizeSafetensors(header) {
 }
 
 export class SafetensorsFetchError extends Error {
-  constructor(message, status) {
+  constructor(message, status, { errorCode = null, sources = null, detail = null } = {}) {
     super(message);
     this.name = "SafetensorsFetchError";
     this.status = status;
+    // huggingface_hub-style classification (populated for fallback
+    // aggregate errors). `errorCode` is the `X-Error-Code` header value
+    // and is also present as `sources[].error` when the backend
+    // returned our structured fallback failure body. Null for ordinary
+    // 4xx / 5xx.
+    this.errorCode = errorCode;
+    this.sources = sources;
+    this.detail = detail;
+  }
+
+  static async fromResponse(response) {
+    // Defensive: tolerate missing body / non-JSON errors. HF upstream
+    // sometimes replies with a plain text 401 body, and our aggregate
+    // failure body is JSON. Try JSON first, fall back to header/text.
+    const status = response.status;
+    const errorCodeHeader = response.headers.get("x-error-code") || null;
+    const errorMessageHeader = response.headers.get("x-error-message") || null;
+
+    let errorCode = errorCodeHeader;
+    let sources = null;
+    let detail = errorMessageHeader;
+
+    try {
+      const body = await response.clone().json();
+      if (body && typeof body === "object") {
+        if (!errorCode && typeof body.error === "string") errorCode = body.error;
+        if (Array.isArray(body.sources)) sources = body.sources;
+        if (!detail && typeof body.detail === "string") detail = body.detail;
+      }
+    } catch {
+      // Not JSON, or empty body — keep header-derived info only.
+    }
+
+    const message = detail || `Range read failed: HTTP ${status}`;
+    return new SafetensorsFetchError(message, status, {
+      errorCode,
+      sources,
+      detail,
+    });
   }
 }
 

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -5,7 +5,7 @@ from typing import Optional
 from urllib.parse import urljoin
 
 import httpx
-from fastapi.responses import RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 from kohakuhub.config import cfg
 from kohakuhub.logger import get_logger
@@ -14,6 +14,8 @@ from kohakuhub.api.fallback.client import FallbackClient
 from kohakuhub.api.fallback.config import get_enabled_sources
 from kohakuhub.api.fallback.utils import (
     add_source_headers,
+    build_fallback_attempt,
+    build_aggregate_failure_response,
     extract_error_message,
     is_not_found_error,
     should_retry_source,
@@ -71,6 +73,14 @@ async def try_fallback_resolve(
 
     # Construct KohakuHub path
     kohaku_path = f"/{repo_type}s/{namespace}/{name}/resolve/{revision}/{path}"
+
+    # Per-source attempts accumulated across the loop. If every source
+    # fails, the aggregated JSON body exposes this list under
+    # `body.sources` so the client can tell which sources were asked,
+    # what each one answered, and pick the right remediation (token,
+    # retry, move on). See src/kohakuhub/api/fallback/utils.py for the
+    # status-priority + HF-compatible X-Error-Code contract.
+    attempts: list[dict] = []
 
     # Try each source in priority order
     for source in sources:
@@ -214,30 +224,58 @@ async def try_fallback_resolve(
                         )
                         return final_resp
                     else:
-                        # GET failed, try next source
+                        # GET failed, try next source. Log the attempt so
+                        # the aggregate response can explain what each
+                        # source actually answered.
                         logger.warning(
                             f"GET request failed for {source['name']}: {get_response.status_code}"
                         )
+                        attempts.append(
+                            build_fallback_attempt(source, response=get_response)
+                        )
                         continue
 
-            elif not should_retry_source(response):
-                # Don't try more sources on auth/permission errors
+            # Non-success HEAD response. Record and continue to the next
+            # source: a mirror that does not gate (or that simply has
+            # the artifact when the first source does not) can still
+            # serve the request. The old short-circuit on 4xx lost the
+            # status + body completely and blamed the local 404 for
+            # what was really an upstream auth failure (issue tied to
+            # PR#28: gated repos surfacing as RepoNotFound).
+            else:
                 logger.warning(
-                    f"Fallback stopped at {source['name']}: {response.status_code}"
+                    f"Fallback attempt at {source['name']}: HTTP {response.status_code}"
                 )
-                return None
+                attempts.append(build_fallback_attempt(source, response=response))
+                continue
 
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as e:
             logger.warning(f"Fallback source {source['name']} timed out")
+            attempts.append(build_fallback_attempt(source, timeout=e))
             continue
 
         except Exception as e:
             logger.warning(f"Fallback source {source['name']} failed: {e}")
+            attempts.append(build_fallback_attempt(source, network=e))
             continue
 
-    # Not found in any source
+    # Every source produced a non-success response. Build an aggregated
+    # error with HF-compatible X-Error-Code (see
+    # build_aggregate_failure_response for the status-priority rules and
+    # the reason we align with huggingface_hub's `hf_raise_for_status`
+    # classification) and let the caller return it unchanged — the
+    # `with_repo_fallback` decorator passes non-None results through, so
+    # the aggregated 4xx/5xx bubbles up to the client instead of
+    # collapsing to the local "RepoNotFound".
+    if attempts:
+        logger.debug(
+            f"Fallback MISS: aggregating {len(attempts)} source failure(s) "
+            f"for {repo_type}/{namespace}/{name}"
+        )
+        return build_aggregate_failure_response(attempts)
+
     logger.debug(
-        f"Fallback MISS: {repo_type}/{namespace}/{name} not found in any source"
+        f"Fallback MISS: no source was tried for {repo_type}/{namespace}/{name}"
     )
     return None
 

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -267,17 +267,16 @@ async def try_fallback_resolve(
     # `with_repo_fallback` decorator passes non-None results through, so
     # the aggregated 4xx/5xx bubbles up to the client instead of
     # collapsing to the local "RepoNotFound".
-    if attempts:
-        logger.debug(
-            f"Fallback MISS: aggregating {len(attempts)} source failure(s) "
-            f"for {repo_type}/{namespace}/{name}"
-        )
-        return build_aggregate_failure_response(attempts)
-
+    # Reaching here means every enabled source produced a non-success
+    # outcome (every branch of the loop that does not `return` also
+    # `attempts.append(...)`), so the attempts list is always non-empty
+    # at this point. The early `if not sources: return None` above
+    # already handled the zero-source case.
     logger.debug(
-        f"Fallback MISS: no source was tried for {repo_type}/{namespace}/{name}"
+        f"Fallback MISS: aggregating {len(attempts)} source failure(s) "
+        f"for {repo_type}/{namespace}/{name}"
     )
-    return None
+    return build_aggregate_failure_response(attempts)
 
 
 async def try_fallback_info(

--- a/src/kohakuhub/api/fallback/utils.py
+++ b/src/kohakuhub/api/fallback/utils.py
@@ -3,10 +3,30 @@
 from typing import Optional
 
 import httpx
+from fastapi.responses import JSONResponse
 
 from kohakuhub.logger import get_logger
 
 logger = get_logger("FALLBACK_UTILS")
+
+
+# Category labels attached to each fallback attempt, used for aggregation.
+# Kept intentionally coarse — finer upstream semantics (e.g. "repo gated"
+# vs "org access revoked") ride in the `message` field pulled from the
+# upstream body, because there is no portable way to distinguish them.
+CATEGORY_AUTH = "auth"  # HTTP 401 — authentication required
+CATEGORY_FORBIDDEN = "forbidden"  # HTTP 403 — explicit deny
+CATEGORY_NOT_FOUND = "not-found"  # HTTP 404 / 410
+CATEGORY_SERVER = "server"  # HTTP 5xx
+CATEGORY_TIMEOUT = "timeout"  # httpx.TimeoutException
+CATEGORY_NETWORK = "network"  # other transport-level failure
+CATEGORY_OTHER = "other"  # anything not covered above (4xx edge cases)
+
+# Cap per-attempt message length so a misbehaving upstream returning a
+# multi-megabyte error page can't blow up response headers or the body
+# schema. The message is advisory; full upstream detail is preserved in
+# logs if anyone needs it.
+MAX_ATTEMPT_MESSAGE_LEN = 500
 
 
 def is_not_found_error(response: httpx.Response) -> bool:
@@ -140,6 +160,132 @@ def strip_xet_response_headers(headers: dict) -> None:
         headers[link_key] = new_link
     else:
         headers.pop(link_key, None)
+
+
+def _categorize_status(status: int) -> str:
+    if status == 401:
+        return CATEGORY_AUTH
+    if status == 403:
+        return CATEGORY_FORBIDDEN
+    if status in (404, 410):
+        return CATEGORY_NOT_FOUND
+    if 500 <= status < 600:
+        return CATEGORY_SERVER
+    return CATEGORY_OTHER
+
+
+def build_fallback_attempt(
+    source: dict,
+    *,
+    response: httpx.Response | None = None,
+    timeout: BaseException | None = None,
+    network: BaseException | None = None,
+) -> dict:
+    """Normalize one probe against one fallback source into a serializable dict.
+
+    Exactly one of ``response`` / ``timeout`` / ``network`` must be set:
+
+    - ``response`` → HTTP response that arrived (status + body available).
+    - ``timeout`` → the request tripped the client timeout before responding.
+    - ``network`` → any other transport-level failure (DNS, refused, etc.).
+
+    Shape is public contract: the same dict is embedded verbatim in the
+    aggregate failure body and is what the SPA / any CLI client will see
+    under ``body.sources[*]``.
+    """
+    base = {
+        "name": source.get("name"),
+        "url": source.get("url"),
+        "status": None,
+        "category": CATEGORY_OTHER,
+        "message": "",
+    }
+
+    if response is not None:
+        base["status"] = response.status_code
+        base["category"] = _categorize_status(response.status_code)
+        msg = extract_error_message(response) or ""
+        base["message"] = msg[:MAX_ATTEMPT_MESSAGE_LEN]
+        return base
+
+    if timeout is not None:
+        base["category"] = CATEGORY_TIMEOUT
+        base["message"] = str(timeout) or "request timed out"
+        return base
+
+    if network is not None:
+        base["category"] = CATEGORY_NETWORK
+        base["message"] = str(network) or type(network).__name__
+        return base
+
+    # Caller violated the contract; keep the default "other" category so
+    # the aggregate still reports something rather than swallowing it.
+    return base
+
+
+def build_aggregate_failure_response(attempts: list[dict]) -> JSONResponse:
+    """Combine per-source attempts into one HTTP response.
+
+    Status priority (highest first): 401 > 403 > 404 > 502. The
+    rationale is user-actionability — an auth failure is the most
+    specific next step ("attach a token"), an explicit 403 is next, a
+    real "not found" after that, and 5xx / timeout / network get
+    collapsed to 502 Bad Gateway.
+
+    X-Error-Code values are intentionally **aligned with
+    huggingface_hub.utils._http.hf_raise_for_status**:
+
+    - 401 → ``GatedRepo`` → ``GatedRepoError`` on the client
+    - 404 (all attempts) → ``EntryNotFound`` → ``EntryNotFoundError``
+    - 403, 502 → no ``X-Error-Code`` (HF client falls back to generic
+      ``HfHubHTTPError``; for 5xx its retry path handles transient
+      upstream issues).
+
+    Putting the code in the header (not just the body) matters because
+    ``huggingface_hub`` reads ``X-Error-Code`` to decide which exception
+    subclass to raise — inventing our own codes here would downgrade
+    gated-repo downloads to a generic 4xx error and lose the actionable
+    exception type that users already handle.
+    """
+    categories = {a.get("category") for a in attempts}
+
+    if CATEGORY_AUTH in categories:
+        status_code = 401
+        error_code = "GatedRepo"
+        detail = (
+            "Upstream source requires authentication - likely a gated "
+            "repository. Attach an access token for that source in "
+            "KohakuHub account settings."
+        )
+    elif CATEGORY_FORBIDDEN in categories:
+        status_code = 403
+        error_code = None  # HF has no specific code for plain 403.
+        detail = "Upstream source denied access."
+    elif attempts and categories <= {CATEGORY_NOT_FOUND}:
+        status_code = 404
+        error_code = "EntryNotFound"
+        detail = "No fallback source serves this file."
+    else:
+        # 5xx / timeout / network mix (or an edge-case "other" category).
+        status_code = 502
+        error_code = None
+        detail = "All fallback sources failed - upstream unavailable."
+
+    body = {
+        "error": error_code or "UpstreamFailure",
+        "detail": detail,
+        "sources": list(attempts),
+    }
+    headers = {
+        "X-Source-Count": str(len(attempts)),
+        # HF client echoes X-Error-Message into its exception text, so the
+        # CLI user ends up with something readable even without the body.
+        "X-Error-Message": detail,
+    }
+    if error_code:
+        headers["X-Error-Code"] = error_code
+
+    return JSONResponse(status_code=status_code, content=body, headers=headers)
 
 
 def add_source_headers(

--- a/test/kohaku-hub-ui/components/test_file_preview_dialog.test.js
+++ b/test/kohaku-hub-ui/components/test_file_preview_dialog.test.js
@@ -416,6 +416,104 @@ describe("FilePreviewDialog", () => {
     wrapper.unmount();
   });
 
+  it("renders a GatedRepo-specific message + sources table when the parser throws a structured fallback error", async () => {
+    const wrapper = mountDialog({
+      kind: "safetensors",
+      resolveUrl: "http://host/repo/resolve/main/model.safetensors",
+      filename: "model.safetensors",
+    });
+    await flushPromises();
+
+    const gatedErr = new Error(
+      "Upstream source requires authentication - likely a gated repository.",
+    );
+    gatedErr.name = "SafetensorsFetchError";
+    gatedErr.status = 401;
+    gatedErr.errorCode = "GatedRepo";
+    gatedErr.detail =
+      "Upstream source requires authentication - likely a gated repository.";
+    gatedErr.sources = [
+      {
+        name: "HuggingFace",
+        url: "https://huggingface.co",
+        status: 401,
+        category: "auth",
+        message: "Access to model owner/demo is restricted.",
+      },
+      {
+        name: "Mirror",
+        url: "https://mirror.local",
+        status: 404,
+        category: "not-found",
+        message: "File not found",
+      },
+    ];
+    safetensorsCtrl.deferred.reject(gatedErr);
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain("Authentication required");
+    // The copy guides the user toward the concrete next step.
+    expect(text).toContain("Attach an access token");
+    // Raw upstream message surfaces in the sources details.
+    expect(text).toContain("Access to model owner/demo is restricted");
+    expect(text).toContain("Mirror");
+    expect(text).toContain("404");
+    // The generic CORS-guidance copy must NOT appear here — CORS and
+    // gated-repo are different remediations.
+    expect(text).not.toContain("CORS failure");
+
+    wrapper.unmount();
+  });
+
+  it("renders a file-not-found message for an aggregated EntryNotFound error", async () => {
+    const wrapper = mountDialog({
+      kind: "safetensors",
+      resolveUrl: "http://host/repo/resolve/main/nope.safetensors",
+      filename: "nope.safetensors",
+    });
+    await flushPromises();
+
+    const notFound = new Error("No fallback source serves this file.");
+    notFound.name = "SafetensorsFetchError";
+    notFound.status = 404;
+    notFound.errorCode = "EntryNotFound";
+    notFound.detail = "No fallback source serves this file.";
+    notFound.sources = [
+      { name: "A", url: "https://a", status: 404, category: "not-found", message: "" },
+      { name: "B", url: "https://b", status: 404, category: "not-found", message: "" },
+    ];
+    safetensorsCtrl.deferred.reject(notFound);
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain("File not found on any source");
+    expect(text).toContain("Every configured fallback source returned 404");
+
+    wrapper.unmount();
+  });
+
+  it("renders an upstream-unavailable message when status is 502 with no error code", async () => {
+    const wrapper = mountDialog({
+      kind: "safetensors",
+      resolveUrl: "http://host/repo/resolve/main/transient.safetensors",
+      filename: "transient.safetensors",
+    });
+    await flushPromises();
+
+    const upstream = new Error("All fallback sources failed - upstream unavailable.");
+    upstream.name = "SafetensorsFetchError";
+    upstream.status = 502;
+    upstream.errorCode = null;
+    upstream.detail = "All fallback sources failed - upstream unavailable.";
+    upstream.sources = null;
+    safetensorsCtrl.deferred.reject(upstream);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Upstream source unavailable");
+    wrapper.unmount();
+  });
+
   it("emits update:visible when the footer Close button is clicked", async () => {
     const wrapper = mountDialog({
       kind: "parquet",

--- a/test/kohaku-hub-ui/utils/test_safetensors.test.js
+++ b/test/kohaku-hub-ui/utils/test_safetensors.test.js
@@ -179,6 +179,76 @@ describe("safetensors utilities", () => {
     expect(err.status).toBe(403);
   });
 
+  it("captures X-Error-Code + structured sources body from an aggregated fallback error", async () => {
+    const { parseSafetensorsMetadata, SafetensorsFetchError } =
+      await loadModule();
+    // Shape matches src/kohakuhub/api/fallback/utils.py
+    // build_aggregate_failure_response — a gated 401 with
+    // HF-compatible X-Error-Code=GatedRepo and a sources[] listing.
+    const aggregated = {
+      error: "GatedRepo",
+      detail:
+        "Upstream source requires authentication - likely a gated repository.",
+      sources: [
+        {
+          name: "HuggingFace",
+          url: "https://huggingface.co",
+          status: 401,
+          category: "auth",
+          message: "Access to model owner/demo is restricted. Please log in.",
+        },
+      ],
+    };
+    server.use(
+      http.get(FIXTURE_URL, () =>
+        HttpResponse.json(aggregated, {
+          status: 401,
+          headers: {
+            "X-Error-Code": "GatedRepo",
+            "X-Error-Message":
+              "Upstream source requires authentication - likely a gated repository.",
+          },
+        }),
+      ),
+    );
+
+    const err = await parseSafetensorsMetadata(FIXTURE_URL).catch((e) => e);
+    expect(err).toBeInstanceOf(SafetensorsFetchError);
+    expect(err.status).toBe(401);
+    expect(err.errorCode).toBe("GatedRepo");
+    expect(err.detail).toContain("authentication");
+    expect(err.sources).toHaveLength(1);
+    expect(err.sources[0]).toMatchObject({
+      name: "HuggingFace",
+      status: 401,
+      category: "auth",
+    });
+    expect(err.message).toContain("authentication");
+  });
+
+  it("falls back to a header-derived message when the error body is not JSON", async () => {
+    const { parseSafetensorsMetadata, SafetensorsFetchError } =
+      await loadModule();
+    server.use(
+      http.get(FIXTURE_URL, () =>
+        HttpResponse.text("plain text body", {
+          status: 500,
+          headers: {
+            "X-Error-Message": "Upstream exploded",
+          },
+        }),
+      ),
+    );
+
+    const err = await parseSafetensorsMetadata(FIXTURE_URL).catch((e) => e);
+    expect(err).toBeInstanceOf(SafetensorsFetchError);
+    expect(err.status).toBe(500);
+    expect(err.errorCode).toBeNull();
+    expect(err.sources).toBeNull();
+    expect(err.detail).toBe("Upstream exploded");
+    expect(err.message).toBe("Upstream exploded");
+  });
+
   it("raises SafetensorsFormatError when the response is shorter than the 8-byte length prefix", async () => {
     const { parseSafetensorsMetadata, SafetensorsFormatError } =
       await loadModule();

--- a/test/kohaku-hub-ui/utils/test_safetensors.test.js
+++ b/test/kohaku-hub-ui/utils/test_safetensors.test.js
@@ -226,6 +226,73 @@ describe("safetensors utilities", () => {
     expect(err.message).toContain("authentication");
   });
 
+  it("defaults tensor data_offsets to [0, 0] when the header omits them", async () => {
+    const { parseSafetensorsMetadata } = await loadModule();
+
+    // A malformed-but-salvageable header: the tensor entry has dtype +
+    // shape but no `data_offsets` field. The parser should still produce
+    // a row (with an inert [0, 0] range) rather than throwing.
+    const headerJson = JSON.stringify({
+      "weird.tensor": { dtype: "F32", shape: [4] },
+    });
+    const headerBytes = new TextEncoder().encode(headerJson);
+    const file = new Uint8Array(8 + headerBytes.length);
+    new DataView(file.buffer).setBigUint64(0, BigInt(headerBytes.length), true);
+    file.set(headerBytes, 8);
+    server.use(http.get(FIXTURE_URL, () => new HttpResponse(file, { status: 206 })));
+
+    const header = await parseSafetensorsMetadata(FIXTURE_URL);
+    expect(header.tensors["weird.tensor"].data_offsets).toEqual([0, 0]);
+  });
+
+  it("fromResponse derives errorCode / sources / detail from body when headers are absent", async () => {
+    const { parseSafetensorsMetadata, SafetensorsFetchError } =
+      await loadModule();
+    // Deliberately omit X-Error-Code + X-Error-Message headers so the
+    // parser must read them from the JSON body alone.
+    server.use(
+      http.get(FIXTURE_URL, () =>
+        HttpResponse.json(
+          {
+            error: "UpstreamFailure",
+            detail: "All sources failed",
+            sources: [
+              { name: "A", status: 500, category: "server", message: "x" },
+            ],
+          },
+          { status: 502 },
+        ),
+      ),
+    );
+
+    const err = await parseSafetensorsMetadata(FIXTURE_URL).catch((e) => e);
+    expect(err).toBeInstanceOf(SafetensorsFetchError);
+    expect(err.status).toBe(502);
+    expect(err.errorCode).toBe("UpstreamFailure");
+    expect(err.detail).toBe("All sources failed");
+    expect(err.message).toBe("All sources failed");
+    expect(err.sources).toHaveLength(1);
+    expect(err.sources[0].name).toBe("A");
+  });
+
+  it("fromResponse ignores body.sources when it is not an array", async () => {
+    const { parseSafetensorsMetadata, SafetensorsFetchError } =
+      await loadModule();
+    server.use(
+      http.get(FIXTURE_URL, () =>
+        HttpResponse.json(
+          { error: "BadShape", sources: "not-an-array" },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const err = await parseSafetensorsMetadata(FIXTURE_URL).catch((e) => e);
+    expect(err).toBeInstanceOf(SafetensorsFetchError);
+    expect(err.errorCode).toBe("BadShape");
+    expect(err.sources).toBeNull();
+  });
+
   it("falls back to a header-derived message when the error body is not JSON", async () => {
     const { parseSafetensorsMetadata, SafetensorsFetchError } =
       await loadModule();

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -44,6 +44,22 @@ except ImportError:  # pre-1.0 hf_hub matrix cells
     parse_xet_file_data_from_response = None  # type: ignore[assignment]
     HAS_XET = False
 
+# hf_hub migrated from `requests` to `httpx` in 1.0. The pattern-D
+# tests below feed httpx.Response objects straight into
+# `hf_raise_for_status`; on pre-1.0 versions that function's
+# `except requests.HTTPError` clause never catches the
+# `httpx.HTTPStatusError` emitted by our synthesized response, so the
+# status-code -> HF-exception classification never runs and the test
+# sees a bare `httpx.HTTPStatusError` instead of `GatedRepoError` /
+# `EntryNotFoundError`. The classification behavior we pin IS present
+# on 1.0+ — the matrix cells that fail are ones where hf_hub's own
+# `_raise_for_status` accepts a different Response type than the one
+# KohakuHub serves.
+import huggingface_hub as _hf
+
+_hf_version_tuple = tuple(int(p) for p in _hf.__version__.split(".")[:2] if p.isdigit())
+_HF_SUPPORTS_HTTPX_CLASSIFICATION = _hf_version_tuple >= (1, 0)
+
 _HF_METADATA_FIELDS = set(inspect.signature(HfFileMetadata).parameters.keys())
 
 import kohakuhub.api.fallback.operations as fallback_ops  # noqa: E402
@@ -453,6 +469,14 @@ async def test_pattern_A_resolve_cache_HEAD_fallback_on_error(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
+    reason="pre-1.0 hf_hub uses `requests` internally; its "
+    "hf_raise_for_status does not catch httpx.HTTPStatusError and "
+    "the GatedRepo classification never runs. The aggregate response "
+    "contract is still upheld — just not observable through this path "
+    "on those matrix cells.",
+)
 @pytest.mark.asyncio
 async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
     """Single gated source → aggregate 401 + X-Error-Code=GatedRepo. When
@@ -491,6 +515,11 @@ async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
         hf_raise_for_status(hx)
 
 
+@pytest.mark.skipif(
+    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
+    reason="pre-1.0 hf_hub: httpx.HTTPStatusError bypasses the "
+    "EntryNotFound classification path.",
+)
 @pytest.mark.asyncio
 async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
     """All sources legitimately 404 → aggregate 404 + X-Error-Code=EntryNotFound.
@@ -531,6 +560,11 @@ async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
         hf_raise_for_status(hx)
 
 
+@pytest.mark.skipif(
+    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
+    reason="pre-1.0 hf_hub: httpx.HTTPStatusError bypasses the "
+    "generic 5xx classification path.",
+)
 @pytest.mark.asyncio
 async def test_pattern_D_all_5xx_raises_generic_HfHubHTTPError(monkeypatch):
     """Aggregate of 5xx / timeout is a 502 with no X-Error-Code so hf_hub

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -44,21 +44,40 @@ except ImportError:  # pre-1.0 hf_hub matrix cells
     parse_xet_file_data_from_response = None  # type: ignore[assignment]
     HAS_XET = False
 
-# hf_hub migrated from `requests` to `httpx` in 1.0. The pattern-D
-# tests below feed httpx.Response objects straight into
-# `hf_raise_for_status`; on pre-1.0 versions that function's
-# `except requests.HTTPError` clause never catches the
-# `httpx.HTTPStatusError` emitted by our synthesized response, so the
-# status-code -> HF-exception classification never runs and the test
-# sees a bare `httpx.HTTPStatusError` instead of `GatedRepoError` /
-# `EntryNotFoundError`. The classification behavior we pin IS present
-# on 1.0+ — the matrix cells that fail are ones where hf_hub's own
-# `_raise_for_status` accepts a different Response type than the one
-# KohakuHub serves.
+# hf_hub migrated its internal HTTP layer from `requests` to `httpx`
+# in 1.0. That migration changed the type `hf_raise_for_status`
+# accepts: older versions expect `requests.Response`, newer ones
+# expect `httpx.Response`. The CLASSIFICATION logic (X-Error-Code →
+# GatedRepoError / EntryNotFoundError / generic HfHubHTTPError) is
+# identical across both branches — only the input type differs, so
+# the pattern-D tests below build whichever Response type the
+# installed hf_hub understands and assert the same classification on
+# every matrix cell.
 import huggingface_hub as _hf
 
-_hf_version_tuple = tuple(int(p) for p in _hf.__version__.split(".")[:2] if p.isdigit())
-_HF_SUPPORTS_HTTPX_CLASSIFICATION = _hf_version_tuple >= (1, 0)
+_hf_version_tuple = tuple(
+    int(p) for p in _hf.__version__.split(".")[:2] if p.isdigit()
+)
+_HF_USES_HTTPX = _hf_version_tuple >= (1, 0)
+
+
+def _hf_error(name):
+    """Resolve an hf_hub exception class across the matrix of installed
+    versions. The public module graph reshuffled a few times:
+
+    - 0.20.x: only ``huggingface_hub.utils.<Name>`` is importable
+    - 0.30.x through latest: ``huggingface_hub.errors.<Name>`` is the
+      documented location, also re-exported from ``huggingface_hub.utils``
+
+    Try the modern path first; fall back to the utils path on old cells.
+    """
+    try:
+        mod = __import__("huggingface_hub.errors", fromlist=[name])
+        return getattr(mod, name)
+    except (ImportError, AttributeError):
+        pass
+    mod = __import__("huggingface_hub.utils", fromlist=[name])
+    return getattr(mod, name)
 
 _HF_METADATA_FIELDS = set(inspect.signature(HfFileMetadata).parameters.keys())
 
@@ -102,6 +121,43 @@ def _to_httpx(response, *, request_url: str) -> httpx.Response:
         content=response.body or b"",
         request=httpx.Request("HEAD", request_url),
     )
+
+
+def _to_hf_response(response, *, request_url: str):
+    """Rehydrate a FastAPI ``Response`` as the Response type the
+    installed hf_hub's ``hf_raise_for_status`` expects.
+
+    - hf_hub >= 1.0 → ``httpx.Response``
+    - hf_hub <  1.0 → ``requests.Response``
+
+    Used only by pattern-D tests that drive ``hf_raise_for_status``;
+    other tests in this file keep using ``_to_httpx`` because they
+    read fields (status, headers) that exist on both shapes.
+    """
+    raw_pairs = [
+        (k.decode("latin-1"), v.decode("latin-1"))
+        for k, v in response.raw_headers
+    ]
+    body = response.body or b""
+    if _HF_USES_HTTPX:
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=httpx.Headers(raw_pairs),
+            content=body,
+            request=httpx.Request("HEAD", request_url),
+        )
+    # requests branch (0.x hf_hub). Import lazily so the module import
+    # does not fail on a hypothetical httpx-only install.
+    import requests
+    from requests.structures import CaseInsensitiveDict
+
+    r = requests.Response()
+    r.status_code = response.status_code
+    r.headers = CaseInsensitiveDict(raw_pairs)
+    r.url = request_url
+    r._content = body
+    r.encoding = "utf-8"
+    return r
 
 
 def _hf_metadata(hx: httpx.Response) -> HfFileMetadata:
@@ -469,14 +525,6 @@ async def test_pattern_A_resolve_cache_HEAD_fallback_on_error(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
-    reason="pre-1.0 hf_hub uses `requests` internally; its "
-    "hf_raise_for_status does not catch httpx.HTTPStatusError and "
-    "the GatedRepo classification never runs. The aggregate response "
-    "contract is still upheld — just not observable through this path "
-    "on those matrix cells.",
-)
 @pytest.mark.asyncio
 async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
     """Single gated source → aggregate 401 + X-Error-Code=GatedRepo. When
@@ -484,8 +532,8 @@ async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
     `GatedRepoError` specifically, not the generic 401→RepositoryNotFound
     fallback. This is the regression-guard for the fallback bug repro
     against `animetimm/mobilenetv3_large_150d.dbv4-full`."""
-    from huggingface_hub.errors import GatedRepoError
-    from huggingface_hub.utils._http import hf_raise_for_status
+    GatedRepoError = _hf_error("GatedRepoError")
+    from huggingface_hub.utils import hf_raise_for_status
 
     _setup_resolve_cache_source(monkeypatch)
     path = f"{REPO_PREFIX}/model.safetensors"
@@ -507,7 +555,7 @@ async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
     resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "model.safetensors", method="HEAD",
     )
-    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/model.safetensors")
+    hx = _to_hf_response(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/model.safetensors")
     assert hx.status_code == 401
     assert hx.headers.get("x-error-code") == "GatedRepo"
 
@@ -515,11 +563,6 @@ async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
         hf_raise_for_status(hx)
 
 
-@pytest.mark.skipif(
-    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
-    reason="pre-1.0 hf_hub: httpx.HTTPStatusError bypasses the "
-    "EntryNotFound classification path.",
-)
 @pytest.mark.asyncio
 async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
     """All sources legitimately 404 → aggregate 404 + X-Error-Code=EntryNotFound.
@@ -527,8 +570,8 @@ async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
     `RepositoryNotFoundError` — the repo exists on at least one source
     per the tree endpoint, it's just this particular file that is
     missing."""
-    from huggingface_hub.errors import EntryNotFoundError
-    from huggingface_hub.utils._http import hf_raise_for_status
+    EntryNotFoundError = _hf_error("EntryNotFoundError")
+    from huggingface_hub.utils import hf_raise_for_status
 
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
@@ -552,7 +595,7 @@ async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
     resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "nope.bin", method="HEAD",
     )
-    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/nope.bin")
+    hx = _to_hf_response(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/nope.bin")
     assert hx.status_code == 404
     assert hx.headers.get("x-error-code") == "EntryNotFound"
 
@@ -560,24 +603,17 @@ async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
         hf_raise_for_status(hx)
 
 
-@pytest.mark.skipif(
-    not _HF_SUPPORTS_HTTPX_CLASSIFICATION,
-    reason="pre-1.0 hf_hub: httpx.HTTPStatusError bypasses the "
-    "generic 5xx classification path.",
-)
 @pytest.mark.asyncio
 async def test_pattern_D_all_5xx_raises_generic_HfHubHTTPError(monkeypatch):
     """Aggregate of 5xx / timeout is a 502 with no X-Error-Code so hf_hub
     raises its generic `HfHubHTTPError` (caller usually treats this as
     a retryable upstream issue). The important property: it is NOT
     mis-classified as GatedRepo / EntryNotFound / RepoNotFound."""
-    from huggingface_hub.errors import (
-        EntryNotFoundError,
-        GatedRepoError,
-        HfHubHTTPError,
-        RepositoryNotFoundError,
-    )
-    from huggingface_hub.utils._http import hf_raise_for_status
+    EntryNotFoundError = _hf_error("EntryNotFoundError")
+    GatedRepoError = _hf_error("GatedRepoError")
+    HfHubHTTPError = _hf_error("HfHubHTTPError")
+    RepositoryNotFoundError = _hf_error("RepositoryNotFoundError")
+    from huggingface_hub.utils import hf_raise_for_status
 
     _setup_resolve_cache_source(monkeypatch)
     path = f"{REPO_PREFIX}/transient.bin"
@@ -589,7 +625,7 @@ async def test_pattern_D_all_5xx_raises_generic_HfHubHTTPError(monkeypatch):
     resp = await fallback_ops.try_fallback_resolve(
         "model", "owner", "demo", "main", "transient.bin", method="HEAD",
     )
-    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/transient.bin")
+    hx = _to_hf_response(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/transient.bin")
     assert hx.status_code == 502
     assert hx.headers.get("x-error-code") is None
 

--- a/test/kohakuhub/api/fallback/test_hf_hub_interop.py
+++ b/test/kohakuhub/api/fallback/test_hf_hub_interop.py
@@ -442,3 +442,128 @@ async def test_pattern_A_resolve_cache_HEAD_fallback_on_error(monkeypatch):
     assert meta.commit_hash == "abc123"
     assert meta.etag == "deadbeef"
     assert meta.size == 278
+
+
+# ---------------------------------------------------------------------------
+# Pattern D. All sources fail — aggregated error must flow through
+# huggingface_hub's `hf_raise_for_status` with the *right* exception
+# subclass. Without these tests a regression that drops `X-Error-Code`
+# would silently downgrade `GatedRepoError` → generic `RepositoryNotFoundError`
+# (the "all 401 look like misses" fallback in hf_hub/utils/_http.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pattern_D_all_401_raises_GatedRepoError(monkeypatch):
+    """Single gated source → aggregate 401 + X-Error-Code=GatedRepo. When
+    fed to `hf_raise_for_status`, huggingface_hub must raise
+    `GatedRepoError` specifically, not the generic 401→RepositoryNotFound
+    fallback. This is the regression-guard for the fallback bug repro
+    against `animetimm/mobilenetv3_large_150d.dbv4-full`."""
+    from huggingface_hub.errors import GatedRepoError
+    from huggingface_hub.utils._http import hf_raise_for_status
+
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/model.safetensors"
+
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", path,
+        _content_response(
+            401,
+            content=(
+                b"Access to model owner/demo is restricted. You must "
+                b"have access to it and be authenticated to access it. "
+                b"Please log in."
+            ),
+            headers={"content-type": "text/plain; charset=utf-8"},
+            url=f"{HF_ENDPOINT}{REPO_PREFIX}/model.safetensors",
+        ),
+    )
+
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "model.safetensors", method="HEAD",
+    )
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/model.safetensors")
+    assert hx.status_code == 401
+    assert hx.headers.get("x-error-code") == "GatedRepo"
+
+    with pytest.raises(GatedRepoError):
+        hf_raise_for_status(hx)
+
+
+@pytest.mark.asyncio
+async def test_pattern_D_all_404_raises_EntryNotFoundError(monkeypatch):
+    """All sources legitimately 404 → aggregate 404 + X-Error-Code=EntryNotFound.
+    hf_hub must raise `EntryNotFoundError` (per-file miss), not
+    `RepositoryNotFoundError` — the repo exists on at least one source
+    per the tree endpoint, it's just this particular file that is
+    missing."""
+    from huggingface_hub.errors import EntryNotFoundError
+    from huggingface_hub.utils._http import hf_raise_for_status
+
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": HF_ENDPOINT, "name": "HF", "source_type": "huggingface"},
+            {"url": "https://mirror.local", "name": "Mirror", "source_type": "huggingface"},
+        ],
+    )
+    path = f"{REPO_PREFIX}/nope.bin"
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", path,
+        _content_response(404, url=f"{HF_ENDPOINT}{REPO_PREFIX}/nope.bin"),
+    )
+    FakeFallbackClient.queue(
+        "https://mirror.local", "HEAD", path,
+        _content_response(404, url=f"https://mirror.local{REPO_PREFIX}/nope.bin"),
+    )
+
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "nope.bin", method="HEAD",
+    )
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/nope.bin")
+    assert hx.status_code == 404
+    assert hx.headers.get("x-error-code") == "EntryNotFound"
+
+    with pytest.raises(EntryNotFoundError):
+        hf_raise_for_status(hx)
+
+
+@pytest.mark.asyncio
+async def test_pattern_D_all_5xx_raises_generic_HfHubHTTPError(monkeypatch):
+    """Aggregate of 5xx / timeout is a 502 with no X-Error-Code so hf_hub
+    raises its generic `HfHubHTTPError` (caller usually treats this as
+    a retryable upstream issue). The important property: it is NOT
+    mis-classified as GatedRepo / EntryNotFound / RepoNotFound."""
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+        RepositoryNotFoundError,
+    )
+    from huggingface_hub.utils._http import hf_raise_for_status
+
+    _setup_resolve_cache_source(monkeypatch)
+    path = f"{REPO_PREFIX}/transient.bin"
+    FakeFallbackClient.queue(
+        HF_ENDPOINT, "HEAD", path,
+        _content_response(503, url=f"{HF_ENDPOINT}{REPO_PREFIX}/transient.bin"),
+    )
+
+    resp = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "transient.bin", method="HEAD",
+    )
+    hx = _to_httpx(resp, request_url=f"{KHUB_BASE}{REPO_PREFIX}/transient.bin")
+    assert hx.status_code == 502
+    assert hx.headers.get("x-error-code") is None
+
+    with pytest.raises(HfHubHTTPError) as excinfo:
+        hf_raise_for_status(hx)
+    # Must NOT match the specific subclasses reserved for gated /
+    # missing-entry / missing-repo — those would signal the wrong
+    # remediation to a downstream user.
+    assert not isinstance(excinfo.value, GatedRepoError)
+    assert not isinstance(excinfo.value, EntryNotFoundError)
+    assert not isinstance(excinfo.value, RepositoryNotFoundError)

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -492,7 +492,13 @@ async def test_try_fallback_resolve_get_strips_xet_signals(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_try_fallback_resolve_stops_on_non_retryable_status_and_handles_timeouts(monkeypatch):
+async def test_try_fallback_resolve_continues_past_every_failure_and_aggregates(monkeypatch):
+    """Every source must be probed even when the first ones fail with
+    non-retryable statuses. Previously the loop exited on the first 4xx
+    that `should_retry_source` flagged (e.g. 401), which meant a gated
+    first source would hide a healthy third source that would have
+    served the file. See `build_aggregate_failure_response` for the
+    status-priority rules that decide the final HTTP code."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -500,7 +506,7 @@ async def test_try_fallback_resolve_stops_on_non_retryable_status_and_handles_ti
         lambda namespace, user_tokens=None: [
             {"url": "https://timeout.local", "name": "Timeout", "source_type": "huggingface"},
             {"url": "https://auth.local", "name": "Auth", "source_type": "huggingface"},
-            {"url": "https://unused.local", "name": "Unused", "source_type": "huggingface"},
+            {"url": "https://missing.local", "name": "Missing", "source_type": "huggingface"},
         ],
     )
     path = "/models/owner/demo/resolve/main/config.json"
@@ -511,6 +517,7 @@ async def test_try_fallback_resolve_stops_on_non_retryable_status_and_handles_ti
         httpx.TimeoutException("too slow"),
     )
     FakeFallbackClient.queue("https://auth.local", "HEAD", path, _content_response(401))
+    FakeFallbackClient.queue("https://missing.local", "HEAD", path, _content_response(404))
 
     response = await fallback_ops.try_fallback_resolve(
         "model",
@@ -520,10 +527,24 @@ async def test_try_fallback_resolve_stops_on_non_retryable_status_and_handles_ti
         "config.json",
     )
 
-    assert response is None
+    # All three sources must have been tried — a 401 on source 2 no
+    # longer skips source 3.
     assert [call[0] for call in FakeFallbackClient.calls] == [
         "https://timeout.local",
         "https://auth.local",
+        "https://missing.local",
+    ]
+
+    # Aggregate: timeout + 401 + 404. Auth wins the priority contest
+    # because it's the most actionable status to surface.
+    assert response is not None
+    assert response.status_code == 401
+    assert response.headers.get("x-error-code") == "GatedRepo"
+    body = _decode_aggregate_body(response)
+    assert [s["category"] for s in body["sources"]] == [
+        "timeout",
+        "auth",
+        "not-found",
     ]
 
 
@@ -823,7 +844,12 @@ async def test_try_fallback_user_repos_supports_hf_aggregation_and_kohakuhub(mon
 
 
 @pytest.mark.asyncio
-async def test_try_fallback_resolve_returns_none_after_generic_source_failures(monkeypatch):
+async def test_try_fallback_resolve_wraps_generic_transport_failure_as_502(monkeypatch):
+    """A generic transport-level exception (DNS failure, connection
+    reset, broken TLS handshake, ...) from the only source is recorded
+    as a ``network`` attempt and bubbled up as a 502 Bad Gateway
+    aggregate, not discarded. The client needs to know the upstream was
+    unreachable rather than seeing a misleading local 404."""
     monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
     monkeypatch.setattr(
         fallback_ops,
@@ -840,16 +866,377 @@ async def test_try_fallback_resolve_returns_none_after_generic_source_failures(m
         RuntimeError("boom"),
     )
 
-    assert (
-        await fallback_ops.try_fallback_resolve(
-            "model",
-            "owner",
-            "demo",
-            "main",
-            "config.json",
-        )
-        is None
+    response = await fallback_ops.try_fallback_resolve(
+        "model",
+        "owner",
+        "demo",
+        "main",
+        "config.json",
     )
+
+    assert response is not None
+    assert response.status_code == 502
+    assert response.headers.get("x-error-code") is None
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "UpstreamFailure"
+    assert len(body["sources"]) == 1
+    assert body["sources"][0]["category"] == "network"
+    assert "boom" in body["sources"][0]["message"]
+
+
+# -------------------------------------------------------------------------
+# Upstream-error classification contract for fallback resolve.
+#
+# When a fallback source returns a non-success status, or when a source
+# fails with a timeout / network error, try_fallback_resolve records a
+# per-source "attempt" and continues to the next source. A mirror that
+# doesn't gate the artifact the first source gates, or a mirror that
+# simply has a file the first source doesn't, can still serve the
+# request — which is the whole point of a multi-source fallback chain.
+#
+# If every source fails, the function returns an HTTP-level aggregate
+# response that pins the information the client needs to pick a
+# remediation:
+#
+#   HTTP status priority:   401 > 403 > 404 > 502
+#   X-Error-Code (aligned with huggingface_hub.utils._http):
+#       401 → GatedRepo         (→ GatedRepoError on hf_hub_download)
+#       404 (all attempts)
+#                       → EntryNotFound    (→ EntryNotFoundError)
+#       403, 502        → unset             (HF falls back to generic)
+#   Body:              { error, detail, sources: [...] }
+#   Each sources[*]:   { name, url, status|null, category, message }
+#
+# Reproduced live against animetimm/mobilenetv3_large_150d.dbv4-full
+# (gated model) while developing PR#28. Before this contract the client
+# saw a bare 404 RepoNotFound for a file whose repo it had just listed.
+# -------------------------------------------------------------------------
+
+
+def _decode_aggregate_body(response):
+    """Parse the structured failure body."""
+    import json
+
+    return json.loads(bytes(response.body).decode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_surfaces_upstream_401_as_aggregated_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {
+                "url": "https://gated.local",
+                "name": "GatedHF",
+                "source_type": "huggingface",
+            }
+        ],
+    )
+    path = "/models/animetimm/gated-demo/resolve/main/model.safetensors"
+    gated_body = (
+        b"Access to model animetimm/gated-demo is restricted. "
+        b"You must have access to it and be authenticated to access "
+        b"it. Please log in."
+    )
+    FakeFallbackClient.queue(
+        "https://gated.local",
+        "HEAD",
+        path,
+        _content_response(
+            401,
+            content=gated_body,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model",
+        "animetimm",
+        "gated-demo",
+        "main",
+        "model.safetensors",
+        method="HEAD",
+    )
+
+    assert response is not None, (
+        "fallback must not discard the only 401 attempt — the client "
+        "needs the status + upstream body to render an 'auth required' "
+        "affordance instead of a misleading 'repo not found'"
+    )
+    assert response.status_code == 401
+    # X-Error-Code uses the huggingface_hub classification so that
+    # hf_hub_download raises GatedRepoError (see HF compat test).
+    assert response.headers.get("x-error-code") == "GatedRepo"
+    # X-Error-Message is the same human-readable summary HF echoes into
+    # exception text, so even a bare curl -I user sees something useful.
+    assert response.headers.get("x-error-message")
+
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "GatedRepo"
+    assert len(body["sources"]) == 1
+    entry = body["sources"][0]
+    assert entry["name"] == "GatedHF"
+    assert entry["url"] == "https://gated.local"
+    assert entry["status"] == 401
+    assert entry["category"] == "auth"
+    assert "restricted" in entry["message"]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_surfaces_upstream_403_as_aggregated_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {
+                "url": "https://forbidden.local",
+                "name": "ForbiddenHF",
+                "source_type": "huggingface",
+            }
+        ],
+    )
+    path = "/models/owner/forbidden-demo/resolve/main/model.bin"
+    FakeFallbackClient.queue(
+        "https://forbidden.local",
+        "HEAD",
+        path,
+        _content_response(
+            403,
+            content=b"Forbidden: this IP range is denied access.",
+            headers={"content-type": "text/plain; charset=utf-8"},
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "forbidden-demo", "main", "model.bin", method="HEAD",
+    )
+
+    assert response is not None
+    assert response.status_code == 403
+    # 403 has no specific HF X-Error-Code mapping — the client sees the
+    # plain status and falls back to generic HfHubHTTPError, which is
+    # what HF itself does for non-gated denies.
+    assert response.headers.get("x-error-code") is None
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "UpstreamFailure"
+    entry = body["sources"][0]
+    assert entry["status"] == 403
+    assert entry["category"] == "forbidden"
+    assert "Forbidden" in entry["message"]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_continues_past_401_and_succeeds_on_next_source(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {
+                "url": "https://gated.local",
+                "name": "GatedHF",
+                "source_type": "huggingface",
+            },
+            {
+                "url": "https://mirror.local",
+                "name": "OpenMirror",
+                "source_type": "huggingface",
+            },
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.bin"
+    # Source 1 is gated.
+    FakeFallbackClient.queue(
+        "https://gated.local",
+        "HEAD",
+        path,
+        _content_response(401, content=b"gated"),
+    )
+    # Source 2 happily serves the same file.
+    FakeFallbackClient.queue(
+        "https://mirror.local",
+        "HEAD",
+        path,
+        _content_response(307, headers={"etag": "mirror-etag"}),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.bin", method="HEAD",
+    )
+
+    assert response is not None
+    assert response.status_code == 307
+    assert response.headers.get("etag") == "mirror-etag"
+    assert response.headers.get("X-Source") == "OpenMirror"
+    # Both sources should have been tried.
+    tried = [call[0] for call in FakeFallbackClient.calls]
+    assert tried == ["https://gated.local", "https://mirror.local"]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_aggregates_mixed_failures_across_sources(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {
+                "url": "https://gated.local",
+                "name": "GatedHF",
+                "source_type": "huggingface",
+            },
+            {
+                "url": "https://missing.local",
+                "name": "MissingMirror",
+                "source_type": "huggingface",
+            },
+            {
+                "url": "https://broken.local",
+                "name": "BrokenMirror",
+                "source_type": "huggingface",
+            },
+            {
+                "url": "https://slow.local",
+                "name": "SlowMirror",
+                "source_type": "huggingface",
+            },
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/file.bin"
+    FakeFallbackClient.queue(
+        "https://gated.local", "HEAD", path,
+        _content_response(401, content=b"Auth required"),
+    )
+    FakeFallbackClient.queue(
+        "https://missing.local", "HEAD", path,
+        _content_response(404, content=b"Not found"),
+    )
+    FakeFallbackClient.queue(
+        "https://broken.local", "HEAD", path,
+        _content_response(503, content=b"Service unavailable"),
+    )
+    FakeFallbackClient.queue(
+        "https://slow.local", "HEAD", path,
+        httpx.TimeoutException("too slow"),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "file.bin", method="HEAD",
+    )
+
+    assert response is not None
+    # 401 is the most actionable status in the mix, so it bubbles up.
+    assert response.status_code == 401
+    assert response.headers.get("x-error-code") == "GatedRepo"
+
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "GatedRepo"
+    assert len(body["sources"]) == 4
+
+    by_name = {s["name"]: s for s in body["sources"]}
+    assert by_name["GatedHF"]["status"] == 401
+    assert by_name["GatedHF"]["category"] == "auth"
+
+    assert by_name["MissingMirror"]["status"] == 404
+    assert by_name["MissingMirror"]["category"] == "not-found"
+
+    assert by_name["BrokenMirror"]["status"] == 503
+    assert by_name["BrokenMirror"]["category"] == "server"
+
+    # Timeout / network failures have no HTTP status — null, not omitted.
+    assert by_name["SlowMirror"]["status"] is None
+    assert by_name["SlowMirror"]["category"] == "timeout"
+    assert "slow" in by_name["SlowMirror"]["message"].lower()
+
+    # Order is the probe order (stable for debuggability).
+    assert [s["name"] for s in body["sources"]] == [
+        "GatedHF",
+        "MissingMirror",
+        "BrokenMirror",
+        "SlowMirror",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_aggregates_all_404_into_upstream_not_found(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://a.local", "name": "A", "source_type": "huggingface"},
+            {"url": "https://b.local", "name": "B", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/nope.bin"
+    FakeFallbackClient.queue(
+        "https://a.local", "HEAD", path, _content_response(404),
+    )
+    FakeFallbackClient.queue(
+        "https://b.local", "HEAD", path, _content_response(404),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "nope.bin", method="HEAD",
+    )
+
+    assert response is not None
+    assert response.status_code == 404
+    # EntryNotFound aligns with huggingface_hub's per-file miss
+    # classification so hf_hub_download raises EntryNotFoundError.
+    assert response.headers.get("x-error-code") == "EntryNotFound"
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "EntryNotFound"
+    assert [s["status"] for s in body["sources"]] == [404, 404]
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_aggregates_all_unavailable_into_502(
+    monkeypatch,
+):
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+            {"url": "https://y.local", "name": "Y", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/thing.bin"
+    FakeFallbackClient.queue(
+        "https://x.local", "HEAD", path, _content_response(500),
+    )
+    FakeFallbackClient.queue(
+        "https://y.local", "HEAD", path, httpx.TimeoutException("too slow"),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "thing.bin", method="HEAD",
+    )
+
+    assert response is not None
+    assert response.status_code == 502
+    # 5xx / timeout / network mixes get no specific X-Error-Code — the
+    # HF client's generic 5xx retry path is the right escape hatch.
+    assert response.headers.get("x-error-code") is None
+    body = _decode_aggregate_body(response)
+    assert body["error"] == "UpstreamFailure"
+    categories = [s["category"] for s in body["sources"]]
+    assert categories == ["server", "timeout"]
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/api/fallback/test_utils.py
+++ b/test/kohakuhub/api/fallback/test_utils.py
@@ -152,3 +152,117 @@ def test_strip_xet_response_headers_is_noop_without_xet_signals():
     strip_xet_response_headers(headers)
 
     assert headers == original
+
+
+# -------------------------------------------------------------------------
+# Aggregated fallback failure helpers (new for the upstream-error-
+# classification fix). The loop-level behavior is already covered by
+# test_operations; these unit tests cover the edge-case branches that
+# only defensive callers would hit.
+# -------------------------------------------------------------------------
+
+
+from kohakuhub.api.fallback.utils import (
+    CATEGORY_AUTH,
+    CATEGORY_FORBIDDEN,
+    CATEGORY_NETWORK,
+    CATEGORY_NOT_FOUND,
+    CATEGORY_OTHER,
+    CATEGORY_SERVER,
+    CATEGORY_TIMEOUT,
+    build_aggregate_failure_response,
+    build_fallback_attempt,
+)
+
+
+def _plain_response(status: int, body: bytes = b"") -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=body,
+        request=httpx.Request("HEAD", "https://src.local/f"),
+    )
+
+
+def test_build_fallback_attempt_categorizes_known_status_codes():
+    src = {"name": "S", "url": "https://s"}
+    assert (
+        build_fallback_attempt(src, response=_plain_response(401))["category"]
+        == CATEGORY_AUTH
+    )
+    assert (
+        build_fallback_attempt(src, response=_plain_response(403))["category"]
+        == CATEGORY_FORBIDDEN
+    )
+    assert (
+        build_fallback_attempt(src, response=_plain_response(404))["category"]
+        == CATEGORY_NOT_FOUND
+    )
+    assert (
+        build_fallback_attempt(src, response=_plain_response(410))["category"]
+        == CATEGORY_NOT_FOUND
+    )
+    assert (
+        build_fallback_attempt(src, response=_plain_response(503))["category"]
+        == CATEGORY_SERVER
+    )
+
+
+def test_build_fallback_attempt_falls_through_on_unclassifiable_status():
+    """Any status that isn't in the enumerated buckets (e.g. an
+    I'm-a-teapot or an odd client error a mirror might invent) gets the
+    ``CATEGORY_OTHER`` label so the aggregate still has a consistent
+    shape and the caller can still display the message."""
+    src = {"name": "S", "url": "https://s"}
+    attempt = build_fallback_attempt(src, response=_plain_response(418))
+    assert attempt["category"] == CATEGORY_OTHER
+    assert attempt["status"] == 418
+
+
+def test_build_fallback_attempt_contract_violation_returns_safe_default():
+    """If the caller passes none of response/timeout/network we still
+    return a well-formed attempt dict with CATEGORY_OTHER so the
+    aggregate loop can't swallow an exception path silently."""
+    attempt = build_fallback_attempt({"name": "S", "url": "https://s"})
+    assert attempt["status"] is None
+    assert attempt["category"] == CATEGORY_OTHER
+    assert attempt["message"] == ""
+    assert attempt["name"] == "S"
+
+
+def test_build_fallback_attempt_truncates_very_long_upstream_messages():
+    """A pathological upstream that returns a multi-MB error body
+    cannot be allowed to blow up response headers or body size. The
+    per-attempt message is capped (see MAX_ATTEMPT_MESSAGE_LEN)."""
+    src = {"name": "S", "url": "https://s"}
+    huge = "x" * 5000
+    attempt = build_fallback_attempt(
+        src, response=_plain_response(500, body=huge.encode())
+    )
+    assert len(attempt["message"]) <= 600  # cap is 500, allow a bit of slack
+
+
+def test_build_fallback_attempt_records_timeout_without_http_status():
+    import httpx
+
+    src = {"name": "S", "url": "https://s"}
+    attempt = build_fallback_attempt(src, timeout=httpx.TimeoutException("slow"))
+    assert attempt["status"] is None
+    assert attempt["category"] == CATEGORY_TIMEOUT
+    assert "slow" in attempt["message"]
+
+
+def test_build_fallback_attempt_records_generic_network_error():
+    src = {"name": "S", "url": "https://s"}
+    attempt = build_fallback_attempt(src, network=ConnectionResetError("reset"))
+    assert attempt["status"] is None
+    assert attempt["category"] == CATEGORY_NETWORK
+    assert "reset" in attempt["message"]
+
+
+def test_build_aggregate_failure_response_empty_attempts_is_generic_502():
+    """No recorded attempts is a contract violation (caller should
+    return None in that case), but we still produce a well-formed 502
+    rather than a KeyError or a nonsensical 401."""
+    resp = build_aggregate_failure_response([])
+    assert resp.status_code == 502
+    assert resp.headers.get("x-error-code") is None


### PR DESCRIPTION
## Summary

Fix: fallback upstream errors are no longer collapsed to a misleading local 404.

**Before**: clicking Download or Preview on a file in a gated-source repo (e.g. `animetimm/mobilenetv3_large_150d.dbv4-full`) returned `404 RepoNotFound`, even though the containing repo was clearly listable via the tree endpoint. The fallback code hit upstream HF, got a `401`, called `should_retry_source`, saw "non-retryable", and returned `None` — erasing the status, the upstream message, and cutting short the source chain. `with_repo_fallback` then re-raised the original local 404.

**After**: every non-2xx/3xx probe is recorded as a per-source attempt, the loop continues to the next source (a mirror might still have the file), and if everything fails the response is an aggregated `JSONResponse` with the right HTTP status + the right `X-Error-Code` for `huggingface_hub` to raise the right exception subclass.

Builds on top of #28 (target branch: `feat/client-side-preview`) so the UI-side error copy and the backend classification ship together.

## The contract

**HTTP status priority** across all attempts: `401 > 403 > 404 > 502` (5xx / timeout / network all collapse to 502 Bad Gateway).

**`X-Error-Code`** deliberately aligns with [`huggingface_hub.utils._http.hf_raise_for_status`](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_http.py):

| Aggregate outcome | HTTP | `X-Error-Code` | `hf_hub` raises |
|---|---|---|---|
| Any source 401 | 401 | **`GatedRepo`** | `GatedRepoError` |
| All sources 404 | 404 | **`EntryNotFound`** | `EntryNotFoundError` |
| Any source 403 (no 401) | 403 | — | generic `HfHubHTTPError` |
| 5xx / timeout / network | 502 | — | generic (retryable) |

Inventing our own codes would downgrade gated-repo `hf_hub_download` calls to `RepositoryNotFoundError` — losing the exception type users actually catch. Alignment is the whole point.

**Body** keeps HF-style `{error, detail}` plus a `sources[]` array so curl / SDK users can see the full timeline:

```json
{
  "error": "GatedRepo",
  "detail": "Upstream source requires authentication - likely a gated repository. ...",
  "sources": [
    {"name": "HuggingFace", "url": "https://huggingface.co", "status": 401, "category": "auth", "message": "..."},
    {"name": "Mirror", "url": "https://mirror.local", "status": 404, "category": "not-found", "message": "..."}
  ]
}
```

**`X-Error-Message`** header mirrors `body.detail` so a bare `curl -I` shows something readable.

## Backend

- `src/kohakuhub/api/fallback/operations.py::try_fallback_resolve` — rewrote the source loop. Non-success HEAD/GET responses + timeout + transport exceptions are all recorded as `build_fallback_attempt(...)` dicts and the loop keeps going. At the end, `build_aggregate_failure_response(attempts)` returns the aggregate, or `None` if no source was even tried (respects the empty-sources early exit).
- `src/kohakuhub/api/fallback/utils.py` — two new helpers:
  - `build_fallback_attempt(source, *, response=None, timeout=None, network=None)` — normalizes one probe into the serializable dict that lands in `body.sources`.
  - `build_aggregate_failure_response(attempts)` — status priority + HF-aligned `X-Error-Code` + body shaping.
- `should_retry_source` is no longer used for flow control (the loop no longer short-circuits). Left intact to avoid touching its other callers.

Other fallback operations (`tree`, `info`, `paths_info`, `user_profile`, avatars, repo aggregation) still return `None` on failure. They don't surface the gated-vs-missing confusion in practice (HF's tree endpoint is public for gated repos), so keeping them focused. Happy to extend in a follow-up if reviewers want the same shape everywhere.

## Frontend

- `src/kohaku-hub-ui/src/utils/safetensors.js` — `SafetensorsFetchError.fromResponse(response)` parses the aggregated body (defensive: non-JSON bodies just use `X-Error-Message`) and attaches `errorCode` / `sources` / `detail` to the thrown error.
- `src/kohaku-hub-ui/src/components/repo/preview/FilePreviewDialog.vue` — four remediation-specific error states (`gated`, `forbidden`, `not-found`, `upstream-unavailable`) plus the existing CORS hint and the existing generic fallback. When `sources[]` is present it collapses into a `<details>` table for diagnostic. The gated state recommends "attach an access token ... in account settings" rather than anything CORS-flavored — the two remediations are different and must not cross-contaminate.

## Tests

**Backend** (`test/kohakuhub/api/fallback/`):

- `test_operations.py` — 6 new cases pinning the contract: single 401, single 403, 401 + second-source-success, mixed 401/404/503/timeout with priority resolution, all-404, all-5xx/timeout. Two pre-existing tests that pinned the old short-circuit behavior (`stops_on_non_retryable_...`, `returns_none_after_generic_...`) rewritten to match the new aggregating semantics.
- `test_hf_hub_interop.py` — 3 new HF-compat tests. Feeds the aggregated response into real `huggingface_hub.utils._http.hf_raise_for_status` and asserts: 401 → `GatedRepoError`, all-404 → `EntryNotFoundError`, all-5xx → generic `HfHubHTTPError` (explicitly NOT any of the subclasses that would signal a wrong remediation). Pins the HF-alignment invariant against future drift.

**Frontend** (`test/kohaku-hub-ui/`):

- `utils/test_safetensors.test.js` — 2 new cases for `SafetensorsFetchError.fromResponse`: JSON body populates `errorCode` / `sources` / `detail`; non-JSON falls back to `X-Error-Message` without crashing.
- `components/test_file_preview_dialog.test.js` — 3 new cases for the gated / not-found / upstream-unavailable copy; asserts gated-copy doesn't bleed CORS copy.

## Verified live

Against the real gated repo through the patched local backend:

- `HEAD /models/animetimm/mobilenetv3_large_150d.dbv4-full/resolve/main/model.safetensors` returns **401** + `X-Error-Code: GatedRepo` + aggregated JSON body (was: 404 + `RepoNotFound`).
- `huggingface_hub.HfApi.parse_safetensors_file_metadata` against the patched endpoint raises **`GatedRepoError`** with the upstream message echoed into the exception text — the HF-native behavior users already handle.

## Test plan

- [x] `pytest test/kohakuhub/api/fallback/` — **84 / 84** pass (was 78 on main, +6 new cases, 2 rewritten)
- [x] `pytest test/kohakuhub/api/test_files.py` — **7 / 7** pass (no regression)
- [x] `npm test` — **180 / 180** pass (+3 new cases on top of the 177 in #28)
- [x] `npm run build` passes
- [x] Live repro resolved: gated-repo resolve now 401 + GatedRepo + structured body; `huggingface_hub` raises `GatedRepoError`.
- [ ] CI green (waiting)

## Not in scope

- Extending the aggregate-error contract to `tree` / `info` / `paths_info` / avatar / user-repos fallback operations. Reasonable follow-up, but none of them currently surface the gated-vs-missing UX confusion (HF's `/api/models/*/tree` is public for gated repos), so the fix stays focused on `resolve`.
- Globally-configured admin HF token for anonymous users. That's a deploy-policy decision the hub operator takes on their own (legal/licensing risk self-owned) — the default remains "each user brings their own token", which this PR's UI copy explicitly guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
