### PR TITLE
Unify make ui (admin under /admin) and stop spurious vite reloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ UI_ADMIN_DIR ?= src/kohaku-hub-admin
 UI_ADMIN_TEST_ROOT ?= test/kohaku-hub-admin
 
 .PHONY: help init-env install-backend install-frontend install infra-up infra-down \
-	backend seed-demo reset-local-data reset-and-seed ui admin status \
+	backend seed-demo reset-local-data reset-and-seed ui ui-only admin status \
 	logs-postgres logs-minio logs-lakefs test test-backend test-ui test-ui-admin \
 	verify-seed-demo
 
@@ -31,8 +31,9 @@ help:
 	@echo "  make reset-local-data Dangerously clear local KohakuHub dev data through the local reset helper"
 	@echo "  make reset-and-seed   Reset persisted local data, then bootstrap fresh demo data"
 	@echo "  make backend          Run FastAPI backend in reload mode"
-	@echo "  make ui               Run the main Vite frontend on :5173"
-	@echo "  make admin            Run the admin Vite frontend on :5174"
+	@echo "  make ui               Run main UI on :5173 with admin mounted at /admin (admin Vite on :5174)"
+	@echo "  make ui-only          Run only the main Vite frontend on :5173 (no admin)"
+	@echo "  make admin            Run only the admin Vite frontend on :5174"
 	@echo "  make test-backend     Run the backend pytest suite against the real test services with coverage"
 	@echo "                        Example: make test-backend RANGE_DIR=api"
 	@echo "                        Example: make test-backend RANGE_DIR=api/repo/routers"
@@ -97,6 +98,17 @@ reset-and-seed: reset-local-data
 	$(MAKE) seed-demo
 
 ui:
+	@# Run admin and main UI together. They share this recipe shell's process
+	@# group (no `set -m`), so SIGINT from the terminal — and the explicit
+	@# `kill 0` on exit — propagate to both vite servers cleanly.
+	@# Use `exec ./node_modules/.bin/vite` instead of `npm run dev` because
+	@# `npm` does not reliably forward SIGINT/SIGTERM to its child process.
+	@trap 'kill 0 2>/dev/null' EXIT INT TERM; \
+	( cd src/kohaku-hub-admin && exec ./node_modules/.bin/vite ) & \
+	( cd src/kohaku-hub-ui    && exec ./node_modules/.bin/vite ) & \
+	wait
+
+ui-only:
 	npm run dev --prefix src/kohaku-hub-ui
 
 admin:

--- a/README.md
+++ b/README.md
@@ -279,8 +279,18 @@ uvicorn kohakuhub.main:app --host 0.0.0.0 --port 48888 --workers 4
 
 **Frontend:**
 ```bash
+# Install deps for both apps once
 npm install --prefix ./src/kohaku-hub-ui
-npm run dev --prefix ./src/kohaku-hub-ui
+npm install --prefix ./src/kohaku-hub-admin
+
+# Recommended: run main UI + admin together on one origin.
+# Main UI on http://localhost:5173, admin mounted at http://localhost:5173/admin.
+# (Internally the admin Vite server runs on :5174 and is reverse-proxied by the main UI.)
+make ui
+
+# Alternatives:
+make ui-only   # Only the main UI on :5173 (no admin)
+make admin     # Only the admin UI on :5174
 ```
 
 **Testing:**

--- a/src/kohaku-hub-admin/src/stores/admin.js
+++ b/src/kohaku-hub-admin/src/stores/admin.js
@@ -1,4 +1,4 @@
-import { defineStore } from "pinia";
+import { defineStore, acceptHMRUpdate } from "pinia";
 import { ref, computed } from "vue";
 import { verifyAdminToken } from "@/utils/api";
 
@@ -47,3 +47,10 @@ export const useAdminStore = defineStore("admin", () => {
     logout,
   };
 });
+
+// Hot-replace this store on edit instead of full-reloading the page.
+// Without this, editing admin.js would full-reload and dump the in-memory
+// token, making local development of auth-related code painful.
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAdminStore, import.meta.hot));
+}

--- a/src/kohaku-hub-admin/vite.config.js
+++ b/src/kohaku-hub-admin/vite.config.js
@@ -37,9 +37,15 @@ export default defineConfig({
       }
     }),
 
-    // Auto import components
+    // Auto import components.
+    // importStyle: false — main.js already imports the full
+    // `element-plus/dist/index.css`, so the per-component
+    // `element-plus/es/components/<name>/style/css` injections are
+    // redundant. They were the main source of dev-server lazy dep discovery
+    // (and the resulting full-page reloads) when navigating to a page that
+    // first uses a new component.
     Components({
-      resolvers: [ElementPlusResolver()],
+      resolvers: [ElementPlusResolver({ importStyle: false })],
       dts: 'src/components.d.ts',
       dirs: ['src/components']
     }),
@@ -89,6 +95,30 @@ export default defineConfig({
       }
     },
     chunkSizeWarningLimit: 1000
+  },
+
+  // Pre-bundle every third-party dep that admin actually imports, and turn
+  // OFF runtime discovery. Combined effect:
+  //   * Vite's dep optimizer never finds a "new" dep at runtime, so it never
+  //     issues the "optimized dependencies changed. reloading" full-reload
+  //     that resets the in-memory admin token.
+  //   * Real code edits still go through the normal HMR / file-watcher path
+  //     and reload as expected.
+  // If a dep is missing from this list it surfaces as an explicit module-not-
+  // found error in the terminal — easier to debug than a silent reload.
+  optimizeDeps: {
+    include: [
+      'vue',
+      'vue-router',
+      'pinia',
+      'element-plus',
+      'element-plus/es',
+      'axios',
+      'dayjs',
+      'chart.js',
+      'vue-chartjs'
+    ],
+    noDiscovery: true
   },
 
   // Enable caching for faster rebuilds

--- a/src/kohaku-hub-ui/src/stores/auth.js
+++ b/src/kohaku-hub-ui/src/stores/auth.js
@@ -1,5 +1,5 @@
 // src/kohaku-hub-ui/src/stores/auth.js
-import { defineStore } from "pinia";
+import { defineStore, acceptHMRUpdate } from "pinia";
 import { authAPI, settingsAPI } from "@/utils/api";
 import { clearRepoSortPreference } from "@/utils/repoSortPreference";
 
@@ -174,3 +174,8 @@ export const useAuthStore = defineStore("auth", {
     },
   },
 });
+
+// Hot-replace this store on edit instead of full-reloading the page.
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAuthStore, import.meta.hot));
+}

--- a/src/kohaku-hub-ui/src/stores/theme.js
+++ b/src/kohaku-hub-ui/src/stores/theme.js
@@ -1,5 +1,5 @@
 // src/kohaku-hub-ui/src/stores/theme.js
-import { defineStore } from "pinia";
+import { defineStore, acceptHMRUpdate } from "pinia";
 
 export const useThemeStore = defineStore("theme", {
   state: () => ({
@@ -47,3 +47,8 @@ export const useThemeStore = defineStore("theme", {
     },
   },
 });
+
+// Hot-replace this store on edit instead of full-reloading the page.
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useThemeStore, import.meta.hot));
+}

--- a/src/kohaku-hub-ui/vite.config.js
+++ b/src/kohaku-hub-ui/vite.config.js
@@ -50,9 +50,15 @@ export default defineConfig({
       }
     }),
 
-    // Auto import components
+    // Auto import components.
+    // importStyle: false — main.js already imports the full
+    // `element-plus/dist/index.css`, so the per-component
+    // `element-plus/es/components/<name>/style/css` injections that the
+    // resolver normally adds are redundant. They were the main source of
+    // dev-server lazy dep discovery (and the resulting full-page reloads)
+    // when navigating to a page that first uses a new component.
     Components({
-      resolvers: [ElementPlusResolver()],
+      resolvers: [ElementPlusResolver({ importStyle: false })],
       dts: 'src/components.d.ts',
       dirs: ['src/components']
     }),
@@ -66,10 +72,88 @@ export default defineConfig({
     }
   },
 
+  // Pre-bundle every third-party dep that the UI actually imports, and turn
+  // OFF runtime discovery. Combined effect:
+  //   * Vite's dep optimizer never finds a "new" dep at runtime, so it never
+  //     issues the "optimized dependencies changed. reloading" full-reload
+  //     that disrupts whatever the user is doing on the page.
+  //   * Real code edits still go through the normal HMR / file-watcher path
+  //     and reload as expected.
+  // If a dep is missing from this list it surfaces as an explicit module-not-
+  // found error in the terminal — easier to debug than a silent reload.
+  // MAINTENANCE: when you add a new third-party import to UI source code,
+  // append the exact specifier here. See AGENTS.md ("Dev server reload policy").
   optimizeDeps: {
     include: [
-      'highlight.js',
+      // Vue core
+      'vue',
+      'vue-router',
+      'pinia',
+
+      // UI library
+      'element-plus',
+      'element-plus/es',
+
+      // HTTP / time
+      'axios',
+      'dayjs',
+      'dayjs/plugin/relativeTime',
+      'dayjs/plugin/timezone',
+      'dayjs/plugin/utc',
+
+      // Code editor
+      'codemirror',
+      '@codemirror/commands',
+      '@codemirror/state',
+      '@codemirror/theme-one-dark',
+      '@codemirror/view',
+      '@codemirror/lang-cpp',
+      '@codemirror/lang-css',
+      '@codemirror/lang-html',
+      '@codemirror/lang-java',
+      '@codemirror/lang-javascript',
+      '@codemirror/lang-json',
+      '@codemirror/lang-markdown',
+      '@codemirror/lang-php',
+      '@codemirror/lang-python',
+      '@codemirror/lang-rust',
+      '@codemirror/lang-sql',
+      '@codemirror/lang-xml',
+
+      // Syntax highlighting
+      'highlight.js/lib/core',
+      'highlight.js/lib/languages/bash',
+      'highlight.js/lib/languages/cpp',
+      'highlight.js/lib/languages/csharp',
+      'highlight.js/lib/languages/css',
+      'highlight.js/lib/languages/go',
+      'highlight.js/lib/languages/java',
+      'highlight.js/lib/languages/javascript',
+      'highlight.js/lib/languages/json',
+      'highlight.js/lib/languages/kotlin',
+      'highlight.js/lib/languages/markdown',
+      'highlight.js/lib/languages/php',
+      'highlight.js/lib/languages/python',
+      'highlight.js/lib/languages/ruby',
+      'highlight.js/lib/languages/rust',
+      'highlight.js/lib/languages/shell',
+      'highlight.js/lib/languages/sql',
+      'highlight.js/lib/languages/swift',
+      'highlight.js/lib/languages/typescript',
+      'highlight.js/lib/languages/xml',
+      'highlight.js/lib/languages/yaml',
+
+      // Misc
+      'cropperjs',
+      'hyparquet',
+      'isomorphic-dompurify',
+      'js-sha256',
+      'js-yaml',
+      'markdown-it',
+      'mermaid',
+      'panzoom'
     ],
+    noDiscovery: true
   },
 
   build: {
@@ -114,6 +198,25 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // Mount the admin Vite dev server under /admin so `make ui` exposes the
+      // admin portal at the same origin as the main UI. Admin builds with
+      // base: '/admin/', and ws: true keeps its HMR socket working through
+      // this proxy. The bypass redirects bare `/admin` to `/admin/` so users
+      // never see Vite's "did you mean to visit /admin/" base-URL hint page.
+      '/admin': {
+        target: 'http://localhost:5174',
+        changeOrigin: true,
+        ws: true,
+        bypass: (req, res) => {
+          const path = (req.url || '').split('?')[0]
+          if (path === '/admin') {
+            const qs = (req.url || '').slice(path.length)
+            res.writeHead(302, { Location: '/admin/' + qs })
+            res.end()
+            return false
+          }
+        }
+      },
       // Proxy API calls
       '/api': {
         target: 'http://localhost:48888',


### PR DESCRIPTION
## Summary

- `make ui` now co-launches the main UI on :5173 and the admin Vite on :5174, with admin reverse-proxied at `:5173/admin` (HMR ws included, bare `/admin` 302→`/admin/`). `make ui-only` keeps the prior single-app behavior; `make admin` remains. SIGINT to make tears both vites down cleanly.
- Stops the dev server from full-reloading the browser when the user hasn't changed source. The trigger was Vite's lazy dep optimizer emitting `optimized dependencies changed. reloading` on first navigation that touched a not-yet-pre-bundled specifier (Element Plus per-component CSS, codemirror lang-*, etc), which discarded in-memory state (admin token, form input, …).
- Fix is three-pronged in both UIs: `optimizeDeps.include` covers every imported third-party specifier with `noDiscovery: true`, `ElementPlusResolver({ importStyle: false })` (main.js already imports the global element-plus stylesheet), and `acceptHMRUpdate` on every Pinia store. Real code edits still take the normal HMR / file-watcher reload path.

## Test plan

- [x] `make ui` starts both vites; `:5173/` serves the main UI; `:5173/admin/` proxies to admin Vite (`<title>KohakuHub Admin Portal</title>`); bare `:5173/admin` returns 302 → `/admin/` (preserving querystring).
- [x] `make ui-only` runs only main UI; `make admin` runs only admin; SIGINT to `make ui` cleanly tears both children down.
- [x] Playwright walks 13 main UI routes + 9 admin routes via client-side navigation: zero full reloads, zero `optimized dependencies changed. reloading` lines in the Vite log, login state preserved across all navigations.
- [x] Idle for 8s on a page produces zero reloads.
- [x] Editing a `.vue` file triggers HMR (no full reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)