### PR TITLE
fix(ui/range-reads): forward same-origin session on /resolve/ Range probes

### DIFF
--- a/scripts/dev/seed_demo_data.py
+++ b/scripts/dev/seed_demo_data.py
@@ -2622,6 +2622,124 @@ def build_open_media_core_repo_seeds() -> tuple[RepoSeed, ...]:
             download_path="model-00001-of-00003.safetensors",
             download_sessions=4,
         ),
+        # Private mirror of the multimodal benchmark — exercises range-read
+        # previews (parquet + hfutils.index tar + safetensors) on a repo
+        # that only the logged-in owner can resolve. Regression coverage
+        # for the 404-on-missing-session bug seen on private datasets in
+        # production.
+        RepoSeed(
+            actor="mai_lin",
+            repo_type="dataset",
+            namespace="mai_lin",
+            name="private-range-preview-bench",
+            private=True,
+            commits=(
+                CommitSeed(
+                    summary="Seed private range-preview fixtures",
+                    description=(
+                        "One real parquet shard and one hfutils.index tar pair "
+                        "so the SPA's range-read preview paths can be exercised "
+                        "against a repo that requires the session cookie."
+                    ),
+                    files=(
+                        (
+                            "README.md",
+                            text_bytes(
+                                """
+                                ---
+                                license: cc-by-4.0
+                                pretty_name: Private Range-Preview Bench
+                                tags:
+                                  - parquet
+                                  - indexed-tar
+                                  - private
+                                ---
+
+                                # private-range-preview-bench
+
+                                Private dataset used to verify that the SPA's
+                                client-side parquet, indexed-tar, and tar-thumbnail
+                                preview paths still resolve when the only thing
+                                identifying the user is the same-origin session
+                                cookie. Owner-only by design.
+                                """
+                            ),
+                        ),
+                        seed_file(
+                            "parquet/sample-00000-of-00001.parquet",
+                            lambda: make_parquet_bytes(
+                                "private-range-preview", row_count=512, payload_size=512
+                            ),
+                        ),
+                        seed_file(
+                            "archives/raw-bundle-0000.tar",
+                            lambda: archive_bundle()[0],
+                        ),
+                        seed_file(
+                            "archives/raw-bundle-0000.json",
+                            lambda: archive_bundle()[1],
+                        ),
+                    ),
+                ),
+            ),
+            download_path="parquet/sample-00000-of-00001.parquet",
+            download_sessions=0,
+        ),
+        # Private safetensors checkpoint — same regression coverage but
+        # for the model side. One shard + index keeps the seed cheap;
+        # the standalone-blob safetensors preview still has a real header
+        # to parse over a Range read.
+        RepoSeed(
+            actor="mai_lin",
+            repo_type="model",
+            namespace="mai_lin",
+            name="private-vision-checkpoint",
+            private=True,
+            commits=(
+                CommitSeed(
+                    summary="Seed private safetensors shard",
+                    description=(
+                        "One sharded safetensors file plus its index manifest, "
+                        "private, so the safetensors header preview can be "
+                        "exercised against a session-gated /resolve/ path."
+                    ),
+                    files=(
+                        (
+                            "README.md",
+                            text_bytes(
+                                """
+                                ---
+                                license: apache-2.0
+                                library_name: transformers
+                                tags:
+                                  - private
+                                  - safetensors
+                                ---
+
+                                # private-vision-checkpoint
+
+                                Private mirror of one shard from the public
+                                vision-language-assistant-3b bundle. Exists so
+                                the SPA's safetensors header preview can be
+                                verified against a private repo where the only
+                                identity hint is the session cookie.
+                                """
+                            ),
+                        ),
+                        seed_file(
+                            "model.safetensors.index.json",
+                            lambda: model_bundle()["model.safetensors.index.json"],
+                        ),
+                        seed_file(
+                            "model-00001-of-00003.safetensors",
+                            lambda: model_bundle()["model-00001-of-00003.safetensors"],
+                        ),
+                    ),
+                ),
+            ),
+            download_path="model-00001-of-00003.safetensors",
+            download_sessions=0,
+        ),
         RepoSeed(
             actor="mai_lin",
             repo_type="dataset",

--- a/src/kohaku-hub-ui/src/utils/indexed-tar.js
+++ b/src/kohaku-hub-ui/src/utils/indexed-tar.js
@@ -77,10 +77,15 @@ export async function parseTarIndex(url, options = {}) {
   const { onProgress = () => {}, signal } = options;
 
   onProgress("fetch");
+  // `same-origin` forwards the SPA session cookie on the /resolve/ hop
+  // — private repos return 404 without it — and the browser drops
+  // cookies on the cross-origin redirect to the presigned object URL,
+  // so the S3/MinIO `Access-Control-Allow-Origin: *` response stays
+  // compatible with credentialed CORS.
   const response = await fetch(url, {
     signal,
     mode: "cors",
-    credentials: "omit",
+    credentials: "same-origin",
   });
   if (!response.ok) {
     throw await IndexedTarFetchError.fromResponse(response, "tar index JSON");
@@ -323,11 +328,14 @@ export async function extractMemberBytes(tarUrl, info, options = {}) {
   }
   if (info.size === 0) return new Uint8Array(0);
 
+  // Same credentials story as parseTarIndex above: send the session
+  // cookie on the same-origin /resolve/ hop, drop it on the cross-origin
+  // redirect to the presigned tar URL.
   const response = await fetch(tarUrl, {
     headers: { Range: buildMemberRangeHeader(info) },
     signal,
     mode: "cors",
-    credentials: "omit",
+    credentials: "same-origin",
   });
   if (response.status !== 200 && response.status !== 206) {
     throw await IndexedTarFetchError.fromResponse(response, "tar member");

--- a/src/kohaku-hub-ui/src/utils/parquet.js
+++ b/src/kohaku-hub-ui/src/utils/parquet.js
@@ -6,9 +6,12 @@
 //
 // Design notes:
 //   - hyparquet's asyncBufferFromUrl does HEAD + tail Range reads on its
-//     own. It accepts `requestInit` so we can pin the cross-origin CORS
-//     contract (mode "cors", credentials "omit") for presigned S3/MinIO
-//     URLs that only allow anonymous access.
+//     own. It accepts `requestInit` so we can pin the CORS contract
+//     (mode "cors", credentials "same-origin"). same-origin forwards the
+//     SPA session cookie on the /resolve/ hop — private repos return 404
+//     without it — and the browser drops cookies on the cross-origin
+//     redirect, so the presigned S3/MinIO URL is still answered with
+//     `Access-Control-Allow-Origin: *` without breaking credentialed CORS.
 //   - The default initial tail fetch is 512 KB, which easily covers the
 //     footer-only cases measured in issue #27 (≤ 264 KB). We leave the
 //     default alone; hyparquet will issue a second Range if the footer
@@ -52,7 +55,7 @@ export async function parseParquetMetadata(url, options = {}) {
 
   const requestInit = {
     mode: "cors",
-    credentials: "omit",
+    credentials: "same-origin",
     ...(signal ? { signal } : {}),
   };
 

--- a/src/kohaku-hub-ui/src/utils/safetensors.js
+++ b/src/kohaku-hub-ui/src/utils/safetensors.js
@@ -17,11 +17,18 @@
 //             `parameters` is derived client-side as product(shape) so the
 //             UI can bucket by dtype and sum totals without a second pass.
 //
-// `fetch()` is used directly (not the axios `api` helper) because:
-//   - axios interceptors re-attach auth cookies that would defeat the CORS
-//     `*` preflight on presigned S3/MinIO URLs
-//   - the browser follows the backend 302 to the presigned URL
-//     transparently, preserving the Range request header per RFC 7231 §6.4.3
+// `fetch()` is used directly (not the axios `api` helper) because the
+// browser follows the backend 302 to the presigned URL transparently,
+// preserving the Range request header per RFC 7231 §6.4.3.
+//
+// `credentials: "same-origin"` is required for private repos: the first
+// hop is `/resolve/...` on the SPA's own origin, where the session cookie
+// is the only thing identifying the user — without it the backend's
+// HF-compat anti-enumeration path returns 404 even though the user is
+// logged in. The browser drops cookies on the cross-origin redirect to
+// S3/MinIO, so the presigned URL still works against an
+// `Access-Control-Allow-Origin: *` response without violating the
+// credentialed-CORS rule.
 
 const SAFETENSORS_FIRST_READ_BYTES = 100000; // HF constant
 const SAFETENSORS_MAX_HEADER_LENGTH = 100 * 1024 * 1024; // HF constant
@@ -68,11 +75,12 @@ export async function parseSafetensorsMetadata(url, options = {}) {
   const firstResp = await fetch(url, {
     headers: { Range: `bytes=0-${SAFETENSORS_FIRST_READ_BYTES}` },
     signal,
-    // `cors` is the default; explicit for clarity. Presigned URLs do not
-    // need cookies and sending them would break the Allow-Credentials
-    // contract downstream.
+    // `mode: "cors"` is the default; explicit for clarity. `same-origin`
+    // forwards the SPA session cookie on the same-origin /resolve/ hop
+    // (private repos return 404 without it) and is dropped on the
+    // cross-origin redirect to the presigned object URL.
     mode: "cors",
-    credentials: "omit",
+    credentials: "same-origin",
   });
   if (firstResp.status !== 200 && firstResp.status !== 206) {
     throw await SafetensorsFetchError.fromResponse(firstResp);
@@ -107,7 +115,7 @@ export async function parseSafetensorsMetadata(url, options = {}) {
       headers: { Range: `bytes=8-${headerLen + 7}` },
       signal,
       mode: "cors",
-      credentials: "omit",
+      credentials: "same-origin",
     });
     if (secondResp.status !== 200 && secondResp.status !== 206) {
       throw await SafetensorsFetchError.fromResponse(secondResp);

--- a/test/kohaku-hub-ui/utils/test_range_credentials.test.js
+++ b/test/kohaku-hub-ui/utils/test_range_credentials.test.js
@@ -1,0 +1,273 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "@/testing/msw";
+
+import { server } from "../setup/msw-server";
+
+import { parseSafetensorsMetadata } from "@/utils/safetensors";
+import { parseParquetMetadata } from "@/utils/parquet";
+import {
+  IndexedTarFetchError,
+  extractMemberBytes,
+  parseTarIndex,
+} from "@/utils/indexed-tar";
+import { extractThumbnail, _resetThumbnailCache } from "@/utils/tar-thumbnail";
+
+// Regression for the private-repo 404: the four range-read entry points
+// (safetensors / parquet / indexed-tar JSON / indexed-tar member, plus
+// the tar-thumbnail strategy chain that routes through the last) used to
+// hard-code `credentials: "omit"` on their fetch options. Same-origin
+// requests with `credentials: "omit"` carry no Cookie header, so the
+// SPA's session cookie never reached the backend's /resolve/ handler;
+// for a private repo the HF-compat anti-enumeration path then returned
+// 404 even though the user was logged in.
+//
+// The contract these tests pin:
+//   * every range-read fetch must use a credentials mode that forwards
+//     same-origin cookies (`same-origin` or `include`); never `omit`.
+//   * a backend that 404s on cookie-less requests must not break the
+//     reader once credentials are forwarded — the request still
+//     succeeds and parses end-to-end.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAFETENSORS_FIXTURE = readFileSync(
+  resolve(__dirname, "../fixtures/previews/tiny.safetensors"),
+);
+const PARQUET_FIXTURE = readFileSync(
+  resolve(__dirname, "../fixtures/previews/tiny.parquet"),
+);
+
+const SAFETENSORS_URL = "https://hub.test.local/datasets/owner/secret/resolve/main/model.safetensors";
+const PARQUET_URL = "https://hub.test.local/datasets/owner/secret/resolve/main/data.parquet";
+const TAR_INDEX_URL = "https://hub.test.local/datasets/owner/secret/resolve/main/archive.json";
+const TAR_URL = "https://hub.test.local/datasets/owner/secret/resolve/main/archive.tar";
+
+// Picks credentials forwarded by the fetch init. Treat any non-"omit"
+// value as a pass — the SPA does not need to commit to a specific
+// non-omit token, just to "not omit". The current implementation uses
+// "same-origin" but a future hardening to "include" would still pin the
+// regression.
+function isCookieCarrying(credentials) {
+  return credentials !== undefined && credentials !== "omit";
+}
+
+// MSW handler factory that mimics the HF-compat anti-enumeration path:
+// without a cookie-carrying credentials mode the response is 404 with a
+// RepoNotFound shape. With credentials it serves real bytes (Range or
+// full body).
+function privateRepoHandler(buffer) {
+  return async ({ request }) => {
+    if (!isCookieCarrying(request.credentials)) {
+      return HttpResponse.json(
+        { error: "RepoNotFound", detail: "Repository 'owner/secret' not found" },
+        {
+          status: 404,
+          headers: {
+            "X-Error-Code": "RepoNotFound",
+            "X-Error-Message": "Repository 'owner/secret' not found",
+          },
+        },
+      );
+    }
+    if (request.method.toUpperCase() === "HEAD") {
+      return new HttpResponse(null, {
+        status: 200,
+        headers: {
+          "Content-Length": String(buffer.length),
+          "Accept-Ranges": "bytes",
+        },
+      });
+    }
+    const range = request.headers.get("range");
+    if (!range) {
+      return new HttpResponse(buffer, {
+        status: 200,
+        headers: { "Content-Length": String(buffer.length) },
+      });
+    }
+    const match = /^bytes=(\d+)-(\d+)?$/.exec(range);
+    if (!match) return new HttpResponse("Bad Range", { status: 400 });
+    const start = Number(match[1]);
+    const end = match[2] == null ? buffer.length - 1 : Math.min(Number(match[2]), buffer.length - 1);
+    const slice = buffer.subarray(start, end + 1);
+    return new HttpResponse(slice, {
+      status: 206,
+      headers: {
+        "Content-Range": `bytes ${start}-${end}/${buffer.length}`,
+        "Content-Length": String(slice.length),
+        "Accept-Ranges": "bytes",
+      },
+    });
+  };
+}
+
+describe("range-read credentials forwarding (private-repo regression)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _resetThumbnailCache();
+  });
+
+  describe("safetensors", () => {
+    it("forwards same-origin cookies on the speculative head Range", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      server.use(http.get(SAFETENSORS_URL, privateRepoHandler(SAFETENSORS_FIXTURE)));
+
+      const header = await parseSafetensorsMetadata(SAFETENSORS_URL);
+
+      expect(fetchSpy).toHaveBeenCalled();
+      for (const call of fetchSpy.mock.calls) {
+        const init = call[1] || {};
+        expect(init.credentials).toBeDefined();
+        expect(init.credentials).not.toBe("omit");
+        expect(isCookieCarrying(init.credentials)).toBe(true);
+      }
+      expect(Object.keys(header.tensors).length).toBeGreaterThan(0);
+    });
+
+    it("404s end-to-end when credentials would be omitted", async () => {
+      // Pin the bug shape: a backend that hides private repos from
+      // cookie-less requests must surface a 404 SafetensorsFetchError.
+      // The fix sends credentials, so this path is only reachable when
+      // the option is regressed back to "omit" — but the test handler
+      // also rejects requests that arrive without same-origin
+      // credentials, so the assertion documents the user-visible
+      // failure mode the regression caused in production.
+      server.use(http.get(SAFETENSORS_URL, privateRepoHandler(SAFETENSORS_FIXTURE)));
+      const realFetch = globalThis.fetch;
+      const stub = vi.spyOn(globalThis, "fetch").mockImplementation((url, init) => {
+        return realFetch(url, { ...(init || {}), credentials: "omit" });
+      });
+      const err = await parseSafetensorsMetadata(SAFETENSORS_URL).catch((e) => e);
+      expect(err).toBeDefined();
+      expect(err.status).toBe(404);
+      expect(err.errorCode).toBe("RepoNotFound");
+      stub.mockRestore();
+    });
+  });
+
+  describe("parquet", () => {
+    it("forwards same-origin cookies on hyparquet's HEAD + tail Range", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      // hyparquet's asyncBufferFromUrl issues HEAD before any Range
+      // GET, so register both methods. http.get does not match HEAD
+      // in MSW v2.
+      const handler = privateRepoHandler(PARQUET_FIXTURE);
+      server.use(
+        http.head(PARQUET_URL, handler),
+        http.get(PARQUET_URL, handler),
+      );
+
+      const metadata = await parseParquetMetadata(PARQUET_URL);
+
+      expect(fetchSpy).toHaveBeenCalled();
+      for (const call of fetchSpy.mock.calls) {
+        const init = call[1] || {};
+        // hyparquet sometimes calls fetch with no init at all when
+        // delegating through its internal `asyncBufferFromUrl` reader;
+        // the requestInit we threaded in is then merged in by hyparquet
+        // before the real network call — `init` here is the merged
+        // version and must carry the credentials we passed.
+        expect(init.credentials).toBeDefined();
+        expect(init.credentials).not.toBe("omit");
+        expect(isCookieCarrying(init.credentials)).toBe(true);
+      }
+      expect(metadata.byteLength).toBe(PARQUET_FIXTURE.length);
+    });
+  });
+
+  describe("indexed-tar", () => {
+    it("parseTarIndex forwards same-origin cookies on the sidecar GET", async () => {
+      const indexJson = JSON.stringify({
+        filesize: 32,
+        hash: "",
+        hash_lfs: "",
+        files: { "a.bin": { offset: 0, size: 4 } },
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      server.use(http.get(TAR_INDEX_URL, privateRepoHandler(Buffer.from(indexJson))));
+
+      const payload = await parseTarIndex(TAR_INDEX_URL);
+
+      expect(fetchSpy).toHaveBeenCalled();
+      for (const call of fetchSpy.mock.calls) {
+        const init = call[1] || {};
+        expect(init.credentials).not.toBe("omit");
+        expect(isCookieCarrying(init.credentials)).toBe(true);
+      }
+      expect(payload.files["a.bin"]).toBeDefined();
+    });
+
+    it("parseTarIndex surfaces the 404 when credentials are omitted", async () => {
+      const indexJson = JSON.stringify({
+        filesize: 32,
+        hash: "",
+        hash_lfs: "",
+        files: { "a.bin": { offset: 0, size: 4 } },
+      });
+      server.use(http.get(TAR_INDEX_URL, privateRepoHandler(Buffer.from(indexJson))));
+      const realFetch = globalThis.fetch;
+      const stub = vi.spyOn(globalThis, "fetch").mockImplementation((url, init) => {
+        return realFetch(url, { ...(init || {}), credentials: "omit" });
+      });
+      const err = await parseTarIndex(TAR_INDEX_URL).catch((e) => e);
+      expect(err).toBeInstanceOf(IndexedTarFetchError);
+      expect(err.status).toBe(404);
+      stub.mockRestore();
+    });
+
+    it("extractMemberBytes forwards same-origin cookies on the member Range", async () => {
+      const fakeTar = new Uint8Array(64);
+      for (let i = 0; i < 64; i++) fakeTar[i] = i;
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      server.use(http.get(TAR_URL, privateRepoHandler(Buffer.from(fakeTar))));
+
+      const bytes = await extractMemberBytes(TAR_URL, { offset: 8, size: 16 });
+
+      expect(fetchSpy).toHaveBeenCalled();
+      for (const call of fetchSpy.mock.calls) {
+        const init = call[1] || {};
+        expect(init.credentials).not.toBe("omit");
+        expect(isCookieCarrying(init.credentials)).toBe(true);
+      }
+      expect(Array.from(bytes.subarray(0, 4))).toEqual([8, 9, 10, 11]);
+    });
+  });
+
+  describe("tar-thumbnail", () => {
+    it("inherits same-origin credentials via extractMemberBytes", async () => {
+      // Build a minimal fake "tar" that contains a JPEG with a SOI
+      // marker plus enough trailing bytes to exit the EXIF parser
+      // cleanly; the strategy chain falls through to the small-image
+      // tier which then runs the canvas decoder. We only care that
+      // the underlying fetch carried credentials — the canvas path
+      // is mocked because jsdom does not decode JPEGs.
+      const jpegHead = new Uint8Array([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00,
+      ]);
+      const tar = new Uint8Array(2048);
+      tar.set(jpegHead, 0);
+      const member = { offset: 0, size: jpegHead.length, name: "img.jpg", path: "img.jpg" };
+
+      // Stub the canvas-decode pipeline — the test cares about the
+      // fetch credentials, not the bitmap result.
+      const stub = vi.spyOn(globalThis, "fetch");
+      server.use(http.get(TAR_URL, privateRepoHandler(Buffer.from(tar))));
+
+      // Force the chain through a strategy that issues the Range read.
+      // Using the EXIF strategy keeps the test cheap; even if EXIF
+      // parsing returns null, the head Range was issued — that is
+      // what the regression cares about.
+      await extractThumbnail({ tarUrl: TAR_URL, member }).catch(() => null);
+
+      expect(stub).toHaveBeenCalled();
+      for (const call of stub.mock.calls) {
+        const init = call[1] || {};
+        expect(init.credentials).not.toBe("omit");
+        expect(isCookieCarrying(init.credentials)).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The safetensors / parquet / indexed-tar / tar-thumbnail clients all hit
  `/resolve/...` directly with `fetch()` and pinned `credentials: "omit"`,
  so the SPA session cookie never reached the backend. On a private
  repo the HF-compat anti-enumeration path then returned 404 even
  though the user was authenticated — exactly the production failure
  reproduced with the `curl` pair (no cookie → 404; with `session_id`
  cookie → 206).
- All four range-read entry points now use `credentials: "same-origin"`.
  Cookies travel on the same-origin `/resolve/` hop and are dropped
  on the cross-origin redirect to S3/MinIO, so the presigned URL is
  still served with `Access-Control-Allow-Origin: *` without
  violating credentialed CORS.
- Demo seed gains two owner-only repos so the new behaviour can be
  exercised end-to-end locally:
  - `mai_lin/private-range-preview-bench` (parquet + hfutils.index tar)
  - `mai_lin/private-vision-checkpoint` (sharded safetensors + index)

## Test plan
- [x] `npx vitest run test_range_credentials.test.js` — 7 new tests pass on the fix and 5 of them fail when reverted to `credentials: "omit"`, pinning the regression in both directions.
- [x] Full UI suite: `npx vitest run` → 392/392 green.
- [ ] `make reset-and-seed` + log in as `mai_lin` and open the new private repos to confirm parquet, indexed-tar, tar-thumbnail, and safetensors previews all resolve. (Local reset is destructive and was deferred to the human reviewer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)