### PR TITLE
feat(tree): same-level name_prefix filter on /tree (issue #54)

### DIFF
--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -405,10 +405,11 @@
               </el-button>
               <el-input
                 v-model="fileSearchQuery"
-                placeholder="Search files..."
+                placeholder="Filter by name prefix..."
                 size="small"
                 class="w-full sm:w-50"
                 clearable
+                data-testid="file-list-name-prefix"
               >
                 <template #prefix>
                   <div class="i-carbon-search" />
@@ -505,7 +506,7 @@
                 they don't trigger the row navigation.
               -->
               <div
-                v-for="file in filteredFiles"
+                v-for="file in fileTree"
                 :key="file.path"
                 class="relative py-3 grid grid-cols-[auto_1fr] md:grid-cols-[auto_minmax(0,1.4fr)_minmax(0,2fr)_120px_110px] gap-3 items-center hover:bg-gray-50 dark:hover:bg-gray-700 px-2 cursor-pointer transition-colors"
               >
@@ -587,14 +588,15 @@
               </div>
 
               <div
-                v-if="filteredFiles.length === 0"
+                v-if="fileTree.length === 0"
                 class="py-12 text-center text-gray-500 dark:text-gray-400"
               >
                 <div
                   class="i-carbon-document-blank text-6xl mb-4 inline-block"
                 />
                 <p v-if="fileSearchQuery">
-                  No files match "{{ fileSearchQuery }}" on this page
+                  No files in this directory start with
+                  "{{ fileSearchQuery }}" (case-sensitive prefix)
                 </p>
                 <p v-else>No files found</p>
               </div>
@@ -1254,14 +1256,10 @@ const pathSegments = computed(() => {
   return props.currentPath ? props.currentPath.split("/").filter(Boolean) : [];
 });
 
-const filteredFiles = computed(() => {
-  if (!fileSearchQuery.value) return fileTree.value;
-
-  const query = fileSearchQuery.value.toLowerCase();
-  return fileTree.value.filter((file) =>
-    getFileName(file.path).toLowerCase().includes(query),
-  );
-});
+// `fileSearchQuery` is wired to the backend's same-level
+// `name_prefix` filter (issue #54). Filtering happens server-side
+// against LakeFS' native `prefix`, so the listing rendered by the
+// table is exactly `fileTree` — no client-side post-filter pass.
 
 // Parse tags from repo info
 const parsedTags = computed(() => {
@@ -1537,6 +1535,17 @@ async function toggleLike() {
   }
 }
 
+function activeNamePrefix() {
+  // Trim like the backend's `_normalize_name_prefix` so a whitespace-
+  // only entry never reaches the wire (response would be byte-
+  // identical to the unfiltered listing, but it would muddle the
+  // cursor-stack-reset watcher below).
+  const value = fileSearchQuery.value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
 async function loadFileTree({ resetPagination = true } = {}) {
   if (resetPagination) {
     fileListDiscoveredCursors.value = [null];
@@ -1554,6 +1563,7 @@ async function loadFileTree({ resetPagination = true } = {}) {
   let sortedEntries = [];
   const targetPage = fileListCurrentPage.value;
   const cursor = fileListDiscoveredCursors.value[targetPage - 1] ?? null;
+  const namePrefix = activeNamePrefix();
 
   try {
     const page = await repoAPI.listTreePage(
@@ -1566,6 +1576,7 @@ async function loadFileTree({ resetPagination = true } = {}) {
         recursive: false,
         limit: fileListPageSize.value,
         cursor: cursor || undefined,
+        name_prefix: namePrefix || undefined,
       },
     );
 
@@ -1805,6 +1816,7 @@ async function extendFileListDiscoveryTo(targetPageCount) {
     const lastIdx = fileListDiscoveredCursors.value.length - 1;
     const cursor = fileListDiscoveredCursors.value[lastIdx];
     if (lastIdx > 0 && cursor === null) break; // safety: should never happen
+    const namePrefix = activeNamePrefix();
     try {
       const page = await repoAPI.listTreePage(
         props.repoType,
@@ -1816,6 +1828,7 @@ async function extendFileListDiscoveryTo(targetPageCount) {
           recursive: false,
           limit: fileListPageSize.value,
           cursor: cursor || undefined,
+          name_prefix: namePrefix || undefined,
         },
       );
       if (fileListDiscoveryRunId !== myRunId) return;
@@ -2115,6 +2128,28 @@ async function deleteFolder() {
 }
 
 // Watchers
+
+// `fileSearchQuery` drives the backend's `name_prefix` filter on the
+// /tree endpoint (issue #54). Debounce keystrokes so we don't hammer
+// LakeFS while the user is typing — and always force a full reset on
+// the cursor stack, since cursors discovered with one prefix do not
+// address the same slice under another. This watcher owns the reset;
+// the loadFileTree() call below picks up the new value via
+// `activeNamePrefix()`.
+const FILE_SEARCH_DEBOUNCE_MS = 300;
+let fileSearchDebounceHandle = null;
+watch(fileSearchQuery, () => {
+  if (fileSearchDebounceHandle) {
+    clearTimeout(fileSearchDebounceHandle);
+  }
+  fileSearchDebounceHandle = setTimeout(() => {
+    fileSearchDebounceHandle = null;
+    if (activeTab.value === "files" || activeTab.value === "card") {
+      loadFileTree({ resetPagination: true });
+    }
+  }, FILE_SEARCH_DEBOUNCE_MS);
+});
+
 watch(
   () => props.currentPath,
   () => {

--- a/src/kohakuhub/api/repo/routers/tree.py
+++ b/src/kohakuhub/api/repo/routers/tree.py
@@ -43,11 +43,26 @@ TREE_DIFF_PAGE_SIZE = 1000
 TREE_COMMIT_SCAN_PAGE_SIZE = 100
 PATHS_INFO_MAX_PATHS = 1000
 PATHS_INFO_CONCURRENCY = 16
+NAME_PREFIX_MAX_LENGTH = 256
 
 
 def _normalize_repo_path(path: str) -> str:
     """Normalize a repository-relative path."""
     return path.lstrip("/").rstrip("/")
+
+
+def _normalize_name_prefix(value: str | None) -> str | None:
+    """Normalize the optional same-level name-prefix filter.
+
+    Returns the trimmed prefix, or ``None`` when the caller did not
+    supply one. Empty strings (or whitespace-only) are treated as
+    omitted so the response stays byte-identical to the unfiltered
+    listing — that matters for the HF-compat invariant in §5.1.
+    """
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
 
 
 def _format_last_modified(mtime: float | int | None) -> str | None:
@@ -484,6 +499,7 @@ async def list_repo_tree(
     expand: bool = False,
     limit: int | None = Query(default=None, ge=1),
     cursor: str | None = None,
+    name_prefix: str | None = None,
     fallback: bool = True,
     user: User | None = Depends(get_optional_user),
 ):
@@ -498,7 +514,23 @@ async def list_repo_tree(
 
     lakefs_repo = lakefs_repo_name(repo_type, repo_id)
     clean_path = _normalize_repo_path(path)
-    prefix = f"{clean_path}/" if clean_path else ""
+    base_prefix = f"{clean_path}/" if clean_path else ""
+
+    # Same-level basename-prefix filter pushed straight to LakeFS via its
+    # `prefix` arg; `delimiter='/'` is preserved when not recursive so
+    # directory rows still surface as `common_prefix` entries (see #54).
+    normalized_prefix = _normalize_name_prefix(name_prefix)
+    if normalized_prefix is not None:
+        if "/" in normalized_prefix:
+            return hf_bad_request("name_prefix must not contain '/'")
+        if len(normalized_prefix) > NAME_PREFIX_MAX_LENGTH:
+            return hf_bad_request(
+                f"name_prefix is too long (max {NAME_PREFIX_MAX_LENGTH} chars)"
+            )
+        lakefs_prefix = f"{base_prefix}{normalized_prefix}"
+    else:
+        lakefs_prefix = base_prefix
+
     default_limit = TREE_EXPAND_PAGE_SIZE if expand else TREE_PAGE_SIZE
     page_size = min(limit or default_limit, default_limit)
 
@@ -513,7 +545,7 @@ async def list_repo_tree(
         page = await fetch_lakefs_objects_page(
             lakefs_repo=lakefs_repo,
             revision=resolved_revision,
-            prefix=prefix,
+            prefix=lakefs_prefix,
             recursive=recursive,
             amount=page_size,
             after=cursor,
@@ -528,7 +560,15 @@ async def list_repo_tree(
         return hf_server_error(f"Failed to list objects: {str(error)}")
 
     page_results = page.get("results", [])
-    if clean_path and not page_results:
+    # "Directory exists but the prefix matched nothing" must stay 200 +
+    # empty list — only treat empty results as 404 when the caller did
+    # not narrow with name_prefix and is not paging into a known dir.
+    if (
+        clean_path
+        and not page_results
+        and normalized_prefix is None
+        and not cursor
+    ):
         return hf_entry_not_found(repo_id, clean_path, revision)
 
     file_paths = [

--- a/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
+++ b/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
@@ -1159,12 +1159,24 @@ describe("RepoViewer path handling", () => {
     wrapper.unmount();
   });
 
-  it("paginated empty-search placeholder reads 'No files match \"…\" on this page', not the bare 'No files found'", async () => {
+  it("name_prefix filter is server-side: the search box drives a new /tree request and renders the prefix-not-found copy when LakeFS returns []", async () => {
+    // Issue #54 — the in-memory `filteredFiles` post-filter was
+    // replaced by a server-side `name_prefix` query param so paginated
+    // listings can actually be searched. The empty-state copy must
+    // reflect the prefix semantics ("starts with", case-sensitive)
+    // rather than the previous in-memory contains-match wording.
+    const treeRequests = [];
     server.use(
       http.get(
         "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main",
-        () =>
-          jsonResponse([
+        ({ request }) => {
+          const url = new URL(request.url);
+          const params = Object.fromEntries(url.searchParams.entries());
+          treeRequests.push(params);
+          if (params.name_prefix === "zeta") {
+            return jsonResponse([]);
+          }
+          return jsonResponse([
             {
               type: "file",
               path: "alpha.txt",
@@ -1177,7 +1189,8 @@ describe("RepoViewer path handling", () => {
               size: 1,
               lastModified: "2026-04-21T13:53:39.000000Z",
             },
-          ]),
+          ]);
+        },
       ),
       http.post(
         "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
@@ -1185,17 +1198,110 @@ describe("RepoViewer path handling", () => {
       ),
     );
 
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     const wrapper = mountViewer();
     await flushPromises();
     await flushPromises();
 
-    // Search for something not on this page (since paginated search
-    // only filters the current slice). The empty-state copy must
-    // distinguish "current page" from "whole repo" so the user is
-    // not misled into thinking the file does not exist at all.
     wrapper.vm.fileSearchQuery = "zeta";
+    // The watcher debounces 300ms before firing the reload. Advance
+    // the timer so the new request goes out, then drain pending
+    // microtasks (paths-info chains off the same request id).
+    await vi.advanceTimersByTimeAsync(350);
     await flushPromises();
-    expect(wrapper.text()).toContain('No files match "zeta" on this page');
+    await flushPromises();
+    vi.useRealTimers();
+
+    // The new request must carry the prefix verbatim — case-sensitive
+    // wire form, no client-side lowercasing.
+    const prefixedReq = treeRequests.find((r) => r.name_prefix === "zeta");
+    expect(prefixedReq).toBeTruthy();
+    // Cursor must be absent — typing a new prefix resets the cursor
+    // stack so previously-discovered cursors (which addressed the
+    // unfiltered slice) cannot leak into the filtered listing.
+    expect(prefixedReq.cursor).toBeUndefined();
+    expect(wrapper.text()).toContain(
+      'No files in this directory start with "zeta"',
+    );
+
+    wrapper.unmount();
+  });
+
+  it("typing into the search box resets the cursor stack so previously-discovered cursors do not leak into the filtered listing", async () => {
+    // Cursors are minted by LakeFS for the unfiltered slice. If the
+    // SPA reused them after a `name_prefix` change, a Prev / direct-N
+    // page click would land on the wrong window of entries — which
+    // is exactly the regression the cursor-stack reset prevents.
+    const treeRequests = [];
+    server.use(
+      http.get(
+        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const params = Object.fromEntries(url.searchParams.entries());
+          treeRequests.push(params);
+          // Filtered request: empty result, simulating "no match".
+          if (params.name_prefix) {
+            return jsonResponse([]);
+          }
+          // Unfiltered: hand back a page with a next cursor so the
+          // SPA records `cursor-page-2` in its discovered-cursors
+          // stack. Subsequent filtered requests must NOT reuse it.
+          return jsonResponse(
+            [
+              {
+                type: "file",
+                path: "alpha.txt",
+                size: 1,
+                lastModified: "2026-04-21T13:53:39.000000Z",
+              },
+            ],
+            {
+              headers: {
+                Link: '<https://hub.local/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main?cursor=cursor-page-2&limit=50>; rel="next"',
+              },
+            },
+          );
+        },
+      ),
+      http.post(
+        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
+        () => jsonResponse([]),
+      ),
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const wrapper = mountViewer();
+    await flushPromises();
+    await flushPromises();
+
+    // Pager should have walked forward and discovered `cursor-page-2`
+    // (and possibly more). Pin that the SPA actually saw the cursor —
+    // otherwise the assertion below is trivially true.
+    expect(
+      treeRequests.some((r) => r.cursor === "cursor-page-2"),
+    ).toBe(true);
+
+    wrapper.vm.fileSearchQuery = "alp";
+    await vi.advanceTimersByTimeAsync(350);
+    await flushPromises();
+    await flushPromises();
+    vi.useRealTimers();
+
+    // Inspect every request issued AFTER the prefix was set: not one
+    // of them should carry the previously-discovered cursor.
+    const filteredRequests = treeRequests.filter(
+      (r) => r.name_prefix === "alp",
+    );
+    expect(filteredRequests.length).toBeGreaterThan(0);
+    for (const req of filteredRequests) {
+      expect(req.cursor).toBeUndefined();
+    }
+    // And after the watcher fires, the visible page indicator goes
+    // back to 1 — direct evidence the discovered-cursors stack was
+    // reset and the SPA did not stay on a stale page index.
+    expect(wrapper.vm.fileListCurrentPage).toBe(1);
+    expect(wrapper.vm.fileListDiscoveredCursors).toEqual([null]);
 
     wrapper.unmount();
   });

--- a/test/kohaku-hub-ui/utils/test_api.test.js
+++ b/test/kohaku-hub-ui/utils/test_api.test.js
@@ -639,6 +639,35 @@ describe("frontend API client", () => {
     );
   });
 
+  it("listTreePage forwards the name_prefix filter to the backend", async () => {
+    // Issue #54 — same-level basename filter is pushed straight to the
+    // /tree endpoint as `name_prefix`. The frontend must hand the
+    // verbatim trimmed value through (case-sensitive prefix on the
+    // wire) so LakeFS-side prefix narrowing kicks in.
+    const { apiClient, repoAPI } = await loadModules();
+    const getSpy = vi.spyOn(apiClient, "get").mockResolvedValueOnce({
+      data: [{ path: "docs/config.json" }],
+      headers: {},
+    });
+
+    const page = await repoAPI.listTreePage(
+      "model",
+      "alice",
+      "demo",
+      "main",
+      "/docs",
+      { recursive: false, limit: 50, name_prefix: "conf" },
+    );
+
+    expect(page.entries).toEqual([{ path: "docs/config.json" }]);
+    expect(getSpy).toHaveBeenCalledWith(
+      "/api/models/alice/demo/tree/main/docs",
+      {
+        params: { recursive: false, limit: 50, name_prefix: "conf" },
+      },
+    );
+  });
+
   it("fileExists resolves true on a 2xx HEAD and false on any non-2xx / error", async () => {
     const { apiClient, repoAPI } = await loadModules();
     const headSpy = vi

--- a/test/kohakuhub/api/repo/routers/test_tree_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_tree_unit.py
@@ -1172,3 +1172,355 @@ async def test_get_paths_info_handles_last_commit_lookup_failures(monkeypatch):
             "securityFileStatus": None,
         }
     ]
+
+
+def test_normalize_name_prefix_treats_blank_as_omitted():
+    # Issue #54 / §5.1: a whitespace-only `name_prefix` must be treated
+    # as omitted so the response is byte-identical to the unfiltered
+    # listing — anything else would silently change the LakeFS prefix
+    # and the downstream cursor stack.
+    assert tree_api._normalize_name_prefix(None) is None
+    assert tree_api._normalize_name_prefix("") is None
+    assert tree_api._normalize_name_prefix("   ") is None
+    assert tree_api._normalize_name_prefix("conf") == "conf"
+    assert tree_api._normalize_name_prefix("  conf  ") == "conf"
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_name_prefix_pushes_lakefs_prefix(monkeypatch):
+    request = _request("/api/models/owner/demo/tree/main/docs")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+
+    fetch_calls = []
+
+    async def _fetch(**kwargs):
+        fetch_calls.append(kwargs)
+        return {
+            "results": [
+                {
+                    "path_type": "object",
+                    "path": "docs/config.json",
+                    "size_bytes": 7,
+                    "checksum": "sha-config",
+                }
+            ],
+            "pagination": {"has_more": False},
+        }
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+    monkeypatch.setattr(tree_api, "should_use_lfs", lambda repository, path, size: False)
+
+    response = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="/docs/",
+        name_prefix="conf",
+        limit=None,
+    )
+
+    assert isinstance(response, JSONResponse)
+    # The LakeFS-side prefix is `<base>/<typed>` — that's the whole
+    # design (see issue #54 §"Approach"). The handler must not leak the
+    # raw `prefix` arg under any other name.
+    assert fetch_calls == [
+        {
+            "lakefs_repo": "lake-repo",
+            "revision": "resolved-main",
+            "prefix": "docs/conf",
+            "recursive": False,
+            "amount": tree_api.TREE_PAGE_SIZE,
+            "after": None,
+        }
+    ]
+    body = _json_body(response)
+    assert [entry["path"] for entry in body] == ["docs/config.json"]
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_name_prefix_root_path(monkeypatch):
+    request = _request("/api/models/owner/demo/tree/main")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+    fetch_calls = []
+
+    async def _fetch(**kwargs):
+        fetch_calls.append(kwargs)
+        return {"results": [], "pagination": {"has_more": False}}
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+
+    # Root path means base_prefix is "" — the LakeFS prefix is then the
+    # raw user-typed prefix, with no leading "/".
+    response = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="",
+        name_prefix="READ",
+        limit=None,
+    )
+    assert isinstance(response, JSONResponse)
+    assert fetch_calls[0]["prefix"] == "READ"
+    # Empty result at root with a prefix is 200 + [], not 404.
+    assert _json_body(response) == []
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_name_prefix_validation(monkeypatch):
+    request = _request("/api/models/owner/demo/tree/main")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+
+    # If validation passes the prefix gate, the handler will try to
+    # call fetch — wire a sentinel so an unwanted call is loud.
+    async def _explode(**kwargs):
+        raise AssertionError("LakeFS must not be called when validation fails")
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _explode)
+    monkeypatch.setattr(
+        tree_api,
+        "hf_bad_request",
+        lambda message: {"bad_request": message},
+    )
+
+    # `/` would silently turn the basename filter into a multi-segment
+    # navigation — that's a UX trap, so the wire form must reject it.
+    slash_result = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        name_prefix="docs/conf",
+        limit=None,
+    )
+    assert slash_result == {"bad_request": "name_prefix must not contain '/'"}
+
+    too_long = "a" * (tree_api.NAME_PREFIX_MAX_LENGTH + 1)
+    long_result = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        name_prefix=too_long,
+        limit=None,
+    )
+    assert "too long" in long_result["bad_request"]
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_blank_name_prefix_is_byte_identical(monkeypatch):
+    """§5.1 invariant — a whitespace-only `name_prefix` must produce the
+    same LakeFS call as omitting the parameter entirely. Without this,
+    HF clients that round-trip the query string (or proxies that
+    normalize empty strings) could accidentally narrow the listing."""
+    request = _request("/api/models/owner/demo/tree/main/docs")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+    fetch_calls = []
+
+    async def _fetch(**kwargs):
+        fetch_calls.append(kwargs)
+        return {
+            "results": [
+                {
+                    "path_type": "object",
+                    "path": "docs/intro.md",
+                    "size_bytes": 4,
+                    "checksum": "sha-intro",
+                }
+            ],
+            "pagination": {"has_more": False},
+        }
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+    monkeypatch.setattr(tree_api, "should_use_lfs", lambda repository, path, size: False)
+
+    await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="/docs",
+        name_prefix="   ",
+        limit=None,
+    )
+    assert fetch_calls[0]["prefix"] == "docs/"
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_empty_with_name_prefix_returns_200(monkeypatch):
+    """A valid directory whose name_prefix matched nothing should
+    return 200 + [] (not 404). Without this, a one-character typo in
+    the search box would render the whole UI as "directory not found"
+    even though the directory clearly exists."""
+    request = _request("/api/models/owner/demo/tree/main/docs")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+
+    async def _empty_fetch(**kwargs):
+        return {"results": [], "pagination": {"has_more": False}}
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _empty_fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+
+    # Sentinel — if the handler took the 404 path, this would clobber
+    # the JSONResponse with our marker dict. It must NOT be called.
+    monkeypatch.setattr(
+        tree_api,
+        "hf_entry_not_found",
+        lambda repo_id, path, revision: {"unexpected_404": True},
+    )
+
+    response = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="/docs",
+        name_prefix="zzz-no-such-thing",
+        limit=None,
+    )
+    assert isinstance(response, JSONResponse)
+    assert _json_body(response) == []
+    assert "link" not in {key.lower() for key in response.headers.keys()}
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_empty_path_with_cursor_no_404(monkeypatch):
+    """Paginating into a non-empty directory and landing on an empty
+    final page must not 404 — the original "entry not found" guard
+    only fires on the *first* request to a path that doesn't exist."""
+    request = _request("/api/models/owner/demo/tree/main/docs")
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+
+    async def _empty_fetch(**kwargs):
+        return {"results": [], "pagination": {"has_more": False}}
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _empty_fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+    monkeypatch.setattr(
+        tree_api,
+        "hf_entry_not_found",
+        lambda repo_id, path, revision: {"unexpected_404": True},
+    )
+
+    response = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="/docs",
+        cursor="cursor-from-previous-page",
+        limit=None,
+    )
+    assert isinstance(response, JSONResponse)
+    assert _json_body(response) == []
+
+
+@pytest.mark.asyncio
+async def test_list_repo_tree_link_header_preserves_name_prefix(monkeypatch):
+    """The Link: rel="next" cursor URL must keep `name_prefix` so
+    follow-up pages see the same filter — `_build_public_link` already
+    forwards `request.query_params`, but pin the behavior so a future
+    refactor doesn't accidentally drop it."""
+    request = _request(
+        "/api/models/owner/demo/tree/main/docs",
+        query={"name_prefix": "conf", "recursive": "false"},
+    )
+    repo = SimpleNamespace(full_id="owner/demo", private=False)
+
+    monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
+    monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
+    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+
+    async def _resolve_revision(client, lakefs_repo, revision):
+        return ("resolved-main", "branch")
+
+    monkeypatch.setattr(tree_api, "resolve_revision", _resolve_revision)
+
+    async def _fetch(**kwargs):
+        return {
+            "results": [
+                {
+                    "path_type": "object",
+                    "path": "docs/config.json",
+                    "size_bytes": 12,
+                    "checksum": "sha-config",
+                }
+            ],
+            "pagination": {"has_more": True, "next_offset": "page-2"},
+        }
+
+    monkeypatch.setattr(tree_api, "fetch_lakefs_objects_page", _fetch)
+    monkeypatch.setattr(tree_api, "_build_file_record_map", lambda repository, paths: {})
+    monkeypatch.setattr(tree_api, "should_use_lfs", lambda repository, path, size: False)
+    monkeypatch.setattr(tree_api.cfg.app, "base_url", "https://hub.local")
+
+    response = await tree_api.list_repo_tree.__wrapped__(
+        "model",
+        "owner",
+        "demo",
+        request,
+        path="/docs",
+        name_prefix="conf",
+        limit=None,
+    )
+    link_header = response.headers["link"]
+    assert "name_prefix=conf" in link_header
+    assert "cursor=page-2" in link_header


### PR DESCRIPTION
## Summary
- Adds an additive optional `name_prefix` query param to `/tree` that pushes a same-level basename-prefix filter straight to LakeFS via its native `prefix` arg, fixing the file-list search box that PR #53 broke (the in-memory filter only saw the visible page).
- Wires the existing search box in `RepoViewer.vue` through the new param: server-side filtering, debounced (300 ms), with full cursor-stack reset on every prefix change so cursors minted for the unfiltered slice cannot leak into a filtered listing.
- Defaults stay byte-identical when `name_prefix` is absent, preserving the §5.1 HF-compat invariant; validation (slash → 400, length ≤ 256) and the "valid path with zero prefix matches → 200 + []" branch are explicit, not implicit.

Closes #54.

## Backend (`api/repo/routers/tree.py`)
- `name_prefix` accepted as an optional query param. Whitespace-only is normalized to "omitted" so the wire shape never silently narrows.
- Slashes rejected via `hf_bad_request` ("would turn the basename filter into multi-segment navigation"); length > 256 rejected the same way.
- LakeFS prefix becomes `<base_prefix><name_prefix>`; `delimiter='/'` is preserved when `recursive=False`, so `common_prefix` directory rows still surface (`name_prefix=da` → returns `data/`).
- 404-on-empty guard now only fires when the caller did not narrow with `name_prefix` and is not paginating with a `cursor` — a real "directory does not exist" response is unchanged, but a zero-match prefix and a paginated empty tail page are both `200 + []`.

## Frontend (`RepoViewer.vue`)
- `filteredFiles` computed deleted; the table renders `fileTree` directly (whatever the server returned for the active prefix).
- `loadFileTree` and the discovery walker pass `activeNamePrefix()` through to `repoAPI.listTreePage` as `name_prefix`.
- New watcher on `fileSearchQuery` debounces 300 ms then triggers `loadFileTree({ resetPagination: true })`. The reset path already lives in `loadFileTree` — same code that path / branch / page-size changes use — so cursor-stack hygiene is consistent.
- Placeholder text now "Filter by name prefix..."; empty state reads "No files in this directory start with `<prefix>` (case-sensitive prefix)".

## Tests
- `test/kohakuhub/api/repo/routers/test_tree_unit.py` — 7 new cases: blank-input normalization, prefix push to LakeFS, root-path prefix handling, slash + length validation, byte-identical handling for whitespace-only input, 200 + [] for valid path with no prefix matches, 200 + [] for paginated empty tail page, and `Link: rel=\"next\"` carrying `name_prefix` forward.
- `test/kohaku-hub-ui/utils/test_api.test.js` — verifies `listTreePage` forwards `name_prefix` through to the GET request.
- `test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js` — replaces the now-obsolete in-memory filter test with a server-side flow assertion (typing fires a new `/tree` request with `name_prefix`, empty result renders the new copy), and adds a cursor-stack reset case that pre-discovers a cursor against the unfiltered listing and pins that subsequent filtered requests do not reuse it.

## Out of scope (per the issue)
- Recursive subtree search.
- Substring / glob matching (deferred; `name_glob` could be added later as a separate optional param).
- Case-insensitive matching (documented behavior is case-sensitive).
- Cloudflare Pages Functions changes — the wildcard pass-through forwards the new query param as-is.

## Test plan
- [x] `python -m pytest test/kohakuhub/api/repo/routers/test_tree_unit.py` — 17/17 pass.
- [x] `npx vitest run --config vitest.config.js` (full UI suite) — 433/433 pass.
- [ ] Manual smoke against a paginated directory: prefix narrows the listing, clearing restores it; pager + page-size selector still work in both modes; HF client `list_repo_tree` still works with `name_prefix` absent.