### PR TITLE
feat(ui/repo-file-list): swap numbered pager for HuggingFace-style Load More (issue #56)

### DIFF
--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -378,14 +378,13 @@
               </el-select>
               <span
                 class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
+                data-testid="file-list-count"
               >
-                <template v-if="fileListShowPager">
-                  Page {{ fileListCurrentPage }} ·
-                  {{ fileTree.length }} on this page
-                </template>
-                <template v-else>
-                  {{ fileTree.length }}
-                  {{ fileTree.length === 1 ? "file" : "files" }}
+                {{ fileTree.length }}
+                {{ fileTree.length === 1 ? "file" : "files" }}<template
+                  v-if="fileListHasMore"
+                >
+                  loaded
                 </template>
               </span>
             </div>
@@ -604,27 +603,32 @@
           </div>
 
           <!--
-            File-list pager. Hidden until the directory actually
-            paginates so a small repo does not see scaffolding it has
-            no use for. Cursor-based — the backend returns LakeFS'
-            opaque `next_offset` only — so the SPA discovers cursors
-            forward in the background; the pager renders real page
-            numbers (with ellipsis), a jumper input for direct
-            page-N navigation, plus First/Last for quick rewind.
+            File-list "Load more" footer. Cursor-based listings (LakeFS
+            exposes only opaque `next_offset`) don't carry a total page
+            count, so a numbered pager forced the SPA to walk every
+            page forward just to know how many buttons to render —
+            visible as buttons popping in one by one (issue #56). Load
+            More mirrors HuggingFace's pattern: append on click, no
+            background walk, no reveal animation.
+
+            Hidden when the listing is fully loaded — at that point
+            the batch-size selector has nothing to act on, since
+            changing it does not retroactively re-fetch already-loaded
+            entries (per the issue's acceptance criteria).
           -->
           <div
-            v-if="!filesLoading && fileListShowPager"
+            v-if="!filesLoading && fileListHasMore"
             class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-            data-testid="file-list-pager"
+            data-testid="file-list-footer"
           >
             <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-              <span>Per page:</span>
+              <span>Per batch:</span>
               <el-select
                 :model-value="fileListPageSize"
                 size="small"
                 class="w-24"
                 data-testid="file-list-page-size"
-                @change="changeFileListPageSize"
+                @change="changeFileListBatchSize"
               >
                 <el-option
                   v-for="size in FILE_LIST_PAGE_SIZE_OPTIONS"
@@ -633,56 +637,23 @@
                   :value="size"
                 />
               </el-select>
-              <span
-                v-if="!fileListEndDiscovered"
-                class="text-xs text-gray-400 dark:text-gray-500"
-                data-testid="file-list-discovery-hint"
-                title="Walking forward through the cursor-based listing — the page count grows as more pages are confirmed."
-              >
-                · discovering more…
+              <span class="text-xs text-gray-400 dark:text-gray-500">
+                · applies to the next click
               </span>
             </div>
-            <div class="flex items-center gap-2 flex-wrap">
-              <el-button
-                size="small"
-                :disabled="!fileListHasPrev || filesLoading"
-                data-testid="file-list-page-first"
-                @click="goToFirstFileListPage"
-                title="Jump to the first page"
-              >
-                <div class="i-carbon-skip-back inline-block mr-1" />
-                First
-              </el-button>
-              <el-pagination
-                :current-page="fileListCurrentPage"
-                :page-count="fileListPageCount"
-                :pager-count="7"
-                :disabled="filesLoading"
-                background
-                hide-on-single-page
-                layout="prev, pager, next, jumper"
-                data-testid="file-list-pagination"
-                @current-change="goToFileListPage"
-              />
-              <el-button
-                size="small"
-                :disabled="
-                  !fileListEndDiscovered ||
-                  fileListCurrentPage === fileListPageCount ||
-                  filesLoading
-                "
-                data-testid="file-list-page-last"
-                @click="goToLastFileListPage"
-                :title="
-                  fileListEndDiscovered
-                    ? 'Jump to the last page'
-                    : 'Last page is still being discovered — try again in a moment'
-                "
-              >
-                Last
-                <div class="i-carbon-skip-forward inline-block ml-1" />
-              </el-button>
-            </div>
+            <el-button
+              size="small"
+              type="primary"
+              plain
+              :loading="fileListLoadingMore"
+              :disabled="fileListLoadingMore"
+              data-testid="file-list-load-more"
+              @click="loadMoreFileTree"
+              title="Fetch and append the next batch"
+            >
+              <div class="i-carbon-add inline-block mr-1" />
+              Load more ({{ fileListPageSize }})
+            </el-button>
           </div>
         </div>
 
@@ -1088,42 +1059,22 @@ const likingInProgress = ref(false);
 const deletingFolder = ref(false);
 const fileTreeRequestId = ref(0);
 
-// Paging state for the file list. The backend exposes opaque LakeFS
-// `next_offset` cursors only — random-page jumps need every cursor to
-// be discovered up to the target page. The SPA tracks a flat array of
-// discovered cursors so direct page-N navigation, jumper input, and
-// "Last page" all work once discovery walks far enough:
-//
-//   discoveredCursors[i] = cursor TO fetch page (i+1)
-//   discoveredCursors[0] = null  (page 1 is always cursor-less)
-//
-// `endDiscovered` flips true once a fetch returns no nextCursor — at
-// that point `discoveredCursors.length` is the true total page count.
-// Until then `pageCount` reflects the highest known page; navigation
-// past it is gated until discovery walks further (extendDiscoveryTo).
+// Cursor-based "Load more" listing (issue #56). LakeFS exposes only
+// an opaque `next_offset` per response, so we cannot pre-compute a
+// total page count or randomly jump. The SPA holds:
+//   * the latest `nextCursor` returned by the backend; null/empty
+//     means "no more — listing is exhausted".
+//   * a separate `loadingMore` flag for the append path so the user
+//     sees the Load More button enter a loading state without
+//     blanking out the already-rendered listing.
+// `fileListPageSize` is reused as the batch-size knob for subsequent
+// Load More clicks — already-loaded entries are not re-fetched when
+// the user changes it (acceptance criteria from issue #56).
 const fileListPageSize = ref(DEFAULT_FILE_LIST_PAGE_SIZE);
-const fileListDiscoveredCursors = ref([null]);
-const fileListEndDiscovered = ref(false);
-const fileListCurrentPage = ref(1);
-const fileListPageCount = computed(() =>
-  Math.max(1, fileListDiscoveredCursors.value.length),
-);
-const fileListHasPrev = computed(() => fileListCurrentPage.value > 1);
-const fileListHasNext = computed(
-  () =>
-    fileListCurrentPage.value < fileListDiscoveredCursors.value.length ||
-    !fileListEndDiscovered.value,
-);
-const fileListShowPager = computed(
-  () =>
-    fileListEndDiscovered.value
-      ? fileListPageCount.value > 1
-      : fileListDiscoveredCursors.value.length > 1 ||
-        Boolean(fileListDiscoveredCursors.value[0] !== null),
-);
+const fileListNextCursor = ref(null);
+const fileListLoadingMore = ref(false);
+const fileListHasMore = computed(() => fileListNextCursor.value !== null);
 const FILE_LIST_PAGE_SIZE_OPTIONS = FILE_LIST_PAGE_SIZES;
-const FILE_LIST_DISCOVERY_MAX_PAGES = 200;
-let fileListDiscoveryRunId = 0;
 
 // Indexed-tar sibling-icon probe state. The sync `hasIndexSibling`
 // lookup runs against the loaded page first (cheap); when a `.tar`
@@ -1546,87 +1497,17 @@ function activeNamePrefix() {
   return trimmed || null;
 }
 
-async function loadFileTree({ resetPagination = true } = {}) {
-  if (resetPagination) {
-    fileListDiscoveredCursors.value = [null];
-    fileListEndDiscovered.value = false;
-    fileListCurrentPage.value = 1;
-    // Bump the discovery run id so any in-flight forward walk from a
-    // previous folder/branch/page-size aborts on its next iteration.
-    fileListDiscoveryRunId += 1;
-  }
-  filesLoading.value = true;
-  treeErrorClassification.value = null;
-  const requestId = fileTreeRequestId.value + 1;
-  fileTreeRequestId.value = requestId;
-
-  let sortedEntries = [];
-  const targetPage = fileListCurrentPage.value;
-  const cursor = fileListDiscoveredCursors.value[targetPage - 1] ?? null;
-  const namePrefix = activeNamePrefix();
-
-  try {
-    const page = await repoAPI.listTreePage(
-      props.repoType,
-      props.namespace,
-      props.name,
-      currentBranch.value,
-      props.currentPath ? `/${props.currentPath}` : "",
-      {
-        recursive: false,
-        limit: fileListPageSize.value,
-        cursor: cursor || undefined,
-        name_prefix: namePrefix || undefined,
-      },
-    );
-
-    if (requestId !== fileTreeRequestId.value) return;
-
-    sortedEntries = sortFileEntries(page.entries || []);
-    fileTree.value = sortedEntries;
-    recordDiscoveredCursor(targetPage, page.nextCursor || null);
-
-    if (sortedEntries.length === 0) {
-      return;
-    }
-  } catch (err) {
-    console.error("Failed to load file tree:", err);
-    if (requestId === fileTreeRequestId.value) {
-      fileTree.value = [];
-      // Axios interceptor in utils/api.js attaches `.classification`.
-      // Prefer it; fall back to classifying the bare error ourselves
-      // if a future refactor changes the interceptor.
-      treeErrorClassification.value =
-        err?.classification || classifyError(err);
-    }
-  } finally {
-    if (requestId === fileTreeRequestId.value) {
-      filesLoading.value = false;
-    }
-  }
-
-  if (sortedEntries.length === 0 || requestId !== fileTreeRequestId.value) {
-    return;
-  }
-
-  // Kick off background discovery on the first page load — it walks
-  // forward issuing minimal listTreePage calls so the pager can render
-  // real page numbers (and a usable Last button) on directories with
-  // hundreds of pages without making the user click Next ten times.
-  if (resetPagination) {
-    void runFileListDiscovery();
-  }
-
-  // Sibling-icon probe pass for `.tar` rows on this page that did NOT
-  // ship a sibling `.json` in the loaded entries. The probe fires
-  // strictly off the loaded slice — paths-info / expanded metadata
-  // below run in parallel and don't depend on it.
-  void probeMissingIndexedTarSiblings(sortedEntries, requestId);
+async function expandPathsInfoAndMerge(newEntries, requestId) {
+  // paths-info expansion runs only over the just-loaded slice — the
+  // already-merged entries kept their lastCommit / lfs metadata when
+  // they were first appended, so re-expanding everything every time
+  // would waste round trips on a Load More flow.
+  if (!newEntries.length) return;
 
   try {
     const pathInfoByPath = new Map();
     const pathBatches = chunkPaths(
-      sortedEntries.map((file) => file.path),
+      newEntries.map((file) => file.path),
       PATHS_INFO_BATCH_SIZE,
     );
 
@@ -1647,26 +1528,167 @@ async function loadFileTree({ resetPagination = true } = {}) {
       }
     }
 
-    fileTree.value = sortedEntries.map((file) => ({
-      ...file,
-      ...(pathInfoByPath.get(file.path) || {}),
-    }));
+    if (requestId !== fileTreeRequestId.value) return;
+
+    // Merge expanded metadata onto already-rendered entries in place
+    // so previously-loaded rows keep theirs and only the new rows
+    // pick up the freshly-resolved data.
+    const newPaths = new Set(newEntries.map((file) => file.path));
+    fileTree.value = fileTree.value.map((file) => {
+      if (!newPaths.has(file.path)) return file;
+      const expanded = pathInfoByPath.get(file.path);
+      return expanded ? { ...file, ...expanded } : file;
+    });
   } catch (err) {
     console.error("Failed to load expanded path info:", err);
   }
 }
 
-async function probeMissingIndexedTarSiblings(entries, requestId) {
-  // Reset memoized probe outcomes whenever the page slice changes —
-  // a paginate / branch-switch / path-change can introduce a new
-  // sibling that we have a "missing" answer cached for.
+async function loadFileTree({ resetPagination = true } = {}) {
+  if (resetPagination) {
+    fileListNextCursor.value = null;
+  }
+  filesLoading.value = true;
+  treeErrorClassification.value = null;
+  const requestId = fileTreeRequestId.value + 1;
+  fileTreeRequestId.value = requestId;
+
+  let sortedEntries = [];
+  const namePrefix = activeNamePrefix();
+
+  try {
+    const page = await repoAPI.listTreePage(
+      props.repoType,
+      props.namespace,
+      props.name,
+      currentBranch.value,
+      props.currentPath ? `/${props.currentPath}` : "",
+      {
+        recursive: false,
+        limit: fileListPageSize.value,
+        // Initial load always starts from cursor-less; Load More uses
+        // a dedicated function that does not go through here.
+        name_prefix: namePrefix || undefined,
+      },
+    );
+
+    if (requestId !== fileTreeRequestId.value) return;
+
+    sortedEntries = sortFileEntries(page.entries || []);
+    fileTree.value = sortedEntries;
+    fileListNextCursor.value = page.nextCursor || null;
+
+    if (sortedEntries.length === 0) {
+      return;
+    }
+  } catch (err) {
+    console.error("Failed to load file tree:", err);
+    if (requestId === fileTreeRequestId.value) {
+      fileTree.value = [];
+      fileListNextCursor.value = null;
+      // Axios interceptor in utils/api.js attaches `.classification`.
+      // Prefer it; fall back to classifying the bare error ourselves
+      // if a future refactor changes the interceptor.
+      treeErrorClassification.value =
+        err?.classification || classifyError(err);
+    }
+  } finally {
+    if (requestId === fileTreeRequestId.value) {
+      filesLoading.value = false;
+    }
+  }
+
+  if (sortedEntries.length === 0 || requestId !== fileTreeRequestId.value) {
+    return;
+  }
+
+  // Sibling-icon probe and paths-info expansion both operate on the
+  // just-loaded slice. The probe is fire-and-forget; paths-info
+  // awaits so the merged metadata replaces the bare rows in one
+  // reactive update.
+  resetIndexedTarProbeMemo();
+  void probeMissingIndexedTarSiblings(sortedEntries, requestId);
+  await expandPathsInfoAndMerge(sortedEntries, requestId);
+}
+
+async function loadMoreFileTree() {
+  // Fetches the next batch using the latest `nextCursor` and appends
+  // it to the existing fileTree. Disabled while in flight so a double
+  // click cannot double-append.
+  if (fileListLoadingMore.value || filesLoading.value) return;
+  if (!fileListNextCursor.value) return;
+
+  fileListLoadingMore.value = true;
+  const requestId = fileTreeRequestId.value + 1;
+  fileTreeRequestId.value = requestId;
+
+  let appendedEntries = [];
+  const cursor = fileListNextCursor.value;
+  const namePrefix = activeNamePrefix();
+
+  try {
+    const page = await repoAPI.listTreePage(
+      props.repoType,
+      props.namespace,
+      props.name,
+      currentBranch.value,
+      props.currentPath ? `/${props.currentPath}` : "",
+      {
+        recursive: false,
+        limit: fileListPageSize.value,
+        cursor,
+        name_prefix: namePrefix || undefined,
+      },
+    );
+
+    if (requestId !== fileTreeRequestId.value) return;
+
+    // Sort across the union so the appended rows respect the same
+    // directories-first / alphabetical ordering as the initial load.
+    appendedEntries = page.entries || [];
+    fileTree.value = sortFileEntries([
+      ...fileTree.value,
+      ...appendedEntries,
+    ]);
+    fileListNextCursor.value = page.nextCursor || null;
+  } catch (err) {
+    console.error("Failed to load more file tree entries:", err);
+    // A failed Load More leaves the already-rendered listing alone —
+    // the user can retry by clicking again. We deliberately do NOT
+    // surface this through `treeErrorClassification`, which is a
+    // listing-wide failure indicator.
+  } finally {
+    if (requestId === fileTreeRequestId.value) {
+      fileListLoadingMore.value = false;
+    }
+  }
+
+  if (!appendedEntries.length || requestId !== fileTreeRequestId.value) {
+    return;
+  }
+
+  void probeMissingIndexedTarSiblings(appendedEntries, requestId);
+  await expandPathsInfoAndMerge(appendedEntries, requestId);
+}
+
+function resetIndexedTarProbeMemo() {
   pendingIndexedTarProbeId += 1;
-  const probeId = pendingIndexedTarProbeId;
   confirmedIndexedTars.value = new Set();
   rejectedIndexedTars.value = new Set();
+}
 
-  const pageHasSibling = new Set(
-    entries
+async function probeMissingIndexedTarSiblings(entries, requestId) {
+  // Probe just the supplied entries; the memoized confirmed/rejected
+  // sets are kept across Load More batches so previously-resolved
+  // siblings stay sticky. (They are reset by `loadFileTree` on a
+  // genuine listing reset — branch / path / name_prefix change.)
+  const probeId = pendingIndexedTarProbeId;
+
+  // Already-rendered files satisfy the sibling check too — Load More
+  // can introduce a `.tar` whose `.json` was loaded in a prior batch,
+  // and vice versa.
+  const loadedSiblings = new Set(
+    fileTree.value
       .filter((entry) => entry && entry.type !== "directory")
       .map((entry) => entry.path),
   );
@@ -1676,7 +1698,9 @@ async function probeMissingIndexedTarSiblings(entries, requestId) {
     if (!entry || entry.type === "directory") continue;
     const sidecar = tarSidecarPath(entry.path);
     if (!sidecar) continue;
-    if (pageHasSibling.has(sidecar)) continue;
+    if (loadedSiblings.has(sidecar)) continue;
+    if (confirmedIndexedTars.value.has(entry.path)) continue;
+    if (rejectedIndexedTars.value.has(entry.path)) continue;
     pending.push({ tarPath: entry.path, sidecar });
   }
   if (pending.length === 0) return;
@@ -1711,142 +1735,15 @@ async function probeMissingIndexedTarSiblings(entries, requestId) {
   );
 }
 
-function changeFileListPageSize(nextSize) {
+function changeFileListBatchSize(nextSize) {
   const n = Number(nextSize);
   if (!FILE_LIST_PAGE_SIZE_OPTIONS.includes(n)) return;
   if (n === fileListPageSize.value) return;
   fileListPageSize.value = n;
   writeFileListPageSize(n);
-  // Resetting to page 1 keeps cursor semantics meaningful — the
-  // previously-discovered cursors were minted at the old page size
-  // and would not address the same slice with the new one.
-  loadFileTree({ resetPagination: true });
-}
-
-function recordDiscoveredCursor(pageIndex, nextCursor) {
-  // pageIndex is the 1-based page we just loaded — its nextCursor is
-  // the cursor required to fetch page (pageIndex + 1). Store it at
-  // index `pageIndex` so discovered[i] addresses page i+1.
-  if (nextCursor) {
-    if (fileListDiscoveredCursors.value.length === pageIndex) {
-      fileListDiscoveredCursors.value = [
-        ...fileListDiscoveredCursors.value,
-        nextCursor,
-      ];
-    } else if (
-      fileListDiscoveredCursors.value[pageIndex] !== nextCursor &&
-      fileListDiscoveredCursors.value.length > pageIndex
-    ) {
-      // The backend handed back a different cursor than we had cached
-      // — overwrite. Happens after a delete or tree rewrite landed on
-      // top of an already-discovered set.
-      const next = [...fileListDiscoveredCursors.value];
-      next[pageIndex] = nextCursor;
-      fileListDiscoveredCursors.value = next;
-    }
-  } else if (
-    fileListDiscoveredCursors.value.length === pageIndex
-  ) {
-    fileListEndDiscovered.value = true;
-  }
-}
-
-async function goToFileListPage(targetPage) {
-  if (filesLoading.value) return;
-  const target = Number(targetPage);
-  if (!Number.isFinite(target) || target < 1) return;
-  if (target === fileListCurrentPage.value) return;
-  if (target > fileListDiscoveredCursors.value.length) {
-    // The user wants a page we haven't discovered yet — extend forward
-    // up to the requested index, then continue. Soft-bound by the
-    // discovery cap so a giant directory does not block the click
-    // forever.
-    await extendFileListDiscoveryTo(target);
-    if (target > fileListDiscoveredCursors.value.length) {
-      // Couldn't reach it — clamp to the highest known page.
-      fileListCurrentPage.value = fileListDiscoveredCursors.value.length;
-    } else {
-      fileListCurrentPage.value = target;
-    }
-  } else {
-    fileListCurrentPage.value = target;
-  }
-  await loadFileTree({ resetPagination: false });
-}
-
-function goToFirstFileListPage() {
-  if (filesLoading.value) return;
-  if (fileListCurrentPage.value === 1) return;
-  fileListCurrentPage.value = 1;
-  loadFileTree({ resetPagination: false });
-}
-
-async function goToLastFileListPage() {
-  if (filesLoading.value) return;
-  if (!fileListEndDiscovered.value) {
-    // Background discovery hasn't reached the end yet; finish the walk
-    // synchronously so "Last" lands on the real last page rather than
-    // the highest known one.
-    await extendFileListDiscoveryTo(FILE_LIST_DISCOVERY_MAX_PAGES);
-  }
-  const last = fileListDiscoveredCursors.value.length;
-  if (last <= 1 || fileListCurrentPage.value === last) return;
-  fileListCurrentPage.value = last;
-  loadFileTree({ resetPagination: false });
-}
-
-async function runFileListDiscovery() {
-  await extendFileListDiscoveryTo(FILE_LIST_DISCOVERY_MAX_PAGES);
-}
-
-async function extendFileListDiscoveryTo(targetPageCount) {
-  // Walk forward from the highest discovered cursor until we either
-  // hit the end or own at least `targetPageCount` cursors. Each step
-  // issues a listTreePage with the same page size — the entries are
-  // discarded; only the next cursor is recorded. Best-effort: any
-  // error stops the loop without surfacing to the user, since the
-  // pager can still navigate to pages we already know about.
-  const myRunId = ++fileListDiscoveryRunId;
-  while (
-    fileListDiscoveryRunId === myRunId &&
-    !fileListEndDiscovered.value &&
-    fileListDiscoveredCursors.value.length < targetPageCount &&
-    fileListDiscoveredCursors.value.length < FILE_LIST_DISCOVERY_MAX_PAGES
-  ) {
-    const lastIdx = fileListDiscoveredCursors.value.length - 1;
-    const cursor = fileListDiscoveredCursors.value[lastIdx];
-    if (lastIdx > 0 && cursor === null) break; // safety: should never happen
-    const namePrefix = activeNamePrefix();
-    try {
-      const page = await repoAPI.listTreePage(
-        props.repoType,
-        props.namespace,
-        props.name,
-        currentBranch.value,
-        props.currentPath ? `/${props.currentPath}` : "",
-        {
-          recursive: false,
-          limit: fileListPageSize.value,
-          cursor: cursor || undefined,
-          name_prefix: namePrefix || undefined,
-        },
-      );
-      if (fileListDiscoveryRunId !== myRunId) return;
-      if (page.nextCursor) {
-        fileListDiscoveredCursors.value = [
-          ...fileListDiscoveredCursors.value,
-          page.nextCursor,
-        ];
-      } else {
-        fileListEndDiscovered.value = true;
-        return;
-      }
-    } catch {
-      // Swallow — discovery is best-effort. The user can still
-      // navigate to known pages.
-      return;
-    }
-  }
+  // Per the issue's acceptance criteria, the new batch size applies
+  // only to the next Load More click — already-loaded entries are
+  // not refetched, so no `loadFileTree` here.
 }
 
 async function loadReadme() {

--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -387,41 +387,6 @@
                   loaded
                 </template>
               </span>
-              <!--
-                Per-batch selector lives in the header next to the
-                count rather than down by the Load More button — that
-                way it's discoverable without scrolling past a long
-                listing, and the visual relationship "this controls
-                the next fetch" is established up front. Visible only
-                while more is fetchable; changing the value persists
-                to localStorage but does not refetch (issue #56).
-              -->
-              <template v-if="fileListHasMore">
-                <span
-                  class="text-sm text-gray-400 dark:text-gray-500 whitespace-nowrap"
-                >
-                  ·
-                </span>
-                <span
-                  class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
-                >
-                  Per batch:
-                </span>
-                <el-select
-                  :model-value="fileListPageSize"
-                  size="small"
-                  class="w-20"
-                  data-testid="file-list-page-size"
-                  @change="changeFileListBatchSize"
-                >
-                  <el-option
-                    v-for="size in FILE_LIST_PAGE_SIZE_OPTIONS"
-                    :key="size"
-                    :label="String(size)"
-                    :value="size"
-                  />
-                </el-select>
-              </template>
             </div>
 
             <div
@@ -1013,12 +978,13 @@ import {
   getPreviewKind,
 } from "@/utils/file-preview";
 import { tarSidecarPath } from "@/utils/indexed-tar";
-import {
-  DEFAULT_PAGE_SIZE as DEFAULT_FILE_LIST_PAGE_SIZE,
-  VALID_PAGE_SIZES as FILE_LIST_PAGE_SIZES,
-  readPageSize as readFileListPageSize,
-  writePageSize as writeFileListPageSize,
-} from "@/utils/repo-list-pagination";
+
+// Fixed batch size for the file-list Load More button. The earlier
+// numbered-pager UI had a 50/100/200 selector, but with Load More the
+// affordance "click to extend" is the entire knob — a per-batch
+// dropdown collided with the surrounding header chrome and earned
+// nothing in return, so it was removed (issue #56 follow-up).
+const FILE_LIST_BATCH_SIZE = 50;
 
 /**
  * @typedef {Object} Props
@@ -1076,14 +1042,9 @@ const fileTreeRequestId = ref(0);
 //   * a separate `loadingMore` flag for the append path so the user
 //     sees the Load More button enter a loading state without
 //     blanking out the already-rendered listing.
-// `fileListPageSize` is reused as the batch-size knob for subsequent
-// Load More clicks — already-loaded entries are not re-fetched when
-// the user changes it (acceptance criteria from issue #56).
-const fileListPageSize = ref(DEFAULT_FILE_LIST_PAGE_SIZE);
 const fileListNextCursor = ref(null);
 const fileListLoadingMore = ref(false);
 const fileListHasMore = computed(() => fileListNextCursor.value !== null);
-const FILE_LIST_PAGE_SIZE_OPTIONS = FILE_LIST_PAGE_SIZES;
 
 // Indexed-tar sibling-icon probe state. The sync `hasIndexSibling`
 // lookup runs against the loaded page first (cheap); when a `.tar`
@@ -1574,7 +1535,7 @@ async function loadFileTree({ resetPagination = true } = {}) {
       props.currentPath ? `/${props.currentPath}` : "",
       {
         recursive: false,
-        limit: fileListPageSize.value,
+        limit: FILE_LIST_BATCH_SIZE,
         // Initial load always starts from cursor-less; Load More uses
         // a dedicated function that does not go through here.
         name_prefix: namePrefix || undefined,
@@ -1644,7 +1605,7 @@ async function loadMoreFileTree() {
       props.currentPath ? `/${props.currentPath}` : "",
       {
         recursive: false,
-        limit: fileListPageSize.value,
+        limit: FILE_LIST_BATCH_SIZE,
         cursor,
         name_prefix: namePrefix || undefined,
       },
@@ -1742,17 +1703,6 @@ async function probeMissingIndexedTarSiblings(entries, requestId) {
       }
     }),
   );
-}
-
-function changeFileListBatchSize(nextSize) {
-  const n = Number(nextSize);
-  if (!FILE_LIST_PAGE_SIZE_OPTIONS.includes(n)) return;
-  if (n === fileListPageSize.value) return;
-  fileListPageSize.value = n;
-  writeFileListPageSize(n);
-  // Per the issue's acceptance criteria, the new batch size applies
-  // only to the next Load More click — already-loaded entries are
-  // not refetched, so no `loadFileTree` here.
 }
 
 async function loadReadme() {
@@ -2103,7 +2053,6 @@ watch(
 
 // Lifecycle
 onMounted(async () => {
-  fileListPageSize.value = readFileListPageSize();
   await loadRepoInfo();
 
   if (activeTab.value === "files") {

--- a/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
+++ b/src/kohaku-hub-ui/src/components/repo/RepoViewer.vue
@@ -387,6 +387,41 @@
                   loaded
                 </template>
               </span>
+              <!--
+                Per-batch selector lives in the header next to the
+                count rather than down by the Load More button — that
+                way it's discoverable without scrolling past a long
+                listing, and the visual relationship "this controls
+                the next fetch" is established up front. Visible only
+                while more is fetchable; changing the value persists
+                to localStorage but does not refetch (issue #56).
+              -->
+              <template v-if="fileListHasMore">
+                <span
+                  class="text-sm text-gray-400 dark:text-gray-500 whitespace-nowrap"
+                >
+                  ·
+                </span>
+                <span
+                  class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
+                >
+                  Per batch:
+                </span>
+                <el-select
+                  :model-value="fileListPageSize"
+                  size="small"
+                  class="w-20"
+                  data-testid="file-list-page-size"
+                  @change="changeFileListBatchSize"
+                >
+                  <el-option
+                    v-for="size in FILE_LIST_PAGE_SIZE_OPTIONS"
+                    :key="size"
+                    :label="String(size)"
+                    :value="size"
+                  />
+                </el-select>
+              </template>
             </div>
 
             <div
@@ -603,56 +638,30 @@
           </div>
 
           <!--
-            File-list "Load more" footer. Cursor-based listings (LakeFS
-            exposes only opaque `next_offset`) don't carry a total page
-            count, so a numbered pager forced the SPA to walk every
-            page forward just to know how many buttons to render —
-            visible as buttons popping in one by one (issue #56). Load
-            More mirrors HuggingFace's pattern: append on click, no
-            background walk, no reveal animation.
+            "Load more" button — centered, plain, mirroring the
+            commit-history "Load More Commits" affordance below. We
+            switched away from a numbered pager because the cursor-
+            only LakeFS list API gives no total page count and the
+            old pager had to walk every page forward just to render
+            its buttons (issue #56). The per-batch selector that
+            controls the next click's `limit` lives up in the header
+            next to the count, not here.
 
-            Hidden when the listing is fully loaded — at that point
-            the batch-size selector has nothing to act on, since
-            changing it does not retroactively re-fetch already-loaded
-            entries (per the issue's acceptance criteria).
+            Hidden when the listing is exhausted — at that point
+            there is nothing to load.
           -->
           <div
             v-if="!filesLoading && fileListHasMore"
-            class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-            data-testid="file-list-footer"
+            class="text-center pt-4"
           >
-            <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-              <span>Per batch:</span>
-              <el-select
-                :model-value="fileListPageSize"
-                size="small"
-                class="w-24"
-                data-testid="file-list-page-size"
-                @change="changeFileListBatchSize"
-              >
-                <el-option
-                  v-for="size in FILE_LIST_PAGE_SIZE_OPTIONS"
-                  :key="size"
-                  :label="String(size)"
-                  :value="size"
-                />
-              </el-select>
-              <span class="text-xs text-gray-400 dark:text-gray-500">
-                · applies to the next click
-              </span>
-            </div>
             <el-button
-              size="small"
-              type="primary"
-              plain
               :loading="fileListLoadingMore"
               :disabled="fileListLoadingMore"
+              plain
               data-testid="file-list-load-more"
               @click="loadMoreFileTree"
-              title="Fetch and append the next batch"
             >
-              <div class="i-carbon-add inline-block mr-1" />
-              Load more ({{ fileListPageSize }})
+              Load More Files
             </el-button>
           </div>
         </div>

--- a/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
+++ b/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
@@ -631,12 +631,9 @@ describe("RepoViewer path handling", () => {
     expect(observed).toHaveLength(1);
     expect(observed[0]).toEqual({ limit: "50", cursor: null });
     expect(wrapper.text()).toContain("a-first.txt");
-    // Load More button + per-batch selector both surface because the
-    // response carried a `Link: rel="next"` cursor.
+    // Load More button surfaces because the response carried a
+    // `Link: rel="next"` cursor.
     expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
-      true,
-    );
-    expect(wrapper.find('[data-testid="file-list-page-size"]').exists()).toBe(
       true,
     );
     // Count copy carries the "loaded" suffix while more is available.
@@ -715,23 +712,21 @@ describe("RepoViewer path handling", () => {
     // Both entries are rendered — Load More appended, did not replace.
     expect(wrapper.text()).toContain("a-first.txt");
     expect(wrapper.text()).toContain("z-last.txt");
-    // Tail batch arrived → Load More button + per-batch selector
-    // both removed (nothing left to fetch, nothing to configure).
+    // Tail batch arrived → Load More button removed (nothing to fetch).
     expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
-      false,
-    );
-    expect(wrapper.find('[data-testid="file-list-page-size"]').exists()).toBe(
       false,
     );
 
     wrapper.unmount();
   });
 
-  it("changing the batch-size selector persists the choice and applies to the next Load More click — already-loaded entries stay in place", async () => {
-    // Acceptance criterion from issue #56: changing the batch-size
-    // selector does NOT re-fetch the listing. The existing rows stay
-    // rendered; the new value only shows up as `limit=` on the next
-    // Load More click.
+  it("every Load More click sends limit=50 — the per-batch selector was removed in favor of a single fixed batch", async () => {
+    // The earlier numbered-pager UI had a 50/100/200 selector. With
+    // Load More the affordance "click to extend" carries the entire
+    // knob, so the selector was dropped (it visually collided with
+    // the surrounding header chrome). Pin the constant batch size on
+    // the wire so a future regression doesn't silently re-introduce
+    // a configurable size without the UI to drive it.
     const observed = [];
     server.use(
       http.get(
@@ -747,7 +742,7 @@ describe("RepoViewer path handling", () => {
               [
                 {
                   type: "file",
-                  path: "catalog/a-first.txt",
+                  path: "catalog/a.txt",
                   size: 1,
                   lastModified: "2026-04-21T13:53:39.000000Z",
                 },
@@ -762,7 +757,7 @@ describe("RepoViewer path handling", () => {
           return jsonResponse([
             {
               type: "file",
-              path: "catalog/z-last.txt",
+              path: "catalog/m.txt",
               size: 1,
               lastModified: "2026-04-21T13:53:39.000000Z",
             },
@@ -779,36 +774,18 @@ describe("RepoViewer path handling", () => {
     await flushPromises();
     await flushPromises();
 
-    expect(observed).toEqual([{ limit: "50", cursor: null }]);
-    expect(wrapper.text()).toContain("a-first.txt");
-
-    // Change the batch size. The selector renders as a stub here —
-    // drive the change handler directly the same way the existing
-    // page-size widget tests do (the el-select stub doesn't render
-    // real <option>s in jsdom).
-    wrapper.vm.changeFileListBatchSize(100);
-    await flushPromises();
-    await flushPromises();
-
-    // Crucially: NO new request fired — the change is queued for
-    // the next Load More click.
-    expect(observed).toEqual([{ limit: "50", cursor: null }]);
-    // Already-loaded row is still rendered — change did not blank
-    // the listing or trigger a reset.
-    expect(wrapper.text()).toContain("a-first.txt");
-    expect(localStorage.getItem("kohaku-repo-file-list-page-size")).toBe(
-      "100",
-    );
-
-    // Now the Load More click goes out with the new limit.
     await wrapper.find('[data-testid="file-list-load-more"]').trigger("click");
     await flushPromises();
     await flushPromises();
+
     expect(observed).toEqual([
       { limit: "50", cursor: null },
-      { limit: "100", cursor: "cursor-2" },
+      { limit: "50", cursor: "cursor-2" },
     ]);
-    expect(wrapper.text()).toContain("z-last.txt");
+    // No batch-size widget renders in either state.
+    expect(wrapper.find('[data-testid="file-list-page-size"]').exists()).toBe(
+      false,
+    );
 
     wrapper.unmount();
   });

--- a/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
+++ b/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
@@ -586,22 +586,80 @@ describe("RepoViewer path handling", () => {
     wrapper.unmount();
   });
 
-  it("paginates the file list: defaults to 50/page, advances via the cursor in Link rel=next, and walks back via First/Prev", async () => {
-    // Two-page directory. Backend hands a `Link: rel=next` header with
-    // a cursor on page 1; the SPA must request the same path with that
-    // cursor for page 2 and stop following on the empty-cursor response.
-    let page1Calls = 0;
-    let page2Calls = 0;
+  it("initial fetch defaults to limit=50 (no cursor) and renders the Load More footer when the response carries a Link rel=next cursor", async () => {
+    // Acceptance criterion from issue #56: the first /tree request
+    // never carries a cursor — random-page jumps were dropped along
+    // with the numbered pager.
+    const observed = [];
+    server.use(
+      http.get(
+        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
+        ({ request }) => {
+          const url = new URL(request.url);
+          observed.push({
+            limit: url.searchParams.get("limit"),
+            cursor: url.searchParams.get("cursor"),
+          });
+          return jsonResponse(
+            [
+              {
+                type: "file",
+                path: "catalog/a-first.txt",
+                size: 1,
+                lastModified: "2026-04-21T13:53:39.000000Z",
+              },
+            ],
+            {
+              headers: {
+                Link: '<https://hub.test/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog?recursive=false&limit=50&cursor=cursor-2>; rel="next"',
+              },
+            },
+          );
+        },
+      ),
+      http.post(
+        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
+        () => jsonResponse([]),
+      ),
+    );
+
+    const wrapper = mountViewer({ currentPath: "catalog" });
+    await flushPromises();
+    await flushPromises();
+
+    // Single round trip on mount — no background walk follows.
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toEqual({ limit: "50", cursor: null });
+    expect(wrapper.text()).toContain("a-first.txt");
+    // Footer becomes visible because nextCursor was parsed off Link.
+    expect(wrapper.find('[data-testid="file-list-footer"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
+      true,
+    );
+    // Count copy carries the "loaded" suffix while more is available.
+    expect(wrapper.find('[data-testid="file-list-count"]').text()).toContain(
+      "loaded",
+    );
+
+    wrapper.unmount();
+  });
+
+  it("Load More appends the next cursor's batch — entries union, dropped pager state, hides footer when the listing is exhausted", async () => {
+    // Two-batch listing. The first response carries a cursor; the
+    // second is the tail (no Link). The Load More click must pass
+    // that cursor as `cursor=...` and append the new entries to the
+    // already-rendered ones (HuggingFace-style append-on-click).
+    const observed = [];
     server.use(
       http.get(
         "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
         ({ request }) => {
           const url = new URL(request.url);
           const cursor = url.searchParams.get("cursor");
-          const limit = url.searchParams.get("limit");
-          expect(limit).toBe("50");
+          observed.push(cursor);
           if (!cursor) {
-            page1Calls += 1;
             return jsonResponse(
               [
                 {
@@ -619,7 +677,8 @@ describe("RepoViewer path handling", () => {
             );
           }
           expect(cursor).toBe("cursor-2");
-          page2Calls += 1;
+          // Tail batch — no Link, so nextCursor flips to null and the
+          // footer should disappear after this response is processed.
           return jsonResponse([
             {
               type: "file",
@@ -639,58 +698,49 @@ describe("RepoViewer path handling", () => {
     const wrapper = mountViewer({ currentPath: "catalog" });
     await flushPromises();
     await flushPromises();
-    await flushPromises();
 
-    expect(page1Calls).toBeGreaterThanOrEqual(1);
-    expect(wrapper.find('[data-testid="file-list-pager"]').exists()).toBe(true);
     expect(wrapper.text()).toContain("a-first.txt");
     expect(wrapper.text()).not.toContain("z-last.txt");
-    expect(wrapper.text()).toContain("Page 1");
 
-    // Background discovery walked forward and confirmed page 2 is the
-    // tail; the pager's Next + page-2 buttons are now usable.
-    const nextBtn = wrapper.find('[data-el-pagination-next="true"]');
-    expect(nextBtn.exists()).toBe(true);
-    await nextBtn.trigger("click");
+    const loadMore = wrapper.find('[data-testid="file-list-load-more"]');
+    expect(loadMore.exists()).toBe(true);
+    await loadMore.trigger("click");
     await flushPromises();
     await flushPromises();
 
-    expect(page2Calls).toBeGreaterThanOrEqual(1);
-    expect(wrapper.text()).toContain("z-last.txt");
-    expect(wrapper.text()).not.toContain("a-first.txt");
-    expect(wrapper.text()).toContain("Page 2");
-    // Page 2 was the tail (no Link rel=next) and discovery confirmed
-    // it — Next disables itself.
-    expect(
-      wrapper
-        .find('[data-el-pagination-next="true"]')
-        .attributes("disabled"),
-    ).toBeDefined();
-
-    // Prev re-issues the cursor-less first-page request (backend can't
-    // seek backwards, so we always re-fetch).
-    await wrapper.find('[data-el-pagination-prev="true"]').trigger("click");
-    await flushPromises();
-    await flushPromises();
+    // Two requests total: the initial cursor-less load, then the
+    // cursor=cursor-2 click. No background walk in between.
+    expect(observed).toEqual([null, "cursor-2"]);
+    // Both entries are rendered — Load More appended, did not replace.
     expect(wrapper.text()).toContain("a-first.txt");
-    expect(wrapper.text()).toContain("Page 1");
+    expect(wrapper.text()).toContain("z-last.txt");
+    // Tail batch arrived → footer + Load More button gone.
+    expect(wrapper.find('[data-testid="file-list-footer"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
+      false,
+    );
 
     wrapper.unmount();
   });
 
-  it("changing the page-size selector resets to page 1, persists the choice in localStorage, and re-fetches with the new limit", async () => {
+  it("changing the batch-size selector persists the choice and applies to the next Load More click — already-loaded entries stay in place", async () => {
+    // Acceptance criterion from issue #56: changing the batch-size
+    // selector does NOT re-fetch the listing. The existing rows stay
+    // rendered; the new value only shows up as `limit=` on the next
+    // Load More click.
     const observed = [];
     server.use(
       http.get(
         "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
         ({ request }) => {
           const url = new URL(request.url);
-          const cursor = url.searchParams.get("cursor");
           observed.push({
             limit: url.searchParams.get("limit"),
-            cursor,
+            cursor: url.searchParams.get("cursor"),
           });
-          if (!cursor) {
+          if (!url.searchParams.get("cursor")) {
             return jsonResponse(
               [
                 {
@@ -707,8 +757,6 @@ describe("RepoViewer path handling", () => {
               },
             );
           }
-          // Tail page — no Link header so background discovery
-          // terminates instead of looping the same cursor forever.
           return jsonResponse([
             {
               type: "file",
@@ -729,326 +777,47 @@ describe("RepoViewer path handling", () => {
     await flushPromises();
     await flushPromises();
 
-    // Default first-page request uses limit=50, no cursor.
-    expect(observed[0]).toEqual({ limit: "50", cursor: null });
+    expect(observed).toEqual([{ limit: "50", cursor: null }]);
+    expect(wrapper.text()).toContain("a-first.txt");
 
-    const select = wrapper.find('[data-testid="file-list-page-size"]');
-    expect(select.exists()).toBe(true);
-
-    // ElSelect renders as a stub here — drive the change handler
-    // directly (the el-select stub doesn't render real <option>s in
-    // jsdom). Mirrors how page-size widgets are exercised elsewhere
-    // in the suite.
-    const componentVm = wrapper.vm;
-    componentVm.changeFileListPageSize(100);
+    // Change the batch size. The selector renders as a stub here —
+    // drive the change handler directly the same way the existing
+    // page-size widget tests do (the el-select stub doesn't render
+    // real <option>s in jsdom).
+    wrapper.vm.changeFileListBatchSize(100);
     await flushPromises();
     await flushPromises();
 
-    // New foreground fetch lands with the new limit AND no cursor —
-    // switching size resets pagination because the previously-discovered
-    // cursors were minted at the old page size and don't address the
-    // same slice anymore. (The very last call is the discovery walk's
-    // page-2 probe; we want the first call AFTER the size change.)
-    const postChange = observed.find(
-      (entry, idx) =>
-        idx > 0 && entry.limit === "100" && entry.cursor === null,
-    );
-    expect(postChange).toBeDefined();
+    // Crucially: NO new request fired — the change is queued for
+    // the next Load More click.
+    expect(observed).toEqual([{ limit: "50", cursor: null }]);
+    // Already-loaded row is still rendered — change did not blank
+    // the listing or trigger a reset.
+    expect(wrapper.text()).toContain("a-first.txt");
     expect(localStorage.getItem("kohaku-repo-file-list-page-size")).toBe(
       "100",
     );
 
-    wrapper.unmount();
-  });
-
-  it("First / Last / page-N / jumper navigate a multi-page directory through discovered cursors", async () => {
-    // Three-page directory; the SPA's discovery walks forward in the
-    // background after the initial page-1 fetch so the pager can
-    // surface a real total + numbered page buttons + a Last button.
-    let calls = 0;
-    server.use(
-      http.get(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
-        ({ request }) => {
-          calls += 1;
-          const url = new URL(request.url);
-          const cursor = url.searchParams.get("cursor");
-          if (!cursor) {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/a.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-2>; rel="next"',
-                },
-              },
-            );
-          }
-          if (cursor === "cursor-2") {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/m.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-3>; rel="next"',
-                },
-              },
-            );
-          }
-          return jsonResponse([
-            {
-              type: "file",
-              path: "catalog/z.txt",
-              size: 1,
-              lastModified: "2026-04-21T13:53:39.000000Z",
-            },
-          ]);
-        },
-      ),
-      http.post(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
-        () => jsonResponse([]),
-      ),
-    );
-
-    const wrapper = mountViewer({ currentPath: "catalog" });
-    // Page 1 fetch + discovery walk + paths-info — flush enough times
-    // for all of them to settle before assertions read the pager.
+    // Now the Load More click goes out with the new limit.
+    await wrapper.find('[data-testid="file-list-load-more"]').trigger("click");
     await flushPromises();
     await flushPromises();
-    await flushPromises();
-    await flushPromises();
-
-    // Discovery has confirmed all three pages.
-    const pagerEl = wrapper.find('[data-el-pagination="true"]');
-    expect(pagerEl.attributes("data-page-count")).toBe("3");
-
-    // Numbered button → page 3 (== Last button equivalent).
-    await wrapper.find('[data-el-pagination-page="3"]').trigger("click");
-    await flushPromises();
-    await flushPromises();
-    expect(wrapper.text()).toContain("z.txt");
-    expect(wrapper.text()).toContain("Page 3");
-    expect(
-      wrapper
-        .find('[data-testid="file-list-page-last"]')
-        .attributes("disabled"),
-    ).toBeDefined();
-
-    // First button rewinds without intermediate hops.
-    await wrapper.find('[data-testid="file-list-page-first"]').trigger("click");
-    await flushPromises();
-    await flushPromises();
-    expect(wrapper.text()).toContain("a.txt");
-    expect(wrapper.text()).toContain("Page 1");
-
-    // Jumper input → direct goto-page-N. Driving the stub's <input>
-    // mirrors what the real ElPagination jumper does: a Number()
-    // change emits `current-change` with the entered page.
-    await wrapper
-      .find('[data-el-pagination-jumper="true"]')
-      .setValue("2");
-    await flushPromises();
-    await flushPromises();
-    expect(wrapper.text()).toContain("m.txt");
-    expect(wrapper.text()).toContain("Page 2");
-
-    // Last button at this point goes to page 3 (end is discovered).
-    await wrapper.find('[data-testid="file-list-page-last"]').trigger("click");
-    await flushPromises();
-    await flushPromises();
-    expect(wrapper.text()).toContain("z.txt");
-    expect(wrapper.text()).toContain("Page 3");
+    expect(observed).toEqual([
+      { limit: "50", cursor: null },
+      { limit: "100", cursor: "cursor-2" },
+    ]);
+    expect(wrapper.text()).toContain("z-last.txt");
 
     wrapper.unmount();
   });
 
-  it("jumper input that targets a not-yet-discovered page extends discovery before navigating", async () => {
-    // Three-page directory; we only flush enough for page 1 to land,
-    // then drive the jumper to page 3. goToFileListPage should walk
-    // forward synchronously (`extendFileListDiscoveryTo`) and then
-    // navigate — i.e. the user is not blocked on background discovery
-    // having finished first.
-    const calls = [];
-    server.use(
-      http.get(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
-        ({ request }) => {
-          const url = new URL(request.url);
-          const cursor = url.searchParams.get("cursor");
-          calls.push(cursor);
-          if (!cursor) {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/a.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-2>; rel="next"',
-                },
-              },
-            );
-          }
-          if (cursor === "cursor-2") {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/m.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-3>; rel="next"',
-                },
-              },
-            );
-          }
-          return jsonResponse([
-            {
-              type: "file",
-              path: "catalog/z.txt",
-              size: 1,
-              lastModified: "2026-04-21T13:53:39.000000Z",
-            },
-          ]);
-        },
-      ),
-      http.post(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
-        () => jsonResponse([]),
-      ),
-    );
-
-    const wrapper = mountViewer({ currentPath: "catalog" });
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
-
-    await wrapper
-      .find('[data-el-pagination-jumper="true"]')
-      .setValue("3");
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
-
-    expect(wrapper.text()).toContain("z.txt");
-    expect(wrapper.text()).toContain("Page 3");
-
-    wrapper.unmount();
-  });
-
-  it("Last button kicks off a synchronous discovery walk when the background pass has not finished yet", async () => {
-    // Background discovery is gated on a never-resolved promise so it
-    // never reaches the end on its own. Last must run its own walk,
-    // which uses the same fetch path — so we open a second gate the
-    // foreground walk can release. Two pages; the second page is the
-    // tail (no Link header) once unblocked.
-    let unblockBackground;
-    const backgroundGate = new Promise((resolve) => {
-      unblockBackground = resolve;
-    });
-    let backgroundCalls = 0;
-
-    server.use(
-      http.get(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
-        async ({ request }) => {
-          const url = new URL(request.url);
-          const cursor = url.searchParams.get("cursor");
-          if (!cursor) {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/a.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-2>; rel="next"',
-                },
-              },
-            );
-          }
-          backgroundCalls += 1;
-          if (backgroundCalls === 1) {
-            // First (background) hop hangs to keep endDiscovered=false.
-            await backgroundGate;
-          }
-          // Tail page (no Link) on whatever call happens to win.
-          return jsonResponse([
-            {
-              type: "file",
-              path: "catalog/z.txt",
-              size: 1,
-              lastModified: "2026-04-21T13:53:39.000000Z",
-            },
-          ]);
-        },
-      ),
-      http.post(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
-        () => jsonResponse([]),
-      ),
-    );
-
-    const wrapper = mountViewer({ currentPath: "catalog" });
-    await flushPromises();
-    await flushPromises();
-
-    // Last should still be disabled — endDiscovered hasn't been
-    // observed yet.
-    expect(
-      wrapper
-        .find('[data-testid="file-list-page-last"]')
-        .attributes("disabled"),
-    ).toBeDefined();
-
-    // Drive the goToLastFileListPage handler directly (the rendered
-    // button is `disabled` while endDiscovered=false, so a real
-    // .click() is dropped at the DOM layer; the user-visible affordance
-    // arrives via the keyboard shortcut / jumper, which both call the
-    // same function). Release the background gate first so the
-    // runId-superseded loop unblocks and exits.
-    unblockBackground();
-    await wrapper.vm.goToLastFileListPage();
-    await flushPromises();
-    await flushPromises();
-    await flushPromises();
-
-    expect(wrapper.text()).toContain("z.txt");
-    expect(wrapper.text()).toContain("Page 2");
-
-    wrapper.unmount();
-  });
-
-  it("background discovery silently swallows a transient fetch error so the foreground listing still renders", async () => {
-    // Discovery's error handler must NOT surface anything to the
-    // user — page 1 still loads, the pager shows what it knows.
-    let bgCalls = 0;
+  it("Load More failure leaves the existing listing intact — the footer stays so the user can retry on the next click", async () => {
+    // The Load-More flow deliberately does NOT route an append
+    // failure through `treeErrorClassification` (that's a
+    // listing-wide failure indicator). Already-rendered rows must
+    // stay; the button must come back out of its loading state so
+    // the user can try again.
+    let secondCallShouldFail = false;
     server.use(
       http.get(
         "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
@@ -1072,8 +841,20 @@ describe("RepoViewer path handling", () => {
               },
             );
           }
-          bgCalls += 1;
-          return jsonResponse({ detail: "discovery probe failed" }, { status: 503 });
+          if (secondCallShouldFail) {
+            return jsonResponse(
+              { detail: "transient" },
+              { status: 503 },
+            );
+          }
+          return jsonResponse([
+            {
+              type: "file",
+              path: "catalog/m.txt",
+              size: 1,
+              lastModified: "2026-04-21T13:53:39.000000Z",
+            },
+          ]);
         },
       ),
       http.post(
@@ -1085,77 +866,28 @@ describe("RepoViewer path handling", () => {
     const wrapper = mountViewer({ currentPath: "catalog" });
     await flushPromises();
     await flushPromises();
+
+    secondCallShouldFail = true;
+    await wrapper.find('[data-testid="file-list-load-more"]').trigger("click");
+    await flushPromises();
     await flushPromises();
 
-    expect(bgCalls).toBeGreaterThanOrEqual(1);
-    // Page 1 is rendered; no error panel.
+    // Initial row stays rendered; no error panel takes over.
     expect(wrapper.text()).toContain("a.txt");
     expect(wrapper.text()).not.toContain("Authentication required");
-
-    wrapper.unmount();
-  });
-
-  it("Last button stays disabled and the 'discovering more…' hint shows while the cursor walk is still in flight", async () => {
-    // We block the discovery walk on its second hop by handing it a
-    // Promise we never resolve, so the SPA stays in the "page 1
-    // loaded; end not confirmed yet" state for the assertion. Page 1
-    // resolves immediately so the foreground load completes; only
-    // the cursor=cursor-2 call hangs.
-    let releaseDiscovery;
-    const discoveryGate = new Promise((resolve) => {
-      releaseDiscovery = resolve;
-    });
-
-    server.use(
-      http.get(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/tree/main/catalog",
-        async ({ request }) => {
-          const url = new URL(request.url);
-          const cursor = url.searchParams.get("cursor");
-          if (!cursor) {
-            return jsonResponse(
-              [
-                {
-                  type: "file",
-                  path: "catalog/a.txt",
-                  size: 1,
-                  lastModified: "2026-04-21T13:53:39.000000Z",
-                },
-              ],
-              {
-                headers: {
-                  Link: '<https://hub.test/api?cursor=cursor-2>; rel="next"',
-                },
-              },
-            );
-          }
-          await discoveryGate;
-          return jsonResponse([]);
-        },
-      ),
-      http.post(
-        "/api/datasets/open-media-lab/hierarchy-crawl-fixtures/paths-info/main",
-        () => jsonResponse([]),
-      ),
+    // Footer + Load More button stay so retry is possible.
+    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
+      true,
     );
 
-    const wrapper = mountViewer({ currentPath: "catalog" });
+    // Retry succeeds — appended row joins the listing.
+    secondCallShouldFail = false;
+    await wrapper.find('[data-testid="file-list-load-more"]').trigger("click");
     await flushPromises();
     await flushPromises();
+    expect(wrapper.text()).toContain("a.txt");
+    expect(wrapper.text()).toContain("m.txt");
 
-    expect(
-      wrapper
-        .find('[data-testid="file-list-page-last"]')
-        .attributes("disabled"),
-    ).toBeDefined();
-    expect(
-      wrapper.find('[data-testid="file-list-discovery-hint"]').exists(),
-    ).toBe(true);
-
-    // Release the discovery hop and tear down so the test cleans up
-    // without leaking the dangling fetch into the next case.
-    releaseDiscovery();
-    await flushPromises();
     wrapper.unmount();
   });
 
@@ -1227,11 +959,12 @@ describe("RepoViewer path handling", () => {
     wrapper.unmount();
   });
 
-  it("typing into the search box resets the cursor stack so previously-discovered cursors do not leak into the filtered listing", async () => {
-    // Cursors are minted by LakeFS for the unfiltered slice. If the
-    // SPA reused them after a `name_prefix` change, a Prev / direct-N
-    // page click would land on the wrong window of entries — which
-    // is exactly the regression the cursor-stack reset prevents.
+  it("typing into the search box resets the listing — already-loaded entries are dropped and the filtered request starts cursor-less", async () => {
+    // Issue #54 invariant carried into the Load-More world: a
+    // name_prefix change must drop the already-rendered batch (the
+    // first batch was minted against the unfiltered listing) and the
+    // subsequent request must NOT carry the cached `nextCursor`,
+    // which addressed the unfiltered slice.
     const treeRequests = [];
     server.use(
       http.get(
@@ -1240,13 +973,9 @@ describe("RepoViewer path handling", () => {
           const url = new URL(request.url);
           const params = Object.fromEntries(url.searchParams.entries());
           treeRequests.push(params);
-          // Filtered request: empty result, simulating "no match".
           if (params.name_prefix) {
             return jsonResponse([]);
           }
-          // Unfiltered: hand back a page with a next cursor so the
-          // SPA records `cursor-page-2` in its discovered-cursors
-          // stack. Subsequent filtered requests must NOT reuse it.
           return jsonResponse(
             [
               {
@@ -1275,12 +1004,10 @@ describe("RepoViewer path handling", () => {
     await flushPromises();
     await flushPromises();
 
-    // Pager should have walked forward and discovered `cursor-page-2`
-    // (and possibly more). Pin that the SPA actually saw the cursor —
-    // otherwise the assertion below is trivially true.
-    expect(
-      treeRequests.some((r) => r.cursor === "cursor-page-2"),
-    ).toBe(true);
+    // After the initial unfiltered fetch the SPA holds `cursor-page-2`
+    // as nextCursor (Load More target) and one rendered row.
+    expect(wrapper.vm.fileListNextCursor).toBe("cursor-page-2");
+    expect(wrapper.text()).toContain("alpha.txt");
 
     wrapper.vm.fileSearchQuery = "alp";
     await vi.advanceTimersByTimeAsync(350);
@@ -1288,8 +1015,8 @@ describe("RepoViewer path handling", () => {
     await flushPromises();
     vi.useRealTimers();
 
-    // Inspect every request issued AFTER the prefix was set: not one
-    // of them should carry the previously-discovered cursor.
+    // Filtered request fired and DID NOT reuse the cached cursor —
+    // typing a new prefix is a full listing reset.
     const filteredRequests = treeRequests.filter(
       (r) => r.name_prefix === "alp",
     );
@@ -1297,11 +1024,11 @@ describe("RepoViewer path handling", () => {
     for (const req of filteredRequests) {
       expect(req.cursor).toBeUndefined();
     }
-    // And after the watcher fires, the visible page indicator goes
-    // back to 1 — direct evidence the discovered-cursors stack was
-    // reset and the SPA did not stay on a stale page index.
-    expect(wrapper.vm.fileListCurrentPage).toBe(1);
-    expect(wrapper.vm.fileListDiscoveredCursors).toEqual([null]);
+    // Listing reset: the previously-rendered row is gone (filter
+    // returned []), and `nextCursor` flipped back to null because
+    // the filtered response had no Link header.
+    expect(wrapper.vm.fileTree).toEqual([]);
+    expect(wrapper.vm.fileListNextCursor).toBe(null);
 
     wrapper.unmount();
   });

--- a/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
+++ b/test/kohaku-hub-ui/components/test_repo_viewer_paths.test.js
@@ -631,11 +631,12 @@ describe("RepoViewer path handling", () => {
     expect(observed).toHaveLength(1);
     expect(observed[0]).toEqual({ limit: "50", cursor: null });
     expect(wrapper.text()).toContain("a-first.txt");
-    // Footer becomes visible because nextCursor was parsed off Link.
-    expect(wrapper.find('[data-testid="file-list-footer"]').exists()).toBe(
+    // Load More button + per-batch selector both surface because the
+    // response carried a `Link: rel="next"` cursor.
+    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
       true,
     );
-    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
+    expect(wrapper.find('[data-testid="file-list-page-size"]').exists()).toBe(
       true,
     );
     // Count copy carries the "loaded" suffix while more is available.
@@ -714,11 +715,12 @@ describe("RepoViewer path handling", () => {
     // Both entries are rendered — Load More appended, did not replace.
     expect(wrapper.text()).toContain("a-first.txt");
     expect(wrapper.text()).toContain("z-last.txt");
-    // Tail batch arrived → footer + Load More button gone.
-    expect(wrapper.find('[data-testid="file-list-footer"]').exists()).toBe(
+    // Tail batch arrived → Load More button + per-batch selector
+    // both removed (nothing left to fetch, nothing to configure).
+    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
       false,
     );
-    expect(wrapper.find('[data-testid="file-list-load-more"]').exists()).toBe(
+    expect(wrapper.find('[data-testid="file-list-page-size"]').exists()).toBe(
       false,
     );
 


### PR DESCRIPTION
## Summary
- Replaces the cursor-walking numbered pager with a HuggingFace-style "Load more" button that appends on click. No more background walk; no more buttons popping in one at a time.
- Drops the entire discovered-cursor stack and the First / Last / jumper / numbered-pages cluster, plus the \`· discovering more…\` hint that was an artifact of the walk.
- Batch-size selector is preserved but its semantics change: it now applies to the **next** Load More click only — already-loaded entries stay in place, no re-fetch.
- ~376 net lines removed.

Closes #56.

## Why this exists

LakeFS' \`/objects/ls\` exposes only an opaque \`next_offset\` cursor — no total page count, no offset semantics. Forcing that into a numbered pager meant \`extendFileListDiscoveryTo\` had to issue one HTTP request per page just to know how many buttons to render. With \`fileListPageSize=50\` against 5 000 entries, that's 99 sequential round trips before "Last" was reachable; users saw it visibly happening as buttons appeared one by one.

The full rationale + LakeFS API audit lives in #56's body. Short version: cursor-only listings don't fit numbered pagination, and the only honest UX is append-on-click.

## Frontend (\`RepoViewer.vue\`)

State changes:

- **Removed**: \`fileListDiscoveredCursors\`, \`fileListEndDiscovered\`, \`fileListCurrentPage\`, \`fileListPageCount\`, \`fileListHasPrev\`, \`fileListHasNext\`, \`fileListShowPager\`, \`FILE_LIST_DISCOVERY_MAX_PAGES\`, \`fileListDiscoveryRunId\`.
- **Added**: \`fileListNextCursor\` (latest cursor; \`null\` when exhausted), \`fileListLoadingMore\` (separate from \`filesLoading\` so the button can show its own loading state without blanking the listing), \`fileListHasMore\` (computed).
- **Kept**: \`fileListPageSize\` + its localStorage persistence, now read as "batch size".

Function changes:

- **Removed**: \`recordDiscoveredCursor\`, \`goToFileListPage\`, \`goToFirstFileListPage\`, \`goToLastFileListPage\`, \`runFileListDiscovery\`, \`extendFileListDiscoveryTo\`.
- **Added**: \`loadMoreFileTree\` — one \`listTreePage\` call against the cached cursor, appends entries, re-sorts the union so directories-first / alphabetical ordering is preserved as the listing grows.
- **Modified**: \`loadFileTree\` always starts at cursor-less head on \`resetPagination: true\`; \`changeFileListBatchSize\` (renamed from \`changeFileListPageSize\`) only persists the new value, no re-fetch.
- **Refactored**: paths-info expansion lives in \`expandPathsInfoAndMerge(newEntries, requestId)\` and runs over only the just-appended slice — already-expanded rows keep their metadata across Load More clicks.
- **Refactored**: \`probeMissingIndexedTarSiblings\` is additive; the confirmed/rejected memo sets persist across batches (a \`.tar\` appended in batch 2 can match a \`.json\` from batch 1, and vice versa). \`resetIndexedTarProbeMemo\` is called only on a real listing reset.

Template changes:

- The numbered-pager block is replaced by a footer that shows when \`fileListHasMore\`. Per-batch selector + a single primary-plain "Load more (\`{n}\`)" button.
- Header count text simplified from \`Page X · N on this page\` / \`N files\` to \`N file(s)\` (with the suffix \`loaded\` while more is available).
- Empty-state copy unchanged (issue #54 wording stays).

## Tests (\`test_repo_viewer_paths.test.js\`)

Removed three cases that no longer have a meaningful analog:

- "First / Last / page-N / jumper navigate a multi-page directory through discovered cursors"
- "jumper input that targets a not-yet-discovered page extends discovery before navigating"
- "Last button kicks off a synchronous discovery walk when the background pass has not finished yet"
- "Last button stays disabled and the 'discovering more…' hint shows while the cursor walk is still in flight"

Migrated cases (kept the testing intent, retargeted at Load More):

- \`initial fetch defaults to limit=50 (no cursor) and renders the Load More footer when the response carries Link rel=next\` — pins the no-background-walk invariant (a single round trip on mount).
- \`Load More appends the next cursor's batch — entries union, dropped pager state, hides footer when the listing is exhausted\` — pins the append semantics + tail-batch hiding the footer.
- \`changing the batch-size selector persists the choice and applies to the next Load More click — already-loaded entries stay in place\` — verifies **no** new request fires on the change, and the new \`limit\` shows up on the next click.
- \`Load More failure leaves the existing listing intact — the footer stays so the user can retry\` — replaces the old "background discovery silently swallows" case.
- \`typing into the search box resets the listing — already-loaded entries are dropped and the filtered request starts cursor-less\` — migrated from the "cursor stack reset" assertion to "listing reset" using \`fileTree\` and \`fileListNextCursor\`.

## Out of scope

- Backend \`/tree\` is unchanged. Same wire shape, same \`Link: rel="next"\` cursor semantics — Load More is purely a frontend reshape.
- The Card tab's README probe and indexed-tar sibling probe behavior is preserved (additive across batches now, but otherwise behaviorally identical).

## Test plan

- [x] \`npx vitest run\` in \`src/kohaku-hub-ui\` — 430/430 pass.
- [x] \`npx vite build\` succeeds; \`RepoViewer\` chunk built clean.
- [ ] Manual smoke against a multi-page directory: footer appears with the right cursor; click appends; tail batch hides footer; batch-size change does not re-fetch; \`name_prefix\` reset works; back button + path navigation work as before.