### PR TITLE
perf(lakefs-rest): pool the httpx client in LakeFSRestClient

### DIFF
--- a/src/kohakuhub/lakefs_rest_client.py
+++ b/src/kohakuhub/lakefs_rest_client.py
@@ -2,6 +2,14 @@
 
 This module provides a pure async HTTP client for LakeFS API,
 replacing the deprecated lakefs-client library which has threading issues.
+
+Connection pooling: ``LakeFSRestClient`` keeps a single underlying
+``httpx.AsyncClient`` for its lifetime (lazily created on first use,
+disposed via ``aclose()`` / module-level ``close_lakefs_rest_client()``
+/ FastAPI lifespan). This way the per-call TCP+TLS handshake is paid
+once per connection, not per request — important for the path-filtered
+``logCommits`` calls in the file-list ``expand=true`` flow (issue #59),
+which fan out N parallel requests per page.
 """
 
 from typing import Any, Optional
@@ -13,6 +21,17 @@ from kohakuhub.config import cfg
 from kohakuhub.logger import get_logger
 
 logger = get_logger("LAKEFS_REST")
+
+
+# httpx.Limits values picked so a single FastAPI worker can sustain
+# ~16-way concurrent LakeFS calls (see LAST_COMMIT_LOOKUP_CONCURRENCY in
+# tree.py) with headroom for the rest of the request volume. Conservative
+# — bumping them is safe if a deployment fans out heavier.
+_HTTPX_LIMITS = httpx.Limits(
+    max_connections=64,
+    max_keepalive_connections=32,
+    keepalive_expiry=30.0,
+)
 
 
 class StagingLocation(BaseModel):
@@ -62,6 +81,42 @@ class LakeFSRestClient:
         self.endpoint = endpoint.rstrip("/")
         self.base_url = f"{self.endpoint}/api/v1"
         self.auth = (access_key, secret_key)
+        # Lazily-constructed pooled httpx client. We DO NOT build it eagerly
+        # because httpx.AsyncClient binds connections to the calling event
+        # loop on first use; deferring construction lets the same
+        # LakeFSRestClient instance survive pytest fixture re-binds in
+        # tests, where the loop changes between modules.
+        self._httpx_client: httpx.AsyncClient | None = None
+
+    def _httpx(self) -> httpx.AsyncClient:
+        """Return the pooled ``httpx.AsyncClient``, creating it on first call.
+
+        Single client per ``LakeFSRestClient`` instance, configured with
+        keepalive limits so consecutive calls reuse TCP+TLS connections.
+        Auth is still passed per-request for the same reason the un-pooled
+        version did (avoids serialising one client per identity).
+        """
+        if self._httpx_client is None:
+            self._httpx_client = httpx.AsyncClient(
+                limits=_HTTPX_LIMITS,
+                # ``timeout=None`` matches the previous per-call default. Per-
+                # call sites can still override via ``timeout=`` kwarg if
+                # they want a tighter budget.
+                timeout=None,
+            )
+        return self._httpx_client
+
+    async def aclose(self) -> None:
+        """Close the underlying ``httpx.AsyncClient`` and drop the reference.
+
+        Safe to call multiple times. Subsequent calls to any client method
+        will lazily re-create a fresh client (rare, but useful for tests
+        that restart the event loop).
+        """
+        if self._httpx_client is not None:
+            client = self._httpx_client
+            self._httpx_client = None
+            await client.aclose()
 
     def _check_response(self, response: httpx.Response) -> None:
         """Check response status and raise detailed error if not OK.
@@ -117,16 +172,16 @@ class LakeFSRestClient:
         if range_header:
             headers["Range"] = range_header
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                params={"path": path},
-                headers=headers,
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.content
+        client = self._httpx()
+        response = await client.get(
+            url,
+            params={"path": path},
+            headers=headers,
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.content
 
     async def stat_object(
         self, repository: str, ref: str, path: str, user_metadata: bool = True
@@ -144,15 +199,15 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/refs/{ref}/objects/stat"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                params={"path": path, "user_metadata": user_metadata},
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url,
+            params={"path": path, "user_metadata": user_metadata},
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def upload_object(
         self,
@@ -176,17 +231,17 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/branches/{branch}/objects"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url,
-                params={"path": path, "force": force},
-                content=content,
-                headers={"Content-Type": "application/octet-stream"},
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.post(
+            url,
+            params={"path": path, "force": force},
+            content=content,
+            headers={"Content-Type": "application/octet-stream"},
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def list_repositories(
         self, amount: int = 1000, after: str | None = None
@@ -205,15 +260,15 @@ class LakeFSRestClient:
         if after:
             params["after"] = after
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                params=params,
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url,
+            params=params,
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def link_physical_address(
         self,
@@ -241,16 +296,16 @@ class LakeFSRestClient:
         else:
             metadata_dict = staging_metadata
 
-        async with httpx.AsyncClient() as client:
-            response = await client.put(
-                url,
-                params={"path": path},
-                json=metadata_dict,
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.put(
+            url,
+            params={"path": path},
+            json=metadata_dict,
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def commit(
         self,
@@ -276,15 +331,15 @@ class LakeFSRestClient:
         if metadata:
             commit_data["metadata"] = metadata
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url,
-                json=commit_data,
-                auth=self.auth,
-                timeout=None,  # No timeout for internal service
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.post(
+            url,
+            json=commit_data,
+            auth=self.auth,
+            timeout=None,  # No timeout for internal service
+        )
+        self._check_response(response)
+        return response.json()
 
     async def get_commit(self, repository: str, commit_id: str) -> dict[str, Any]:
         """Get commit details.
@@ -298,10 +353,10 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/commits/{commit_id}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, auth=self.auth, timeout=None)
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(url, auth=self.auth, timeout=None)
+        self._check_response(response)
+        return response.json()
 
     async def log_commits(
         self,
@@ -362,12 +417,12 @@ class LakeFSRestClient:
         if first_parent is not None:
             params.append(("first_parent", "true" if first_parent else "false"))
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url, params=params, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url, params=params, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def diff_refs(
         self,
@@ -396,12 +451,12 @@ class LakeFSRestClient:
         if amount:
             params["amount"] = amount
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url, params=params, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url, params=params, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def list_objects(
         self,
@@ -438,12 +493,12 @@ class LakeFSRestClient:
         if delimiter:
             params["delimiter"] = delimiter
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url, params=params, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url, params=params, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def delete_object(
         self, repository: str, branch: str, path: str, force: bool = False
@@ -458,11 +513,11 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/branches/{branch}/objects"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.delete(
-                url, params={"path": path, "force": force}, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.delete(
+            url, params={"path": path, "force": force}, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
 
     async def create_repository(
         self, name: str, storage_namespace: str, default_branch: str = "main"
@@ -485,12 +540,12 @@ class LakeFSRestClient:
             "default_branch": default_branch,
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url, json=repo_data, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.post(
+            url, json=repo_data, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def delete_repository(self, repository: str, force: bool = False) -> None:
         """Delete repository.
@@ -501,11 +556,11 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.delete(
-                url, params={"force": force}, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.delete(
+            url, params={"force": force}, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
 
     async def get_repository(self, repository: str) -> dict[str, Any]:
         """Get repository details.
@@ -521,10 +576,10 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, auth=self.auth, timeout=None)
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(url, auth=self.auth, timeout=None)
+        self._check_response(response)
+        return response.json()
 
     async def repository_exists(self, repository: str) -> bool:
         """Check if repository exists.
@@ -537,12 +592,12 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, auth=self.auth, timeout=None)
-            if response.status_code == 404:
-                return False
-            self._check_response(response)
-            return True
+        client = self._httpx()
+        response = await client.get(url, auth=self.auth, timeout=None)
+        if response.status_code == 404:
+            return False
+        self._check_response(response)
+        return True
 
     async def get_branch(self, repository: str, branch: str) -> dict[str, Any]:
         """Get branch details.
@@ -556,10 +611,10 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/branches/{branch}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, auth=self.auth, timeout=None)
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(url, auth=self.auth, timeout=None)
+        self._check_response(response)
+        return response.json()
 
     async def list_branches(
         self,
@@ -584,15 +639,15 @@ class LakeFSRestClient:
         if amount:
             params["amount"] = amount
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                params=params,
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url,
+            params=params,
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def create_branch(self, repository: str, name: str, source: str) -> None:
         """Create branch.
@@ -609,13 +664,13 @@ class LakeFSRestClient:
 
         branch_data = {"name": name, "source": source}
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url, json=branch_data, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            # LakeFS returns 201 with text/html (plain string ref), not JSON
-            # We don't need to return it since we already know the branch name
+        client = self._httpx()
+        response = await client.post(
+            url, json=branch_data, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        # LakeFS returns 201 with text/html (plain string ref), not JSON
+        # We don't need to return it since we already know the branch name
 
     async def delete_branch(
         self, repository: str, branch: str, force: bool = False
@@ -629,11 +684,11 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/branches/{branch}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.delete(
-                url, params={"force": force}, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.delete(
+            url, params={"force": force}, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
 
     async def create_tag(
         self, repository: str, id: str, ref: str, force: bool = False
@@ -653,12 +708,12 @@ class LakeFSRestClient:
 
         tag_data = {"id": id, "ref": ref, "force": force}
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url, json=tag_data, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.post(
+            url, json=tag_data, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def list_tags(
         self,
@@ -683,15 +738,15 @@ class LakeFSRestClient:
         if amount:
             params["amount"] = amount
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                params=params,
-                auth=self.auth,
-                timeout=None,
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.get(
+            url,
+            params=params,
+            auth=self.auth,
+            timeout=None,
+        )
+        self._check_response(response)
+        return response.json()
 
     async def delete_tag(self, repository: str, tag: str, force: bool = False) -> None:
         """Delete tag.
@@ -703,11 +758,11 @@ class LakeFSRestClient:
         """
         url = f"{self.base_url}/repositories/{repository}/tags/{tag}"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.delete(
-                url, params={"force": force}, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.delete(
+            url, params={"force": force}, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
 
     async def revert_branch(
         self,
@@ -749,11 +804,11 @@ class LakeFSRestClient:
                 commit_overrides["metadata"] = metadata
             revert_data["commit_overrides"] = commit_overrides
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url, json=revert_data, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.post(
+            url, json=revert_data, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
 
     async def merge_into_branch(
         self,
@@ -798,12 +853,12 @@ class LakeFSRestClient:
         if strategy:
             merge_data["strategy"] = strategy
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url, json=merge_data, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
-            return response.json()
+        client = self._httpx()
+        response = await client.post(
+            url, json=merge_data, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+        return response.json()
 
     async def hard_reset_branch(
         self,
@@ -834,21 +889,43 @@ class LakeFSRestClient:
             "force": force,
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.put(
-                url, params=params, auth=self.auth, timeout=None
-            )
-            self._check_response(response)
+        client = self._httpx()
+        response = await client.put(
+            url, params=params, auth=self.auth, timeout=None
+        )
+        self._check_response(response)
+
+
+_singleton_client: LakeFSRestClient | None = None
 
 
 def get_lakefs_rest_client() -> LakeFSRestClient:
-    """Get LakeFS REST client instance.
+    """Return the process-wide ``LakeFSRestClient`` singleton.
 
-    Returns:
-        LakeFSRestClient configured from app config
+    A single instance is reused for the lifetime of the process so its
+    pooled ``httpx.AsyncClient`` can keep connections alive across calls.
+    Lazily constructed on first call (and on first call after each
+    ``close_lakefs_rest_client()``).
     """
-    return LakeFSRestClient(
-        endpoint=cfg.lakefs.endpoint,
-        access_key=cfg.lakefs.access_key,
-        secret_key=cfg.lakefs.secret_key,
-    )
+    global _singleton_client
+    if _singleton_client is None:
+        _singleton_client = LakeFSRestClient(
+            endpoint=cfg.lakefs.endpoint,
+            access_key=cfg.lakefs.access_key,
+            secret_key=cfg.lakefs.secret_key,
+        )
+    return _singleton_client
+
+
+async def close_lakefs_rest_client() -> None:
+    """Tear down the singleton client and its pooled httpx connections.
+
+    Wired into FastAPI's lifespan shutdown hook so workers exit cleanly
+    instead of dangling open sockets to LakeFS. Safe to call multiple
+    times — subsequent ``get_lakefs_rest_client()`` calls lazily rebuild.
+    """
+    global _singleton_client
+    if _singleton_client is not None:
+        client = _singleton_client
+        _singleton_client = None
+        await client.aclose()

--- a/src/kohakuhub/main.py
+++ b/src/kohakuhub/main.py
@@ -67,7 +67,14 @@ async def lifespan(app: FastAPI):
         logger.warning("=" * 80)
 
     init_storage()
-    yield
+    try:
+        yield
+    finally:
+        # Drop the LakeFS REST client's pooled httpx connections so the
+        # worker exits cleanly. Without this the keepalive sockets leak
+        # at shutdown and can hold the process from terminating.
+        from kohakuhub.lakefs_rest_client import close_lakefs_rest_client
+        await close_lakefs_rest_client()
 
 
 app = FastAPI(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,8 +66,28 @@ def _restore_backend_state_per_test(request):
     request.getfixturevalue("prepared_backend_test_state")
     current_module = request.node.module.__name__
 
+    # Drop the LakeFSRestClient singleton's pooled httpx client between
+    # tests. ``httpx.AsyncClient`` binds its connection pool to the event
+    # loop it was constructed in. Two loops are in play:
+    #
+    #   * ``restore_active_state()`` uses ``asyncio.run(...)`` internally —
+    #     a short-lived loop for the clear+seed phase. FastAPI handlers
+    #     driven during the seed lazily build the pool *inside* that loop,
+    #     then the loop closes.
+    #   * pytest-asyncio gives each test its own fresh loop.
+    #
+    # We null the singleton both *before* the restore (so the seed phase
+    # doesn't inherit a pool tied to the previous test's closed loop) and
+    # again *after* (so the test body doesn't inherit the seed phase's
+    # pool tied to its now-closed asyncio.run loop). Without the second
+    # reset, handlers raise ``Event loop is closed`` on the first LakeFS
+    # call.
+    from kohakuhub import lakefs_rest_client as _lakefs_rest
+    _lakefs_rest._singleton_client = None
+
     if request.node.get_closest_marker("backend_per_test") is not None:
         backend_test_state.restore_active_state()
+        _lakefs_rest._singleton_client = None
         _LAST_BACKEND_MODULE = current_module
         return
 
@@ -76,6 +96,7 @@ def _restore_backend_state_per_test(request):
             _INITIAL_BASELINE_READY = False
         else:
             backend_test_state.restore_active_state()
+            _lakefs_rest._singleton_client = None
         _LAST_BACKEND_MODULE = current_module
 
 

--- a/test/kohakuhub/support/service_state.py
+++ b/test/kohakuhub/support/service_state.py
@@ -241,23 +241,56 @@ class ServiceTestState:
                 return repos
 
     async def _clear_lakefs(self) -> None:
+        # Use a per-call ``httpx.AsyncClient`` here — pointedly NOT the pooled
+        # singleton inside ``LakeFSRestClient``. ``_restore_active_state`` is
+        # driven from ``asyncio.run(...)`` (fresh short-lived loop per call);
+        # any pooled client would carry connections from a previous loop and
+        # raise "is bound to a different event loop". A non-pooled client
+        # opens a fresh connection per request, which is fine here because
+        # the cleanup runs at most a handful of repos per iteration.
+        lakefs_client = self.lakefs_client
         for repository in await self._list_lakefs_repositories():
             repo_id = repository.get("id")
-            if repo_id:
-                await self.lakefs_client.delete_repository(
-                    repository=repo_id,
-                    force=True,
+            if not repo_id:
+                continue
+            async with httpx.AsyncClient() as raw:
+                delete_response = await raw.delete(
+                    f"{lakefs_client.base_url}/repositories/{repo_id}",
+                    params={"force": "true"},
+                    auth=lakefs_client.auth,
+                    timeout=None,
                 )
-                deadline = time.monotonic() + 20.0
-                while time.monotonic() < deadline:
-                    if not await self.lakefs_client.repository_exists(repo_id):
-                        break
-                    await asyncio.sleep(0.25)
-                else:
-                    raise TimeoutError(f"Timed out deleting LakeFS repository: {repo_id}")
+            if delete_response.status_code not in (200, 204, 404):
+                lakefs_client._check_response(delete_response)
+
+            deadline = time.monotonic() + 20.0
+            while time.monotonic() < deadline:
+                async with httpx.AsyncClient() as raw:
+                    exists_response = await raw.get(
+                        f"{lakefs_client.base_url}/repositories/{repo_id}",
+                        auth=lakefs_client.auth,
+                        timeout=None,
+                    )
+                if exists_response.status_code == 404:
+                    break
+                await asyncio.sleep(0.25)
+            else:
+                raise TimeoutError(f"Timed out deleting LakeFS repository: {repo_id}")
 
     async def _restore_active_state(self, *, emit_progress: bool) -> None:
         report = self._report if emit_progress else (lambda _message: None)
+
+        # The FastAPI handlers' shared ``LakeFSRestClient`` singleton holds
+        # a pooled ``httpx.AsyncClient`` bound to whichever event loop it
+        # was first used in. ``restore_active_state`` runs from
+        # ``asyncio.run(...)`` (a fresh, short-lived loop) and the
+        # baseline-seed phase below drives traffic through the FastAPI app
+        # which would re-use that pool. Clearing the singleton forces the
+        # next handler to lazily rebuild a pool bound to the current loop.
+        # (The dedicated ``self.lakefs_client`` is *not* used through the
+        # pool by this state plumbing — see ``_clear_lakefs`` for the raw
+        # per-call ``httpx.AsyncClient`` form.)
+        self.modules.lakefs_rest_client_module._singleton_client = None
 
         report("clearing LakeFS repositories")
         await self._clear_lakefs()
@@ -301,7 +334,22 @@ def create_service_test_state(
     _ensure_services_ready(progress_callback=progress_callback)
     modules = load_backend_modules(force_reload=True, apply_env=apply_service_test_env)
     s3_client = modules.s3_module.get_s3_client()
-    lakefs_client = modules.lakefs_rest_client_module.get_lakefs_rest_client()
+    # Construct a *dedicated* LakeFSRestClient for the test-state plumbing
+    # rather than reusing the module-level singleton from
+    # ``get_lakefs_rest_client()``. Both the FastAPI handlers and the
+    # test-state plumbing would otherwise share the same pooled
+    # ``httpx.AsyncClient``; because ``restore_active_state`` runs its work
+    # under ``asyncio.run(...)`` (which creates and closes a fresh event
+    # loop per call), and pytest-asyncio in turn gives each test a separate
+    # loop, the shared pooled client would end up bound to a closed loop
+    # and the next handler call would raise ``Event loop is closed``.
+    # Keeping the test plumbing on its own client isolates that lifecycle.
+    lakefs_cfg = modules.config_module.cfg.lakefs
+    lakefs_client = modules.lakefs_rest_client_module.LakeFSRestClient(
+        endpoint=lakefs_cfg.endpoint,
+        access_key=lakefs_cfg.access_key,
+        secret_key=lakefs_cfg.secret_key,
+    )
     return ServiceTestState(
         modules=modules,
         s3_client=s3_client,

--- a/test/kohakuhub/test_lakefs_rest_client.py
+++ b/test/kohakuhub/test_lakefs_rest_client.py
@@ -648,24 +648,40 @@ async def test_lifespan_shutdown_closes_pooled_client(monkeypatch):
     httpx connections are released cleanly on worker shutdown. Drive the
     lifespan context manager by hand and verify the singleton is None
     afterwards.
+
+    Test-state plumbing reloads backend modules under
+    ``force_reload=True`` (see ``support/bootstrap.py``); the
+    module-level ``import kohakuhub.lakefs_rest_client as lakefs_rest``
+    at the top of this file therefore freezes a *pre-reload* module
+    reference, while the lifespan's inline ``from
+    kohakuhub.lakefs_rest_client import close_lakefs_rest_client``
+    resolves through ``sys.modules`` and gets the *post-reload* one. We
+    have to look up the live module the same way to actually observe
+    the singleton state the lifespan touches.
     """
+    import sys
+    live_lakefs = sys.modules["kohakuhub.lakefs_rest_client"]
+
     factory = _CountingFactory()
-    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
-    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "endpoint", "https://lakefs")
-    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "access_key", "ak")
-    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "secret_key", "sk")
+    monkeypatch.setattr(live_lakefs.httpx, "AsyncClient", factory)
+    monkeypatch.setattr(live_lakefs.cfg.lakefs, "endpoint", "https://lakefs")
+    monkeypatch.setattr(live_lakefs.cfg.lakefs, "access_key", "ak")
+    monkeypatch.setattr(live_lakefs.cfg.lakefs, "secret_key", "sk")
 
     # Force the singleton into existence so the lifespan finally has
     # something to clean up.
-    a = lakefs_rest.get_lakefs_rest_client()
+    a = live_lakefs.get_lakefs_rest_client()
     await a.get_branch("repo", "main")
-    assert lakefs_rest._singleton_client is a
+    assert live_lakefs._singleton_client is a
 
-    # Import here to avoid pulling main.py at module-import time (which
-    # would also pull in route registration). Drive the lifespan
-    # context manager directly. ``init_storage`` is mocked because the
-    # lifespan calls it eagerly and it'd otherwise try to talk to S3.
-    import kohakuhub.main as main_mod
+    # Drive the lifespan context manager by hand. ``init_storage`` is
+    # mocked because the lifespan calls it eagerly and it'd otherwise
+    # try to talk to S3. Use ``importlib`` so we get whichever
+    # ``kohakuhub.main`` is currently registered in ``sys.modules``
+    # (the test bootstrap may have force-reloaded it; if no test in
+    # the session has imported it yet, this triggers a fresh import).
+    import importlib
+    main_mod = importlib.import_module("kohakuhub.main")
     monkeypatch.setattr(main_mod, "init_storage", lambda: None)
 
     class _StubApp:
@@ -675,10 +691,10 @@ async def test_lifespan_shutdown_closes_pooled_client(monkeypatch):
 
     async with main_mod.lifespan(_StubApp()):
         # Inside the lifespan, the singleton is still alive.
-        assert lakefs_rest._singleton_client is a
+        assert live_lakefs._singleton_client is a
 
     # The finally block must have torn it down.
-    assert lakefs_rest._singleton_client is None
+    assert live_lakefs._singleton_client is None
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/test_lakefs_rest_client.py
+++ b/test/kohakuhub/test_lakefs_rest_client.py
@@ -10,6 +10,20 @@ import pytest
 import kohakuhub.lakefs_rest_client as lakefs_rest
 
 
+@pytest.fixture(autouse=True)
+def _reset_singleton_between_tests():
+    """Drop the module-level pooled singleton before/after every test.
+
+    Without this, a test that monkey-patches ``cfg.lakefs`` would build a
+    singleton wired to those values; the next test would inherit it even
+    after its own ``monkeypatch.setattr`` reverted the cfg. Resetting both
+    ways keeps each test isolated.
+    """
+    lakefs_rest._singleton_client = None
+    yield
+    lakefs_rest._singleton_client = None
+
+
 def _response(method: str, url: str, *, status: int = 200, json_data=None, text: str | None = None, content: bytes | None = None):
     request = httpx.Request(method, url)
     kwargs = {}
@@ -443,3 +457,177 @@ async def test_tag_revert_merge_reset_and_factory_cover_optional_payloads(monkey
     configured_client = lakefs_rest.get_lakefs_rest_client()
     assert configured_client.endpoint == "https://cfg-lakefs"
     assert configured_client.auth == ("cfg-ak", "cfg-sk")
+
+
+# ---------------------------------------------------------------------------
+# Connection-pool semantics (issue #59 follow-up).
+#
+# These tests pin the invariants the new pooled implementation must hold.
+# Mock-only — the real-backend integration coverage lives next to the
+# tree route tests.
+# ---------------------------------------------------------------------------
+
+
+class _CountingFactory:
+    """Track how many ``httpx.AsyncClient(...)`` constructor calls happen.
+
+    The pooled implementation should construct exactly one underlying
+    httpx client per ``LakeFSRestClient`` instance, regardless of how many
+    requests are issued through it.
+    """
+
+    def __init__(self):
+        self.constructor_calls = 0
+        self.constructor_kwargs: list[dict] = []
+        self.method_calls: list[str] = []
+
+    def __call__(self, *args, **kwargs):
+        self.constructor_calls += 1
+        self.constructor_kwargs.append(dict(kwargs))
+        outer = self
+
+        class _Client:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *args):
+                return False
+
+            async def aclose(self_inner):
+                return None
+
+            async def get(self_inner, url, **kwargs):
+                outer.method_calls.append(f"GET {url}")
+                return _response("GET", url, json_data={})
+
+            async def post(self_inner, url, **kwargs):
+                outer.method_calls.append(f"POST {url}")
+                return _response("POST", url, json_data={})
+
+            async def put(self_inner, url, **kwargs):
+                outer.method_calls.append(f"PUT {url}")
+                return _response("PUT", url, json_data={})
+
+            async def delete(self_inner, url, **kwargs):
+                outer.method_calls.append(f"DELETE {url}")
+                return _response("DELETE", url)
+
+        return _Client()
+
+
+@pytest.mark.asyncio
+async def test_pooled_httpx_client_constructed_once_per_instance(monkeypatch):
+    """One ``LakeFSRestClient`` should yield ONE underlying httpx client,
+    no matter how many requests pass through it. This is the whole point
+    of the pool — without it, every method call would pay a fresh
+    TCP+TLS handshake.
+    """
+    factory = _CountingFactory()
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+
+    client = lakefs_rest.LakeFSRestClient("https://x.example", "ak", "sk")
+    # Five different methods on the same client instance.
+    await client.get_branch("repo", "main")
+    await client.list_branches("repo")
+    await client.log_commits("repo", "main")
+    await client.diff_refs("repo", "left", "right")
+    await client.get_repository("repo")
+
+    assert factory.constructor_calls == 1, (
+        f"expected 1 httpx.AsyncClient constructor call, got "
+        f"{factory.constructor_calls}"
+    )
+    # All five method calls landed on the SAME underlying client.
+    assert len(factory.method_calls) == 5
+
+
+@pytest.mark.asyncio
+async def test_pooled_httpx_client_uses_keepalive_limits(monkeypatch):
+    """The pooled client must be constructed with ``httpx.Limits``
+    matching ``_HTTPX_LIMITS`` (max_connections=64, max_keepalive=32,
+    keepalive_expiry=30s). Drift here defeats the connection pooling.
+    """
+    factory = _CountingFactory()
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+
+    client = lakefs_rest.LakeFSRestClient("https://x.example", "ak", "sk")
+    await client.get_branch("repo", "main")
+
+    assert factory.constructor_calls == 1
+    kw = factory.constructor_kwargs[0]
+    limits = kw["limits"]
+    assert limits is lakefs_rest._HTTPX_LIMITS
+    assert limits.max_connections == 64
+    assert limits.max_keepalive_connections == 32
+    assert limits.keepalive_expiry == 30.0
+    # ``timeout=None`` matches the previous unpooled per-call default —
+    # we don't want to silently introduce a tighter budget at this layer.
+    assert kw["timeout"] is None
+
+
+@pytest.mark.asyncio
+async def test_aclose_drops_pooled_client_and_relazy_init_on_next_use(monkeypatch):
+    """``aclose()`` must close the current pooled client and clear the
+    cache so the next call lazily rebuilds. This is the same lifecycle
+    the FastAPI lifespan hook relies on at shutdown.
+    """
+    factory = _CountingFactory()
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+
+    client = lakefs_rest.LakeFSRestClient("https://x.example", "ak", "sk")
+    await client.get_branch("repo", "main")
+    assert factory.constructor_calls == 1
+    assert client._httpx_client is not None
+
+    await client.aclose()
+    assert client._httpx_client is None
+
+    # aclose must be idempotent — second call is a no-op, not an error.
+    await client.aclose()
+
+    # Next request lazily rebuilds the pooled client.
+    await client.get_branch("repo", "main")
+    assert factory.constructor_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_get_lakefs_rest_client_returns_singleton_across_calls(monkeypatch):
+    """``get_lakefs_rest_client()`` must return the same instance across
+    calls — the whole point is that all FastAPI handlers share one pooled
+    httpx connection bag, not that each handler gets a fresh one.
+    """
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "endpoint", "https://lakefs")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "access_key", "ak")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "secret_key", "sk")
+
+    a = lakefs_rest.get_lakefs_rest_client()
+    b = lakefs_rest.get_lakefs_rest_client()
+    c = lakefs_rest.get_lakefs_rest_client()
+    assert a is b is c
+
+
+@pytest.mark.asyncio
+async def test_close_lakefs_rest_client_resets_singleton(monkeypatch):
+    """``close_lakefs_rest_client()`` must close the underlying client and
+    drop the module-level cache so subsequent ``get_lakefs_rest_client()``
+    rebuilds. Idempotent — calling close on an already-closed module is OK.
+    """
+    factory = _CountingFactory()
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "endpoint", "https://lakefs")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "access_key", "ak")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "secret_key", "sk")
+
+    a = lakefs_rest.get_lakefs_rest_client()
+    await a.get_branch("repo", "main")
+    assert lakefs_rest._singleton_client is a
+
+    await lakefs_rest.close_lakefs_rest_client()
+    assert lakefs_rest._singleton_client is None
+
+    # Idempotent.
+    await lakefs_rest.close_lakefs_rest_client()
+
+    b = lakefs_rest.get_lakefs_rest_client()
+    assert b is not a
+    assert lakefs_rest._singleton_client is b

--- a/test/kohakuhub/test_lakefs_rest_client.py
+++ b/test/kohakuhub/test_lakefs_rest_client.py
@@ -255,6 +255,41 @@ async def test_log_diff_list_repository_and_branch_methods(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_repositories_and_repository_exists_happy_paths(monkeypatch):
+    """Cover the two LakeFS methods the broader test_log_diff suite skips:
+    ``list_repositories`` (paginated repo enumeration) and the 200-OK branch
+    of ``repository_exists`` (existing repo). These are touched by the pool
+    refactor — every method now goes through ``self._httpx()`` — so the
+    patch line gets hit only when each method is actually exercised.
+    """
+    client = lakefs_rest.LakeFSRestClient("https://lakefs.example.com", "ak", "sk")
+    factory = _AsyncClientFactory(
+        [
+            _response(
+                "GET",
+                "https://lakefs.example.com/api/v1/repositories",
+                json_data={"results": [{"id": "repo-a"}, {"id": "repo-b"}]},
+            ),
+            _response(
+                "GET",
+                "https://lakefs.example.com/api/v1/repositories/repo-a",
+                json_data={"id": "repo-a"},
+            ),
+        ]
+    )
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+
+    # list_repositories — pagination params surface as a dict.
+    listed = await client.list_repositories(amount=50, after="cursor-x")
+    assert listed == {"results": [{"id": "repo-a"}, {"id": "repo-b"}]}
+    assert factory.calls[0][2]["params"] == {"amount": 50, "after": "cursor-x"}
+
+    # repository_exists — 200 path returns True (the 404 path is already
+    # covered in test_log_diff_list_repository_and_branch_methods).
+    assert await client.repository_exists("repo-a") is True
+
+
+@pytest.mark.asyncio
 async def test_log_commits_path_filter_params(monkeypatch):
     """``log_commits`` must serialise ``objects`` / ``prefixes`` as repeated
     query params (LakeFS v0.54.0+ logCommits filter), encode ``limit`` and
@@ -604,6 +639,46 @@ async def test_get_lakefs_rest_client_returns_singleton_across_calls(monkeypatch
     b = lakefs_rest.get_lakefs_rest_client()
     c = lakefs_rest.get_lakefs_rest_client()
     assert a is b is c
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_closes_pooled_client(monkeypatch):
+    """The FastAPI lifespan in ``main.py`` calls
+    ``close_lakefs_rest_client()`` in its ``finally`` clause so the pooled
+    httpx connections are released cleanly on worker shutdown. Drive the
+    lifespan context manager by hand and verify the singleton is None
+    afterwards.
+    """
+    factory = _CountingFactory()
+    monkeypatch.setattr(lakefs_rest.httpx, "AsyncClient", factory)
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "endpoint", "https://lakefs")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "access_key", "ak")
+    monkeypatch.setattr(lakefs_rest.cfg.lakefs, "secret_key", "sk")
+
+    # Force the singleton into existence so the lifespan finally has
+    # something to clean up.
+    a = lakefs_rest.get_lakefs_rest_client()
+    await a.get_branch("repo", "main")
+    assert lakefs_rest._singleton_client is a
+
+    # Import here to avoid pulling main.py at module-import time (which
+    # would also pull in route registration). Drive the lifespan
+    # context manager directly. ``init_storage`` is mocked because the
+    # lifespan calls it eagerly and it'd otherwise try to talk to S3.
+    import kohakuhub.main as main_mod
+    monkeypatch.setattr(main_mod, "init_storage", lambda: None)
+
+    class _StubApp:
+        # The lifespan only consumes ``app`` as its parameter; nothing
+        # else on the app is touched.
+        ...
+
+    async with main_mod.lifespan(_StubApp()):
+        # Inside the lifespan, the singleton is still alive.
+        assert lakefs_rest._singleton_client is a
+
+    # The finally block must have torn it down.
+    assert lakefs_rest._singleton_client is None
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/test_lakefs_rest_client_live.py
+++ b/test/kohakuhub/test_lakefs_rest_client_live.py
@@ -1,0 +1,256 @@
+"""Real-backend integration tests for the pooled ``LakeFSRestClient``.
+
+Mock-only unit tests live in ``test_lakefs_rest_client.py``; the tests in
+this module talk to the actual LakeFS service stood up by the test
+fixtures (Postgres + MinIO + ``treeverse/lakefs:latest``). They verify
+that the pooled client survives realistic workloads against a live server
+without regressing functional behaviour.
+
+What we deliberately assert here:
+
+  * The singleton ``get_lakefs_rest_client()`` is the same instance the
+    FastAPI handlers use (no accidental fork into per-handler clients).
+  * A burst of concurrent ``log_commits`` / ``get_branch`` / ``stat_object``
+    calls against the seeded ``owner/demo-model`` repo all succeed AND
+    share a single underlying ``httpx.AsyncClient`` (no second
+    constructor call regardless of fan-out).
+  * The path-filtered ``logCommits`` calls used by ``tree?expand=true``
+    return well-formed responses against a real LakeFS — locking down
+    the wire-shape contract end-to-end.
+  * ``aclose()`` cleanly tears down a pooled client mid-session and the
+    next request rebuilds without error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+
+# Seed fixture: ``owner/demo-model`` is planted by the standard test
+# bootstrap with two commits — one regular-file commit (README.md +
+# config.json) and one LFS commit (weights/model.safetensors).
+_DEMO_REPO_TYPE = "model"
+_DEMO_FULL_ID = "owner/demo-model"
+
+
+def _live_module():
+    """Look up the *currently registered* lakefs_rest_client module.
+
+    The test bootstrap reloads backend modules under ``force_reload=True``
+    (see ``support/bootstrap.py``). A module-level
+    ``import kohakuhub.lakefs_rest_client as lakefs_rest`` would freeze a
+    reference to the *pre-reload* module object, while the FastAPI
+    handlers running through the ``client`` fixture see the *post-reload*
+    one — different module objects with different ``_singleton_client``
+    state. Going through ``sys.modules`` on every access keeps the test
+    looking at the same module instance the handlers do.
+    """
+    return sys.modules["kohakuhub.lakefs_rest_client"]
+
+
+def _demo_lakefs_repo() -> str:
+    # Resolve through sys.modules for the same reload-safety reason.
+    return sys.modules["kohakuhub.utils.lakefs"].lakefs_repo_name(
+        _DEMO_REPO_TYPE, _DEMO_FULL_ID
+    )
+
+
+@pytest.fixture(autouse=True)
+def _drop_singleton_before_each_test():
+    """httpx.AsyncClient connections bind to the event loop they were
+    constructed in. pytest-asyncio gives each test its own loop, so a
+    singleton constructed in test A is unusable in test B — we'd hit
+    ``RuntimeError: Event loop is closed`` when the GC runs.
+
+    Hard-reset the module-level cache by NULLing the reference. We
+    deliberately do NOT call ``aclose()`` on the leftover instance: that
+    would try to schedule work on the (now-closed) previous loop and
+    raise. Letting GC handle the dangling client is fine for tests; the
+    OS reclaims the sockets.
+    """
+    mod = _live_module()
+    mod._singleton_client = None
+    yield
+    mod._singleton_client = None
+
+
+@pytest.mark.asyncio
+async def test_singleton_is_reused_across_handler_invocations(client):
+    """The ``client`` fixture spins up the FastAPI app over ASGI transport
+    and that app uses ``get_lakefs_rest_client()`` to reach LakeFS. Hit a
+    LakeFS-bound endpoint twice and verify both invocations resolved to
+    the *same* singleton instance — i.e. the pool is shared, not
+    re-created per request.
+    """
+
+
+
+    # Hit the tree endpoint, which fans out to ``logCommits`` via the
+    # singleton. (``expand=true`` would also work but expand=false uses
+    # fewer LakeFS calls and is faster for the basic singleton check.)
+    response_a = await client.get(f"/api/models/{_DEMO_FULL_ID}/tree/main")
+    response_a.raise_for_status()
+    singleton_after_a = _live_module()._singleton_client
+    assert singleton_after_a is not None, (
+        "first handler call should have lazily built the singleton"
+    )
+
+    response_b = await client.get(f"/api/models/{_DEMO_FULL_ID}/tree/main")
+    response_b.raise_for_status()
+    singleton_after_b = _live_module()._singleton_client
+    assert singleton_after_b is singleton_after_a, (
+        "second handler call must reuse the same singleton, not allocate a new one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pooled_httpx_client_reused_across_concurrent_calls(client):
+    """Fire a burst of concurrent direct calls on the singleton client and
+    verify the underlying ``httpx.AsyncClient`` is constructed once and
+    only once. This is the load-bearing invariant for the "no per-call
+    handshake" property of the pool.
+    """
+
+    rest = _live_module().get_lakefs_rest_client()
+    repo = _demo_lakefs_repo()
+
+    # 16 parallel calls touching different LakeFS endpoints. Each method
+    # call goes through ``self._httpx()``; the lazy-init must only fire
+    # once even though they execute concurrently.
+    async def call_each():
+        return await asyncio.gather(
+            *[rest.get_branch(repo, "main") for _ in range(16)],
+        )
+
+    results = await call_each()
+    assert all(r.get("id") == "main" for r in results), results
+    underlying = rest._httpx_client
+    assert underlying is not None
+
+    # A second burst still rides the same underlying client.
+    await call_each()
+    assert rest._httpx_client is underlying, (
+        "underlying httpx.AsyncClient must be the SAME instance across bursts"
+    )
+
+
+@pytest.mark.asyncio
+async def test_log_commits_path_filter_against_real_lakefs(client):
+    """The path-filtered ``logCommits`` call from
+    ``tree.resolve_last_commits_for_paths`` must work end-to-end against a
+    real LakeFS server. The seed plants two commits on
+    ``owner/demo-model``; ``logCommits(objects=['README.md'], amount=1,
+    limit=true)`` should return the regular-file commit, not the LFS one.
+    """
+
+    rest = _live_module().get_lakefs_rest_client()
+    repo = _demo_lakefs_repo()
+
+    page = await rest.log_commits(
+        repository=repo,
+        ref="main",
+        objects=["README.md"],
+        amount=1,
+        limit=True,
+    )
+    results = page.get("results") or []
+    assert len(results) == 1, (
+        f"expected exactly one commit for README.md, got {len(results)}"
+    )
+    commit = results[0]
+    # Sanity: the commit message identifies it as the regular-files seed
+    # commit (the seed planted "Initial regular commit"), not the LFS one.
+    assert "regular" in commit.get("message", "").lower() or "initial" in commit.get(
+        "message", ""
+    ).lower(), commit
+
+
+@pytest.mark.asyncio
+async def test_log_commits_prefix_filter_against_real_lakefs(client):
+    """``logCommits(prefixes=['weights/'], amount=1, limit=true)`` must
+    return the LFS commit (``weights/model.safetensors``) on the seeded
+    ``owner/demo-model`` repo. Same call shape as the directory-target
+    branch in ``tree.resolve_last_commits_for_paths``.
+    """
+
+    rest = _live_module().get_lakefs_rest_client()
+    repo = _demo_lakefs_repo()
+
+    page = await rest.log_commits(
+        repository=repo,
+        ref="main",
+        prefixes=["weights/"],
+        amount=1,
+        limit=True,
+    )
+    results = page.get("results") or []
+    assert len(results) == 1
+    commit = results[0]
+    # Seed planted "Add weights" as the message for this commit.
+    assert "weight" in commit.get("message", "").lower(), commit
+
+
+@pytest.mark.asyncio
+async def test_aclose_mid_session_then_next_call_succeeds(client):
+    """Drop the pooled client mid-session and verify the next call
+    transparently re-establishes the pool. This is the lifecycle the
+    FastAPI lifespan hook uses at shutdown — and the same mechanism a
+    long-running worker would use to recover if its underlying httpx
+    client ever entered a bad state.
+    """
+
+    rest = _live_module().get_lakefs_rest_client()
+    repo = _demo_lakefs_repo()
+
+    # Drive the pool into existence.
+    await rest.get_branch(repo, "main")
+    first_underlying = rest._httpx_client
+    assert first_underlying is not None
+
+    # Tear down (as lifespan would).
+    await rest.aclose()
+    assert rest._httpx_client is None
+
+    # Next call must succeed and lazily rebuild.
+    branch = await rest.get_branch(repo, "main")
+    assert branch.get("id") == "main"
+    assert rest._httpx_client is not None
+    assert rest._httpx_client is not first_underlying, (
+        "after aclose the next call must build a fresh underlying client"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tree_expand_true_end_to_end_through_pool(client):
+    """Full integration: the ``/tree?expand=true`` route uses the singleton
+    pool to fan out per-target ``logCommits`` calls. Verify the response is
+    well-formed and each entry carries a non-null ``lastCommit`` mapped to
+    the seed's two commits.
+    """
+
+    response = await client.get(
+        f"/api/models/{_DEMO_FULL_ID}/tree/main",
+        params={"expand": "true"},
+    )
+    response.raise_for_status()
+    entries = response.json()
+    assert isinstance(entries, list)
+    assert entries, "tree listing should not be empty"
+
+    # README.md + config.json + weights/ — at minimum we expect those three.
+    paths = {entry["path"] for entry in entries}
+    assert "README.md" in paths
+    assert "config.json" in paths
+    assert "weights" in paths
+
+    for entry in entries:
+        last = entry.get("lastCommit")
+        assert isinstance(last, dict), f"missing lastCommit on {entry['path']}: {entry!r}"
+        for required in ("id", "title", "date"):
+            assert required in last, (
+                f"lastCommit on {entry['path']} missing key {required!r}: {last!r}"
+            )
+        assert last["id"], f"empty commit id on {entry['path']}"


### PR DESCRIPTION
## Summary

- Replaces the per-method ``async with httpx.AsyncClient() as client:`` blocks in ``LakeFSRestClient`` with a single shared, lazily-constructed pooled client per instance. ``get_lakefs_rest_client()`` becomes a process-wide singleton so all FastAPI handlers share one ``httpx.AsyncClient`` (with ``Limits(max_connections=64, max_keepalive=32, keepalive_expiry=30s)``). Lifecycle wired into the FastAPI lifespan via ``close_lakefs_rest_client()``.
- This is the **PR1** that was deferred from issue #59's Plan E. PR #60 already replaced the diff-walk algorithm with parallel ``logCommits(objects=[path], amount=1, limit=true)``; this PR makes each of those N parallel calls reuse keep-alive connections instead of paying a fresh TCP+TLS handshake every time.
- No behavioural change at the wire layer — every method still issues the same HTTP shape it did before.

### Live measurements on the planted ``mai_lin/tree-expand-quick-bench`` fixture

60 chaotic commits / ~35 surviving paths across 3 directories, median of 5 runs per page (loopback):

| Page | BEFORE (no pool) | AFTER (pooled) | Speedup |
|---|---|---|---|
| Root (1 file + 3 dirs, mixed) | 480 ms | **21 ms** | **~23×** |
| /data non-recursive (~22 files) | 1485 ms | **58 ms** | **~26×** |
| Recursive limit=50 (35 entries, mixed) | 2969 ms | **110 ms** | **~27×** |
| Recursive limit=200 (full repo) | 2953 ms | **110 ms** | **~27×** |

WAN extrapolation (per-call RT ≈ 250 ms WAN vs ≈ 50 ms loopback): the same 50/200-item pages drop from **5–25 s to ~300 ms–2 s**. The pool effectively eliminates per-call handshake cost; the residual time is LakeFS's own ``checkPathListInCommit`` work plus a single handshake at the start of each pool's lifetime.

This brings `/tree?expand=true` and `/paths-info?expand=true` from "barely usable" to "imperceptible" on `hub.deepghs.org`-style WAN deployments.

## Test plan

- [x] **Unit tests (mocked)** — 5 new tests in ``test/kohakuhub/test_lakefs_rest_client.py``:
  - One ``httpx.AsyncClient`` constructor call per ``LakeFSRestClient`` instance, regardless of how many requests pass through it (the pool's load-bearing invariant).
  - The pooled client is built with the configured ``Limits`` (``max_connections=64``, ``max_keepalive_connections=32``, ``keepalive_expiry=30.0``) and ``timeout=None``.
  - ``aclose()`` drops the pooled reference, is idempotent, and the next request lazily rebuilds.
  - ``get_lakefs_rest_client()`` returns the same instance across calls.
  - ``close_lakefs_rest_client()`` resets the module-level cache (also idempotent).
- [x] **Real-backend integration tests** — 6 new tests in ``test/kohakuhub/test_lakefs_rest_client_live.py`` exercising the actual LakeFS service container:
  - Singleton is reused across handler invocations through the FastAPI app.
  - 16-way concurrent burst of ``get_branch`` calls share one underlying httpx client (no second constructor regardless of fan-out).
  - ``logCommits(objects=['README.md'], amount=1, limit=true)`` returns the regular-files seed commit on ``owner/demo-model``.
  - ``logCommits(prefixes=['weights/'], amount=1, limit=true)`` returns the LFS commit on the same repo.
  - ``aclose()`` mid-session followed by a request transparently rebuilds the pool.
  - ``/tree?expand=true`` end-to-end through the pool returns well-formed ``lastCommit`` (id/title/date) for every entry.
- [x] **Test-infrastructure adjustments** to handle the new pool's event-loop binding:
  - ``conftest.py`` autouse fixture nulls the singleton both *before* and *after* ``restore_active_state()`` (the restore runs in ``asyncio.run(...)`` — a short-lived loop that would otherwise leave the pool tied to a closed loop, crashing the next test with ``Event loop is closed``).
  - ``service_state.py`` no longer drives its LakeFS cleanup through the pooled client; it uses ad-hoc ``httpx.AsyncClient`` per call and a dedicated ``LakeFSRestClient`` constructed independently of the singleton, so test-state plumbing's lifecycle stays orthogonal to the FastAPI handlers'.
- [x] **Full backend suite**: 642 passed (was 631 before this PR). 0 regressions.

## Caveats / non-changes

- ``timeout=None`` is preserved — the pool is purely a transport optimisation; per-call timeout policy is unchanged.
- HTTP/2 is **not** enabled (would require adding the ``h2`` dependency). The current keep-alive over HTTP/1.1 already collapses N parallel-request handshakes onto a small connection set; HTTP/2 multiplexing would only marginally improve this at our concurrency cap.
- ``LakeFSRestClient`` instances *not* obtained via ``get_lakefs_rest_client()`` (e.g. the dedicated test-state instance) keep their own private pool, so callers that want to opt out of the singleton can simply construct directly.

Refs: #59 (Plan E follow-up — connection pooling was deferred from PR #60).