### PR TITLE
perf(org): inline repo_count in /org/{name}, drop frontend listRepos fan-out

### DIFF
--- a/src/kohaku-hub-ui/src/pages/organizations/index.vue
+++ b/src/kohaku-hub-ui/src/pages/organizations/index.vue
@@ -123,7 +123,7 @@
 <script setup>
 import { useRouter } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
-import { orgAPI, repoAPI, settingsAPI } from "@/utils/api";
+import { orgAPI, settingsAPI } from "@/utils/api";
 import { ElMessage } from "element-plus";
 
 const router = useRouter();
@@ -174,14 +174,17 @@ async function loadOrganizations() {
       const { data } = await settingsAPI.whoamiV2();
       const userOrgs = data.orgs || [];
 
-      // Fetch detailed info for each organization
+      // Fetch detailed info for each organization. The org info endpoint
+      // now returns `repo_count` directly (issue #63), so we no longer
+      // fan out to listRepos(limit=1000) × 3 types per card just to read
+      // `.length` — that pattern triggered hundreds of LakeFS round-trips
+      // per org card on the backend.
       const orgsWithDetails = await Promise.all(
         userOrgs.map(async (org) => {
           try {
-            const [orgInfo, members, repos] = await Promise.all([
+            const [orgInfo, members] = await Promise.all([
               orgAPI.get(org.name),
               orgAPI.listMembers(org.name),
-              fetchOrgRepoCount(org.name),
             ]);
 
             return {
@@ -189,7 +192,7 @@ async function loadOrganizations() {
               description: orgInfo.data.description,
               role: org.roleInOrg || org.role,
               memberCount: members.data.members?.length || 0,
-              repoCount: repos,
+              repoCount: orgInfo.data.repo_count?.total ?? 0,
               created_at: orgInfo.data.created_at,
             };
           } catch (err) {
@@ -216,23 +219,6 @@ async function loadOrganizations() {
     ElMessage.error("Failed to load organizations");
   } finally {
     loading.value = false;
-  }
-}
-
-async function fetchOrgRepoCount(orgName) {
-  try {
-    const [models, datasets, spaces] = await Promise.all([
-      repoAPI.listRepos("model", { author: orgName, limit: 1000 }),
-      repoAPI.listRepos("dataset", { author: orgName, limit: 1000 }),
-      repoAPI.listRepos("space", { author: orgName, limit: 1000 }),
-    ]);
-    return (
-      (models.data?.length || 0) +
-      (datasets.data?.length || 0) +
-      (spaces.data?.length || 0)
-    );
-  } catch (err) {
-    return 0;
   }
 }
 

--- a/src/kohakuhub/api/org/router.py
+++ b/src/kohakuhub/api/org/router.py
@@ -1,9 +1,10 @@
 """Organization related API endpoints."""
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from peewee import fn
 from pydantic import BaseModel
 
-from kohakuhub.db import User, UserOrganization, db
+from kohakuhub.db import Repository, User, UserOrganization, db
 from kohakuhub.constants import ERROR_USER_NOT_FOUND
 from kohakuhub.db_operations import (
     create_organization,
@@ -71,10 +72,39 @@ async def create_organization_endpoint(
     return {"success": True, "name": org.username}
 
 
+def _count_repos_by_type(namespace: str) -> dict[str, int]:
+    """Return repo counts in ``namespace`` grouped by type.
+
+    Single ``GROUP BY repo_type`` SQL — replaces the frontend pattern of
+    listing 1000 rows × 3 types per org card just to read ``.length``.
+    See issue #63.
+    """
+    counts: dict[str, int] = {"model": 0, "dataset": 0, "space": 0}
+    for row in (
+        Repository.select(
+            Repository.repo_type, fn.COUNT(Repository.id).alias("c")
+        )
+        .where(Repository.namespace == namespace)
+        .group_by(Repository.repo_type)
+        .dicts()
+    ):
+        counts[row["repo_type"]] = row["c"]
+    counts["total"] = counts["model"] + counts["dataset"] + counts["space"]
+    return counts
+
+
 @router.get("/{org_name}")
 @with_user_fallback("profile")
 async def get_organization_info(org_name: str, request: Request, fallback: bool = True):
     """Get organization details.
+
+    Includes a ``repo_count`` field grouped by repo type so the orgs grid
+    page can render the per-card "X repos" badge without fan-out listing
+    (see issue #63). The count covers all repos in the namespace
+    (public + private); the orgs grid card is only rendered for orgs the
+    viewer is a member of, so private repos counting is fine. Public-only
+    surfaces should derive their own count via the privacy-filtered list
+    endpoints.
 
     Query params:
         fallback: Set to "false" to disable fallback to external sources (default: true)
@@ -86,6 +116,7 @@ async def get_organization_info(org_name: str, request: Request, fallback: bool 
         "name": org.username,
         "description": org.description,
         "created_at": org.created_at,
+        "repo_count": _count_repos_by_type(org_name),
         "_source": "local",  # Tag local orgs
     }
 

--- a/test/kohakuhub/api/org/test_repo_count.py
+++ b/test/kohakuhub/api/org/test_repo_count.py
@@ -1,0 +1,210 @@
+"""Tests covering the ``repo_count`` field on ``GET /org/{org_name}``.
+
+Background (issue #63): the ``/organizations`` grid page used to call
+``listRepos(limit=1000)`` × 3 types per org card just to read ``.length``,
+triggering hundreds of LakeFS round-trips per card on the backend. The
+fix returns ``repo_count`` directly from the org info endpoint via a
+single ``GROUP BY repo_type`` SQL.
+
+This module pins:
+
+1. the SQL aggregate counts each repo type correctly
+2. counts are isolated per namespace
+3. counts grow when new repos are created
+4. ``repo_count.total`` round-trips equal to the union of
+   ``HfApi.list_models / list_datasets / list_spaces(author=org)``,
+   so a future drift in either side surfaces immediately
+
+Reference: issue #63 (perf umbrella #69).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def test_org_repo_count_zero_for_empty_org(owner_client):
+    """Freshly-created org with no repos must report all zeros."""
+    create_resp = await owner_client.post(
+        "/org/create",
+        json={"name": "empty-team", "description": "no repos here"},
+    )
+    create_resp.raise_for_status()
+
+    info_resp = await owner_client.get("/org/empty-team")
+    info_resp.raise_for_status()
+    counts = info_resp.json()["repo_count"]
+    assert counts == {"model": 0, "dataset": 0, "space": 0, "total": 0}
+
+
+async def test_org_repo_count_isolated_per_namespace(owner_client):
+    """``repo_count`` for acme-labs must not include owner's repos.
+
+    The seed plants ``owner/demo-model`` in the ``owner`` namespace — that
+    must not bleed into the acme-labs count."""
+    info_resp = await owner_client.get("/org/acme-labs")
+    info_resp.raise_for_status()
+    counts = info_resp.json()["repo_count"]
+    # Seed: acme-labs has exactly one (private) dataset.
+    assert counts == {"model": 0, "dataset": 1, "space": 0, "total": 1}
+
+
+async def test_org_repo_count_grows_after_creating_a_new_repo(owner_client):
+    """Creating a model under acme-labs must bump model + total by 1
+    while leaving dataset / space unchanged."""
+    before = (await owner_client.get("/org/acme-labs")).json()["repo_count"]
+    assert before["model"] == 0
+    assert before["dataset"] == 1
+    assert before["total"] == before["model"] + before["dataset"] + before["space"]
+
+    create_resp = await owner_client.post(
+        "/api/repos/create",
+        json={
+            "type": "model",
+            "name": "labs-bench",
+            "private": False,
+            "organization": "acme-labs",
+        },
+    )
+    create_resp.raise_for_status()
+
+    after = (await owner_client.get("/org/acme-labs")).json()["repo_count"]
+    assert after["model"] == before["model"] + 1
+    assert after["dataset"] == before["dataset"]
+    assert after["space"] == before["space"]
+    assert after["total"] == before["total"] + 1
+
+
+async def test_org_repo_count_counts_each_type_independently(owner_client):
+    """Plant one repo of each type under a fresh org and verify the
+    GROUP BY SQL reports them per-type rather than collapsing to a single
+    bucket."""
+    # New org so we don't have to worry about pre-seeded entries.
+    create_org = await owner_client.post(
+        "/org/create",
+        json={"name": "trio-team", "description": "one of each"},
+    )
+    create_org.raise_for_status()
+
+    for repo_type, name in (
+        ("model", "trio-model"),
+        ("dataset", "trio-dataset"),
+        ("space", "trio-space"),
+    ):
+        payload = {
+            "type": repo_type,
+            "name": name,
+            "private": False,
+            "organization": "trio-team",
+        }
+        if repo_type == "space":
+            # space create requires sdk
+            payload["space_sdk"] = "static"
+        resp = await owner_client.post("/api/repos/create", json=payload)
+        resp.raise_for_status()
+
+    counts = (await owner_client.get("/org/trio-team")).json()["repo_count"]
+    assert counts == {"model": 1, "dataset": 1, "space": 1, "total": 3}
+
+
+# --- huggingface_hub upstream cross-check ----------------------------------
+#
+# The KohakuHub /org/{name} endpoint is *not* a HuggingFace API surface (HF
+# uses /api/users/{name}/overview for both users and orgs). But the orgs
+# grid page used to derive its count from HF-compatible list endpoints, so
+# the migration from "listRepos.length" to "repo_count" must keep both
+# numbers aligned: ``repo_count.total`` from /org/{name} must equal the
+# total surfaced by ``HfApi.list_models/list_datasets/list_spaces``. If
+# they ever drift, either the SQL aggregate or one of the list privacy
+# filters has a bug.
+#
+# Uses the live HTTP server (HfApi can't talk to ASGITransport).
+
+
+async def test_org_repo_count_matches_hf_list_apis(
+    live_server_url, hf_api_token, owner_client
+):
+    """``repo_count.total`` from /org/{name} must equal what
+    ``huggingface_hub.HfApi`` would compute from its own list endpoints.
+
+    This protects against the SQL aggregate diverging from the privacy-
+    filtered list endpoints (e.g. if a future change adds a ``deleted``
+    flag to ``Repository`` and one query forgets to honor it).
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi(endpoint=live_server_url, token=hf_api_token)
+
+    # Plant a known mix under a fresh org so we don't conflate with seed
+    # data that other tests might have mutated in-session.
+    create_org = await owner_client.post(
+        "/org/create",
+        json={"name": "hfapi-cross-team", "description": "cross-check"},
+    )
+    create_org.raise_for_status()
+
+    plants = [
+        ("model", "alpha"),
+        ("model", "beta"),
+        ("dataset", "wiki-shard"),
+        ("space", "demo"),
+    ]
+    for repo_type, name in plants:
+        payload = {
+            "type": repo_type,
+            "name": name,
+            "private": False,
+            "organization": "hfapi-cross-team",
+        }
+        if repo_type == "space":
+            payload["space_sdk"] = "static"
+        resp = await owner_client.post("/api/repos/create", json=payload)
+        resp.raise_for_status()
+
+    info_resp = await owner_client.get("/org/hfapi-cross-team")
+    info_resp.raise_for_status()
+    counts = info_resp.json()["repo_count"]
+
+    # Pull each list type via HfApi (the upstream client) and compare.
+    models = await asyncio.to_thread(
+        lambda: list(api.list_models(author="hfapi-cross-team", limit=1000))
+    )
+    datasets = await asyncio.to_thread(
+        lambda: list(api.list_datasets(author="hfapi-cross-team", limit=1000))
+    )
+    spaces = await asyncio.to_thread(
+        lambda: list(api.list_spaces(author="hfapi-cross-team", limit=1000))
+    )
+
+    assert counts["model"] == len(models), (
+        f"repo_count.model={counts['model']} but HfApi.list_models returned "
+        f"{len(models)} (ids: {[m.id for m in models]})"
+    )
+    assert counts["dataset"] == len(datasets), (
+        f"repo_count.dataset={counts['dataset']} but HfApi.list_datasets returned "
+        f"{len(datasets)} (ids: {[d.id for d in datasets]})"
+    )
+    assert counts["space"] == len(spaces), (
+        f"repo_count.space={counts['space']} but HfApi.list_spaces returned "
+        f"{len(spaces)} (ids: {[s.id for s in spaces]})"
+    )
+    assert counts["total"] == len(models) + len(datasets) + len(spaces)
+
+    # Sanity: the planted shape we expect.
+    assert counts == {"model": 2, "dataset": 1, "space": 1, "total": 4}
+
+
+async def test_org_info_payload_shape_unchanged_except_for_repo_count(owner_client):
+    """The other fields on the org info payload — ``name``, ``description``,
+    ``created_at``, ``_source`` — must be untouched. Adding ``repo_count``
+    is purely additive."""
+    resp = await owner_client.get("/org/acme-labs")
+    resp.raise_for_status()
+    payload = resp.json()
+    assert payload["name"] == "acme-labs"
+    assert "description" in payload
+    assert "created_at" in payload
+    assert payload["_source"] == "local"
+    # The new field, asserted separately.
+    assert isinstance(payload["repo_count"], dict)
+    assert set(payload["repo_count"].keys()) == {"model", "dataset", "space", "total"}

--- a/test/kohakuhub/api/org/test_router.py
+++ b/test/kohakuhub/api/org/test_router.py
@@ -1,10 +1,24 @@
 """API tests for organization routes."""
 
+import asyncio
+
 
 async def test_get_organization_and_members(owner_client):
     org_response = await owner_client.get("/org/acme-labs")
     assert org_response.status_code == 200
-    assert org_response.json()["name"] == "acme-labs"
+    payload = org_response.json()
+    assert payload["name"] == "acme-labs"
+
+    # ``repo_count`` is included in the org info payload (issue #63) so the
+    # orgs grid card can render the per-card "X repos" badge without
+    # listing 1000 rows × 3 types per card. Seed plants exactly one
+    # dataset under acme-labs (``private-dataset``); no models / spaces.
+    assert "repo_count" in payload
+    counts = payload["repo_count"]
+    assert counts["model"] == 0
+    assert counts["dataset"] == 1
+    assert counts["space"] == 0
+    assert counts["total"] == 1
 
     members_response = await owner_client.get("/org/acme-labs/members")
     assert members_response.status_code == 200


### PR DESCRIPTION
## Summary

Fixes [#63](https://github.com/deepghs/KohakuHub/issues/63) (under perf umbrella [#69](https://github.com/deepghs/KohakuHub/issues/69)).

The `/organizations` grid page was issuing **3 × `listRepos(limit=1000)` per org card** just to read `.length` for the "X repos" badge. Combined with the N+1 LakeFS round-trips that **PR #70** fixed inside list endpoints, that meant ~390 LakeFS round-trips per card on the backend (deepghs scale: 74+91+30 repos × 2 RT) just to render one integer.

This PR removes the fan-out by returning `repo_count` directly from the org info endpoint via a single `GROUP BY repo_type` SQL.

## What changed

### Backend (`src/kohakuhub/api/org/router.py`)

`GET /org/{name}` now returns `repo_count` alongside the existing fields:

```http
GET /org/acme-labs

200 OK
{
  "name": "acme-labs",
  "description": "...",
  "created_at": "...",
  "repo_count": {
    "model":   0,
    "dataset": 1,
    "space":   0,
    "total":   1
  },
  "_source": "local"
}
```

New helper `_count_repos_by_type(namespace)` does one SQL:

```python
Repository
    .select(Repository.repo_type, fn.COUNT(Repository.id).alias("c"))
    .where(Repository.namespace == namespace)
    .group_by(Repository.repo_type)
```

### Frontend (`src/kohaku-hub-ui/src/pages/organizations/index.vue`)

- Deleted `fetchOrgRepoCount(orgName)` (the 3 × `listRepos(limit=1000)` fan-out)
- `loadOrganizations` now reads `orgInfo.data.repo_count?.total ?? 0`
- Net: **−3 list requests per card, 0 extra round-trips**

What does **not** change:
- All other `/org/{name}` response fields (`name`, `description`, `created_at`, `_source`)
- Privacy semantics (counts cover public + private; the orgs grid card is already gated by membership upstream)
- `huggingface_hub.HfApi.list_models / list_datasets / list_spaces` behavior

## Privacy

`COUNT(*)` is over **all** repos in the namespace (public + private). The grid card on `/organizations` only renders for orgs the current user is a member of (gated upstream by `whoamiV2().orgs`), so counting private repos is fine.

If we ever expose this count on a public `/organizations/{name}` page for non-members, we'd want to count only public repos there — but that's a separate UX decision, not a regression introduced by this PR.

## Tests

### Existing test extended

`test_router.py::test_get_organization_and_members` now also asserts the seed-derived count: acme-labs has 0 models / 1 dataset / 0 spaces / total 1.

### New file: `test/kohakuhub/api/org/test_repo_count.py` (6 tests)

| Test | What it pins |
|---|---|
| `test_org_repo_count_zero_for_empty_org` | freshly-created org with no repos reports all zeros |
| `test_org_repo_count_isolated_per_namespace` | owner's `demo-model` doesn't bleed into acme-labs's count |
| `test_org_repo_count_grows_after_creating_a_new_repo` | model bump leaves dataset/space unchanged |
| `test_org_repo_count_counts_each_type_independently` | one of each → `{model:1, dataset:1, space:1, total:3}` (GROUP BY isn't collapsing) |
| `test_org_repo_count_matches_hf_list_apis` | **`huggingface_hub.HfApi` cross-check** — `repo_count.total` must equal `len(list_models) + len(list_datasets) + len(list_spaces)` for the same author. Guards against the SQL aggregate diverging from the privacy-filtered list endpoints. |
| `test_org_info_payload_shape_unchanged_except_for_repo_count` | regression net for the rest of the payload |

The HfApi cross-check is the load-bearing one for upstream compatibility. It plants 2 models + 1 dataset + 1 space, then compares the SQL count to what `HfApi` itself would compute via its standard list endpoints — if either side ever drifts (e.g. a future change adds a `deleted` flag and one query forgets to honor it), this test catches it before reviewers do.

### Behavior alignment with huggingface_hub

`/org/{name}` is **NOT** an HF protocol surface — HF uses `/api/users/{name}/overview` for both users and orgs, and `huggingface_hub.HfApi.get_user_overview` doesn't return per-type repo counts. So there's no upstream wire-format contract to align here; the cross-check test ensures the *value* of `repo_count` is consistent with what HF clients would compute via their own list endpoints, even though those clients never call `/org/{name}` directly.

## Performance evidence

For deepghs's profile (74 models + 91 datasets + 30 spaces = 195 repos), per org card before/after:

| | Before | After |
|---|---:|---:|
| Frontend requests per card (info + members + counts) | 5 (1 info + 1 members + 3 listRepos) | **2** (info + members) |
| Backend SQL queries | 1 (info) + 3 (list) + 3 × N (per-row visibility) | 1 (info, now also doing one extra GROUP BY) + 1 (members) |
| Backend LakeFS round-trips | ~390 (issue #62 / PR #70 covered the inner per-row RT) | **0** |
| Backend payload | ~200 KB | ~600 bytes |

For a user that belongs to N orgs, the orgs grid concurrent fan-out drops from `5N` HTTP requests to `2N`.

## Test plan

- [x] 6 new tests in `test_repo_count.py` — pass locally
- [x] Existing org suite (`test/kohakuhub/api/org/`) — 16/16 pass after assertion extension
- [x] Wider regression: org + repo + huggingface_hub_compat + huggingface_hub_surface + invitation — 99/99 pass
- [x] HfApi cross-check planted 4 repos, asserts `repo_count` matches `len(list_*)` per type
- [ ] CI matrix (Python 3.10/3.11/3.12 × `huggingface_hub` 6 versions) — watching after push

## Related

- Builds on PR #70 (issue #62) — without it, this PR alone would still leave the inner per-row LakeFS RT problem inside the list endpoints. With both shipped, the orgs grid drops from 5–10 s to <1 s.
- Tracking umbrella: [#69](https://github.com/deepghs/KohakuHub/issues/69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
