### PR TITLE
feat(fallback): strict-freshness cache contract — per-(user, tokens_hash) keying + 3-dim gens + repo CRUD invalidation (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fallback cache: strict-freshness contract** ([#79](https://github.com/deepghs/KohakuHub/issues/79)).
+  Cache key now includes `user_id` and a `tokens_hash` derived from the
+  user's effective external tokens. Two users (or one user with
+  different per-request `Authorization: Bearer ...|url,token|...` external
+  tokens) can no longer share a binding. Three monotonic generation
+  counters (`global_gen`, `user_gens[uid]`, `repo_gens[(rt, ns, name)]`)
+  drive a `safe_set` race-protection check that rejects cache writes
+  whose pre-probe snapshot disagrees with the post-probe state — closing
+  the admin-mutation / token-rotation / repo-CRUD races where a probe
+  in flight could otherwise pin a stale binding after an invalidation.
+- **Fallback cache: invalidation hooks** ([#79](https://github.com/deepghs/KohakuHub/issues/79)).
+  `cache.invalidate_repo(repo_type, ns, name)` and
+  `cache.clear_user(user_id)` provide the two new eviction primitives;
+  hooked into local repo create/delete/move/visibility-toggle, user
+  external-token POST/DELETE/PUT bulk, and admin source create (the
+  last one parallels the existing UPDATE/DELETE that already evicted).
+- **Admin endpoints: per-repo and per-user fallback cache eviction**
+  ([#79](https://github.com/deepghs/KohakuHub/issues/79)). New
+  `DELETE /admin/api/fallback-sources/cache/repo/{repo_type}/{namespace}/{name}`
+  and `DELETE /admin/api/fallback-sources/cache/user/{user_id}` for
+  operational hygiene.
 - **Fallback: repo-grain binding.** Within a single bind window every read
   against one `repo_id` goes to exactly one source. Eliminates cross-source
   mixing where the SPA showed source A's metadata while `resolve` served
@@ -51,7 +72,3 @@ Planned follow-up work surfaced during the [#77](https://github.com/deepghs/Koha
   fallback cache TTL (`KOHAKU_HUB_FALLBACK_CACHE_TTL`) from `300` to `60`,
   decouple chain-probe logic into a pure `core.probe_chain` function, and
   add admin endpoints + frontend panel for real / simulated chain testing.
-- [#79](https://github.com/deepghs/KohakuHub/issues/79) — include
-  `user_id` in the fallback cache key so two users with different
-  effective source visibility cannot mix bindings; invalidate cache on
-  user-token rotation.

--- a/src/kohaku-hub-admin/src/pages/fallback-sources.vue
+++ b/src/kohaku-hub-admin/src/pages/fallback-sources.vue
@@ -10,6 +10,11 @@ import {
   deleteFallbackSource,
   getFallbackCacheStats,
   clearFallbackCache,
+  invalidateFallbackRepoCache,
+  invalidateFallbackUserCacheById,
+  invalidateFallbackUserCacheByUsername,
+  listUsers,
+  listRepositories,
 } from "@/utils/api";
 import { ElMessage, ElMessageBox } from "element-plus";
 import dayjs from "dayjs";
@@ -33,6 +38,24 @@ const formData = ref({
   name: "",
   source_type: "huggingface",
   enabled: true,
+});
+
+// Per-repo eviction dialog (#79 admin tooling).
+const evictRepoDialogVisible = ref(false);
+const evictRepoForm = ref({
+  repo_type: "model",
+  namespace: "",
+  name: "",
+});
+
+// Per-user eviction dialog. ``mode`` toggles between username- and
+// user_id-keyed paths so an admin who only knows one of the two doesn't
+// have to leave the page to look up the other.
+const evictUserDialogVisible = ref(false);
+const evictUserForm = ref({
+  mode: "username", // "username" | "user_id"
+  username: "",
+  user_id: null,
 });
 
 function checkAuth() {
@@ -210,6 +233,245 @@ async function handleClearCache() {
   }
 }
 
+function openEvictRepoDialog() {
+  evictRepoForm.value = {
+    repo_type: "model",
+    namespace: "",
+    name: "",
+  };
+  evictRepoDialogVisible.value = true;
+}
+
+// Autocomplete suggestion fetchers (#79). Each is scoped to the right
+// admin lookup for the field it serves:
+//
+//  - namespace (evict-by-repo dialog) → ``listUsers(include_orgs=true)``
+//    because a repository's namespace is either a user **or** an
+//    organisation, and listUsers in that mode returns the union.
+//
+//  - repo name (evict-by-repo dialog, given a fixed namespace) →
+//    ``listRepositories(namespace, repo_type)`` for the
+//    namespace-scoped enumeration. The query string filters
+//    server-side via the existing ``search`` param.
+//
+//  - username (evict-by-user dialog, username mode) →
+//    ``listUsers(include_orgs=false)``. Per the post-#79 cache key
+//    shape ``(user_id_or_None, tokens_hash, repo_type, ns, name)``,
+//    user_id is the request originator — orgs never originate a
+//    request, so they have no cache bucket to evict and don't belong
+//    in these suggestions.
+//
+// All three return ``{value: string}[]`` per Element Plus's
+// ``el-autocomplete`` ``fetch-suggestions`` contract.
+async function fetchNamespaceSuggestions(query, cb) {
+  if (!checkAuth()) {
+    cb([]);
+    return;
+  }
+  try {
+    if (!query || query.length < 1) {
+      cb([]);
+      return;
+    }
+    const data = await listUsers(adminStore.token, {
+      search: query,
+      limit: 20,
+      include_orgs: true, // namespaces span both users and orgs
+    });
+    const items = Array.isArray(data) ? data : data?.users || data?.items || [];
+    cb(
+      items
+        .filter((u) => u.username)
+        .map((u) => ({ value: u.username })),
+    );
+  } catch (error) {
+    console.error("Failed to fetch namespace suggestions:", error);
+    cb([]);
+  }
+}
+
+async function fetchRepoNameSuggestions(query, cb) {
+  if (!checkAuth()) {
+    cb([]);
+    return;
+  }
+  try {
+    if (!query || query.length < 1) {
+      cb([]);
+      return;
+    }
+    // Namespace-scoped enumeration. Without a chosen namespace we
+    // can't bound the search to a single namespace, so fall back to
+    // a coarse filter — but this dialog asks the operator to pick
+    // namespace first, so the namespace-empty case is a UX hint to
+    // fill that field first.
+    const data = await listRepositories(adminStore.token, {
+      search: query,
+      repo_type: evictRepoForm.value.repo_type,
+      namespace: evictRepoForm.value.namespace || undefined,
+      limit: 20,
+    });
+    // Backend wraps under ``{repositories: [...]}`` (admin /repositories
+    // route shape); also tolerate ``{items: [...]}`` and a raw array
+    // for forward compatibility.
+    const items = Array.isArray(data)
+      ? data
+      : data?.repositories || data?.items || [];
+    cb(
+      items
+        .filter((repo) => repo.name)
+        .map((repo) => ({ value: repo.name })),
+    );
+  } catch (error) {
+    console.error("Failed to fetch repo name suggestions:", error);
+    cb([]);
+  }
+}
+
+async function fetchUsernameSuggestions(query, cb) {
+  if (!checkAuth()) {
+    cb([]);
+    return;
+  }
+  try {
+    if (!query || query.length < 1) {
+      cb([]);
+      return;
+    }
+    // ``include_orgs: false`` — fallback cache buckets are keyed by the
+    // real user_id of the request originator. Orgs never make requests
+    // themselves, so they have no bucket to evict and don't belong in
+    // these suggestions.
+    const data = await listUsers(adminStore.token, {
+      search: query,
+      limit: 20,
+      include_orgs: false,
+    });
+    const items = Array.isArray(data) ? data : data?.users || data?.items || [];
+    cb(
+      items
+        .filter((u) => u.username)
+        .map((u) => ({ value: u.username })),
+    );
+  } catch (error) {
+    console.error("Failed to fetch username suggestions:", error);
+    cb([]);
+  }
+}
+
+function openEvictUserDialog() {
+  evictUserForm.value = {
+    mode: "username",
+    username: "",
+    user_id: null,
+  };
+  evictUserDialogVisible.value = true;
+}
+
+async function handleEvictRepo() {
+  if (!checkAuth()) return;
+
+  const { repo_type, namespace, name } = evictRepoForm.value;
+  if (!repo_type || !namespace || !name) {
+    ElMessage.error("repo_type, namespace, and name are all required");
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const result = await invalidateFallbackRepoCache(
+      adminStore.token,
+      repo_type,
+      namespace.trim(),
+      name.trim(),
+    );
+    ElMessage.success(
+      `Evicted ${result.evicted} cache entr${result.evicted === 1 ? "y" : "ies"} for ${repo_type}/${namespace}/${name}`,
+    );
+    evictRepoDialogVisible.value = false;
+    await loadCacheStats();
+  } catch (error) {
+    console.error("Failed to evict repo cache:", error);
+    ElMessage.error(
+      error.response?.data?.detail?.error || "Failed to evict repo cache",
+    );
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleEvictUser() {
+  if (!checkAuth()) return;
+
+  const { mode, username, user_id } = evictUserForm.value;
+
+  if (mode === "username") {
+    if (!username || !username.trim()) {
+      ElMessage.error("Username is required");
+      return;
+    }
+  } else {
+    if (user_id == null || Number.isNaN(Number(user_id)) || Number(user_id) <= 0) {
+      ElMessage.error("user_id must be a positive integer");
+      return;
+    }
+  }
+
+  // Strong confirm — per-user eviction crosses every repo this user has
+  // bound. See PR #81 review item #5–#12 noted comment for the
+  // confirm-on-broad-scope rule.
+  try {
+    const targetLabel =
+      mode === "username" ? `username "${username}"` : `user_id ${user_id}`;
+    await ElMessageBox.confirm(
+      `Evict every cached fallback binding for ${targetLabel}? This drops every repo binding the user has cached and forces a re-probe on their next request.`,
+      "Confirm User Cache Eviction",
+      {
+        confirmButtonText: "Evict",
+        cancelButtonText: "Cancel",
+        type: "warning",
+      },
+    );
+  } catch (error) {
+    if (error !== "cancel") {
+      console.error("Confirm dialog dismissed unexpectedly:", error);
+    }
+    return;
+  }
+
+  loading.value = true;
+  try {
+    let result;
+    if (mode === "username") {
+      result = await invalidateFallbackUserCacheByUsername(
+        adminStore.token,
+        username.trim(),
+      );
+    } else {
+      result = await invalidateFallbackUserCacheById(
+        adminStore.token,
+        Number(user_id),
+      );
+    }
+    const tail =
+      mode === "username"
+        ? `${username} (user_id=${result.user_id})`
+        : `user_id=${user_id}`;
+    ElMessage.success(
+      `Evicted ${result.evicted} cache entr${result.evicted === 1 ? "y" : "ies"} for ${tail}`,
+    );
+    evictUserDialogVisible.value = false;
+    await loadCacheStats();
+  } catch (error) {
+    console.error("Failed to evict user cache:", error);
+    ElMessage.error(
+      error.response?.data?.detail?.error || "Failed to evict user cache",
+    );
+  } finally {
+    loading.value = false;
+  }
+}
+
 function formatDate(dateStr) {
   return dayjs(dateStr).format("YYYY-MM-DD HH:mm:ss");
 }
@@ -222,13 +484,17 @@ onMounted(() => {
 
 <template>
   <AdminLayout>
-    <div class="fallback-sources-page">
-      <div class="page-header">
-        <h1>Fallback Sources</h1>
-        <p>
-          Manage external repository sources (HuggingFace, other KohakuHub
-          instances)
-        </p>
+    <div class="page-container">
+      <div class="flex justify-between items-center mb-6 gap-4 flex-wrap">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Fallback Sources
+          </h1>
+          <p class="text-gray-500 dark:text-gray-400 text-sm mt-1">
+            Manage external repository sources (HuggingFace, other KohakuHub
+            instances).
+          </p>
+        </div>
       </div>
 
       <!-- Cache Stats Card -->
@@ -236,15 +502,37 @@ onMounted(() => {
         <template #header>
           <div class="card-header">
             <span>Cache Statistics</span>
-            <el-button
-              type="danger"
-              size="small"
-              @click="handleClearCache"
-              :loading="loading"
-            >
-              <i class="i-carbon-trash-can mr-1"></i>
-              Clear Cache
-            </el-button>
+            <div class="cache-actions">
+              <el-button
+                type="warning"
+                size="small"
+                @click="openEvictRepoDialog"
+                :loading="loading"
+                data-testid="evict-repo-button"
+              >
+                <i class="i-carbon-cube mr-1"></i>
+                Evict by Repo...
+              </el-button>
+              <el-button
+                type="warning"
+                size="small"
+                @click="openEvictUserDialog"
+                :loading="loading"
+                data-testid="evict-user-button"
+              >
+                <i class="i-carbon-user mr-1"></i>
+                Evict by User...
+              </el-button>
+              <el-button
+                type="danger"
+                size="small"
+                @click="handleClearCache"
+                :loading="loading"
+              >
+                <i class="i-carbon-trash-can mr-1"></i>
+                Clear Cache
+              </el-button>
+            </div>
           </div>
         </template>
         <div class="stats-grid">
@@ -454,13 +742,132 @@ onMounted(() => {
           </el-button>
         </template>
       </el-dialog>
+
+      <!-- Per-repo cache eviction dialog (#79) -->
+      <el-dialog
+        v-model="evictRepoDialogVisible"
+        title="Evict Fallback Cache by Repo"
+        width="540px"
+        data-testid="evict-repo-dialog"
+      >
+        <p class="dialog-help">
+          Drop every cached source binding for one repository, across all
+          users. Useful when you know an upstream repo's state changed and
+          you don't want to wait for the TTL.
+        </p>
+        <el-form :model="evictRepoForm" label-width="120px">
+          <el-form-item label="Repo type" required>
+            <el-select
+              v-model="evictRepoForm.repo_type"
+              style="width: 100%"
+              data-testid="evict-repo-type"
+            >
+              <el-option label="model" value="model" />
+              <el-option label="dataset" value="dataset" />
+              <el-option label="space" value="space" />
+            </el-select>
+          </el-form-item>
+          <el-form-item label="Namespace" required>
+            <el-autocomplete
+              v-model="evictRepoForm.namespace"
+              :fetch-suggestions="fetchNamespaceSuggestions"
+              placeholder="owner / org name"
+              clearable
+              style="width: 100%"
+              data-testid="evict-repo-namespace"
+            />
+          </el-form-item>
+          <el-form-item label="Name" required>
+            <el-autocomplete
+              v-model="evictRepoForm.name"
+              :fetch-suggestions="fetchRepoNameSuggestions"
+              placeholder="repo name"
+              clearable
+              style="width: 100%"
+              data-testid="evict-repo-name"
+            />
+          </el-form-item>
+        </el-form>
+        <template #footer>
+          <el-button @click="evictRepoDialogVisible = false">Cancel</el-button>
+          <el-button
+            type="warning"
+            @click="handleEvictRepo"
+            :loading="loading"
+            data-testid="evict-repo-submit"
+          >
+            Evict
+          </el-button>
+        </template>
+      </el-dialog>
+
+      <!-- Per-user cache eviction dialog (#79) -->
+      <el-dialog
+        v-model="evictUserDialogVisible"
+        title="Evict Fallback Cache by User"
+        width="540px"
+        data-testid="evict-user-dialog"
+      >
+        <p class="dialog-help">
+          Drop every cached source binding belonging to one user (across
+          every repo they have a binding for). The next request from that
+          user re-probes the chain. Address by username (resolved
+          server-side) or numeric user_id (script-friendly).
+        </p>
+        <el-form :model="evictUserForm" label-width="120px">
+          <el-form-item label="Mode" required>
+            <el-radio-group
+              v-model="evictUserForm.mode"
+              data-testid="evict-user-mode"
+            >
+              <el-radio value="username">By username</el-radio>
+              <el-radio value="user_id">By user_id</el-radio>
+            </el-radio-group>
+          </el-form-item>
+          <el-form-item
+            v-if="evictUserForm.mode === 'username'"
+            label="Username"
+            required
+          >
+            <el-autocomplete
+              v-model="evictUserForm.username"
+              :fetch-suggestions="fetchUsernameSuggestions"
+              placeholder="e.g. mai_lin"
+              clearable
+              style="width: 100%"
+              data-testid="evict-user-username"
+            />
+          </el-form-item>
+          <el-form-item v-else label="User ID" required>
+            <el-input-number
+              v-model="evictUserForm.user_id"
+              :min="1"
+              style="width: 100%"
+              data-testid="evict-user-userid"
+            />
+          </el-form-item>
+        </el-form>
+        <template #footer>
+          <el-button @click="evictUserDialogVisible = false">Cancel</el-button>
+          <el-button
+            type="warning"
+            @click="handleEvictUser"
+            :loading="loading"
+            data-testid="evict-user-submit"
+          >
+            Evict...
+          </el-button>
+        </template>
+      </el-dialog>
     </div>
   </AdminLayout>
 </template>
 
 <style scoped>
-.fallback-sources-page {
-  padding: 20px;
+.page-container {
+  padding: 24px;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 
 .page-header {
@@ -486,6 +893,19 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.cache-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dialog-help {
+  margin: 0 0 16px 0;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .stats-grid {

--- a/src/kohaku-hub-admin/src/utils/api.js
+++ b/src/kohaku-hub-admin/src/utils/api.js
@@ -802,6 +802,64 @@ export async function clearFallbackCache(token) {
   return response.data;
 }
 
+/**
+ * Evict every cached binding for one repo across all user buckets.
+ * Bumps the repo's generation counter so any in-flight probe's
+ * ``safe_set`` is rejected. Use as a surgical alternative to the
+ * global ``clearFallbackCache`` when only one repo's cache is stale.
+ *
+ * @param {string} token - Admin token
+ * @param {("model"|"dataset"|"space")} repoType
+ * @param {string} namespace - Repository namespace (no slashes)
+ * @param {string} name - Repository name (no slashes)
+ * @returns {Promise<{success: boolean, evicted: number, repo_type: string, namespace: string, name: string}>}
+ */
+export async function invalidateFallbackRepoCache(
+  token,
+  repoType,
+  namespace,
+  name,
+) {
+  const client = createAdminClient(token);
+  const response = await client.delete(
+    `/fallback-sources/cache/repo/${encodeURIComponent(repoType)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+  );
+  return response.data;
+}
+
+/**
+ * Evict every cached binding for one user across all repos, addressed
+ * by numeric ``user_id``. Bumps that user's generation counter.
+ *
+ * @param {string} token - Admin token
+ * @param {number} userId - User PK
+ * @returns {Promise<{success: boolean, evicted: number, user_id: number}>}
+ */
+export async function invalidateFallbackUserCacheById(token, userId) {
+  const client = createAdminClient(token);
+  const response = await client.delete(
+    `/fallback-sources/cache/user/${encodeURIComponent(userId)}`,
+  );
+  return response.data;
+}
+
+/**
+ * Evict every cached binding for one user across all repos, addressed
+ * by ``username``. Convenience wrapper that the backend resolves to
+ * ``user_id`` server-side.
+ *
+ * @param {string} token - Admin token
+ * @param {string} username - Username (case-sensitive)
+ * @returns {Promise<{success: boolean, evicted: number, user_id: number, username: string}>}
+ */
+export async function invalidateFallbackUserCacheByUsername(token, username) {
+  const client = createAdminClient(token);
+  const response = await client.delete(
+    `/fallback-sources/cache/username/${encodeURIComponent(username)}`,
+  );
+  return response.data;
+}
+
 // ===== Repository Management =====
 
 /**

--- a/src/kohaku-hub-admin/vitest.config.js
+++ b/src/kohaku-hub-admin/vitest.config.js
@@ -52,6 +52,7 @@ export default defineConfig({
         "src/App.vue",
         "src/components/AdminLayout.vue",
         "src/pages/credentials.vue",
+        "src/pages/fallback-sources.vue",
         "src/pages/health.vue",
         "src/pages/login.vue",
         "src/stores/admin.js",

--- a/src/kohakuhub/api/admin/routers/fallback.py
+++ b/src/kohakuhub/api/admin/routers/fallback.py
@@ -7,7 +7,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from kohakuhub.db import FallbackSource, db
+from kohakuhub.db import FallbackSource, User, db
 from kohakuhub.logger import get_logger
 from kohakuhub.api.admin.utils.auth import verify_admin_token
 from kohakuhub.api.fallback.cache import get_cache
@@ -487,4 +487,59 @@ async def invalidate_user_cache(
         logger.error(f"Failed to invalidate user cache: {e}")
         raise HTTPException(
             500, detail={"error": f"Failed to invalidate user cache: {str(e)}"}
+        )
+
+
+@router.delete("/fallback-sources/cache/username/{username}")
+async def invalidate_user_cache_by_username(
+    username: str,
+    _admin=Depends(verify_admin_token),
+):
+    """Evict cache for one user identified by username (UX-friendly path).
+
+    Convenience wrapper around ``DELETE .../cache/user/{user_id}``: looks
+    up the user by name and forwards to ``cache.clear_user(user.id)``.
+    The admin frontend uses this so operators don't have to hand-look up
+    a numeric user_id.
+
+    Args:
+        username: Username (case-sensitive, matches the User table).
+        _admin: Admin authentication dependency.
+
+    Returns:
+        ``{success, evicted, user_id, username}``.
+
+    Raises:
+        404 if no user with that username exists.
+    """
+    try:
+        user = User.get_or_none(User.username == username)
+        if user is None:
+            raise HTTPException(
+                404, detail={"error": f"User not found: {username}"}
+            )
+        cache = get_cache()
+        evicted = cache.clear_user(user.id)
+
+        logger.info(
+            f"Admin invalidated fallback cache for username={username} "
+            f"(user_id={user.id}, {evicted} entries)"
+        )
+
+        return {
+            "success": True,
+            "evicted": evicted,
+            "user_id": user.id,
+            "username": username,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to invalidate user cache by username: {e}")
+        raise HTTPException(
+            500,
+            detail={
+                "error": f"Failed to invalidate user cache by username: {str(e)}"
+            },
         )

--- a/src/kohakuhub/api/admin/routers/fallback.py
+++ b/src/kohakuhub/api/admin/routers/fallback.py
@@ -92,6 +92,14 @@ async def create_fallback_source(
             updated_at=datetime.now(tz=timezone.utc),
         )
 
+        # Strict-freshness invalidation (#79): a new source can change
+        # which source wins for any given repo (e.g. higher-priority
+        # source supersedes a previously-bound lower-priority one).
+        # Match the existing UPDATE/DELETE paths that already
+        # ``cache.clear()``.
+        cache = get_cache()
+        cache.clear()
+
         logger.info(f"Created fallback source: {source.name} ({source.url})")
 
         return FallbackSourceResponse(
@@ -387,3 +395,96 @@ async def clear_cache(_admin=Depends(verify_admin_token)):
     except Exception as e:
         logger.error(f"Failed to clear cache: {e}")
         raise HTTPException(500, detail={"error": f"Failed to clear cache: {str(e)}"})
+
+
+@router.delete("/fallback-sources/cache/repo/{repo_type}/{namespace}/{name}")
+async def invalidate_repo_cache(
+    repo_type: str,
+    namespace: str,
+    name: str,
+    _admin=Depends(verify_admin_token),
+):
+    """Evict every cached binding for one repo across all user buckets.
+
+    Bumps ``repo_gens[(repo_type, namespace, name)]`` so any fallback
+    probe currently in flight for this repo will have its ``safe_set``
+    rejected. Use for operational hygiene — e.g. when you know a repo's
+    upstream state changed and want every user's next request to
+    re-probe immediately.
+
+    Args:
+        repo_type: "model", "dataset", or "space"
+        namespace: Repository namespace
+        name: Repository name
+        _admin: Admin authentication dependency
+
+    Returns:
+        Eviction count.
+    """
+    try:
+        cache = get_cache()
+        evicted = cache.invalidate_repo(repo_type, namespace, name)
+
+        logger.info(
+            f"Admin invalidated fallback cache for "
+            f"{repo_type}/{namespace}/{name} ({evicted} entries)"
+        )
+
+        return {
+            "success": True,
+            "evicted": evicted,
+            "repo_type": repo_type,
+            "namespace": namespace,
+            "name": name,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to invalidate repo cache: {e}")
+        raise HTTPException(
+            500, detail={"error": f"Failed to invalidate repo cache: {str(e)}"}
+        )
+
+
+@router.delete("/fallback-sources/cache/user/{user_id}")
+async def invalidate_user_cache(
+    user_id: int,
+    _admin=Depends(verify_admin_token),
+):
+    """Evict every cached binding for one user across all repos.
+
+    Bumps ``user_gens[user_id]`` so any fallback probe currently in
+    flight for this user will have its ``safe_set`` rejected. Use for
+    operational hygiene — e.g. when a user's external token has been
+    rotated externally and the user_id-keyed cache needs to drop.
+
+    Args:
+        user_id: User PK (use ``0`` or negative integers for special
+            buckets if needed; the anonymous bucket is keyed by ``None``
+            internally and is not addressable through this endpoint —
+            use ``DELETE /admin/api/fallback-sources/cache/clear``
+            instead to wipe the anonymous bucket).
+        _admin: Admin authentication dependency
+
+    Returns:
+        Eviction count.
+    """
+    try:
+        cache = get_cache()
+        evicted = cache.clear_user(user_id)
+
+        logger.info(
+            f"Admin invalidated fallback cache for user_id={user_id} "
+            f"({evicted} entries)"
+        )
+
+        return {
+            "success": True,
+            "evicted": evicted,
+            "user_id": user_id,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to invalidate user cache: {e}")
+        raise HTTPException(
+            500, detail={"error": f"Failed to invalidate user cache: {str(e)}"}
+        )

--- a/src/kohakuhub/api/auth/external_tokens.py
+++ b/src/kohakuhub/api/auth/external_tokens.py
@@ -16,6 +16,7 @@ from kohakuhub.db_operations import (
 from kohakuhub.logger import get_logger
 from kohakuhub.utils.datetime_utils import safe_isoformat
 from kohakuhub.auth.dependencies import get_current_user
+from kohakuhub.api.fallback.cache import get_cache
 
 router = APIRouter()
 logger = get_logger("AUTH_EXT_TOKENS")
@@ -147,7 +148,16 @@ async def add_external_token(
     # Add/update token
     set_user_external_token(user, data.url, data.token)
 
-    logger.info(f"User {username} set external token for {data.url}")
+    # Strict-freshness invalidation (#79): a per-user token mutation
+    # changes the user's effective fallback chain auth. Drop every
+    # cached binding for this user (across all repos) and bump the
+    # user's generation so any in-flight probe's safe_set is rejected.
+    evicted = get_cache().clear_user(user.id)
+
+    logger.info(
+        f"User {username} set external token for {data.url} "
+        f"(cache evicted {evicted} entries)"
+    )
 
     return {"success": True, "message": "External token saved"}
 
@@ -167,7 +177,13 @@ async def delete_external_token(
     if not deleted:
         raise HTTPException(404, detail="Token not found for this URL")
 
-    logger.info(f"User {username} deleted external token for {url}")
+    # Strict-freshness invalidation (#79): see add_external_token comment.
+    evicted = get_cache().clear_user(user.id)
+
+    logger.info(
+        f"User {username} deleted external token for {url} "
+        f"(cache evicted {evicted} entries)"
+    )
 
     return {"success": True, "message": "External token deleted"}
 
@@ -204,7 +220,15 @@ async def bulk_update_external_tokens(
 
         set_user_external_token(user, token_data.url, token_data.token)
 
-    logger.info(f"User {username} bulk updated {len(data.tokens)} external tokens")
+    # Strict-freshness invalidation (#79): bulk replace is the
+    # "every per-source token may have changed" event; drop every
+    # cached binding for this user and bump the user generation.
+    evicted = get_cache().clear_user(user.id)
+
+    logger.info(
+        f"User {username} bulk updated {len(data.tokens)} external tokens "
+        f"(cache evicted {evicted} entries)"
+    )
 
     return {
         "success": True,

--- a/src/kohakuhub/api/fallback/README.md
+++ b/src/kohakuhub/api/fallback/README.md
@@ -129,15 +129,21 @@ final response is a 404 with `X-Error-Code: RepoNotFound`.
 
 | Property | Value |
 |---|---|
-| Key | `f"fallback:repo:{repo_type}:{namespace}/{name}"` |
+| Key | `f"fallback:repo:u={user_id\|anon}:t={tokens_hash\|}:{repo_type}:{namespace}/{name}"` |
 | Value | `{source_url, source_name, source_type, exists, checked_at}` |
 | TTL | `cfg.fallback.cache_ttl_seconds` (env: `KOHAKU_HUB_FALLBACK_CACHE_TTL`, default `300`) |
 | Eviction | TTL + LRU at `maxsize` |
 
+`tokens_hash` is `sha256_hex(canonical_json(sorted(merged_tokens.items())))[:16]`,
+or empty when no per-user tokens are present. This isolates two requests
+that authenticate as the same user but pass different external tokens
+via `Authorization: Bearer ...|url,token|...`.
+
 Lifecycle:
 
 - **Write**: only on `BIND_AND_RESPOND` / `BIND_AND_PROPAGATE` from a
-  fresh chain probe.
+  fresh chain probe, and only via `safe_set` (see "Generation
+  counters" below).
 - **No write on chain exhaustion**: an aggregate-failure response leaves
   the next caller free to re-probe.
 - **No write from cache hits**: a cache hit serves directly without
@@ -147,28 +153,62 @@ Lifecycle:
   or rebind. The error surfaces to the client. Self-heal is bounded by
   the TTL.
 
-### Operator invalidation
+### Generation counters (race protection, #79)
+
+Three monotonic counters guard against the "an invalidation event lands
+mid-probe and the probe writes a now-stale binding after the
+invalidation" race:
+
+| Counter | Bumped by | Reset on |
+|---|---|---|
+| `global_gen` | `cache.clear()` (admin source mutations) | never |
+| `user_gens[user_id]` | `cache.clear_user(user_id)` (user external-token mutations) | never |
+| `repo_gens[(rt, ns, name)]` | `cache.invalidate_repo(rt, ns, name)` (local repo CRUD, admin per-repo eviction) | never |
+
+`_run_cached_then_chain` snapshots all three before doing upstream I/O
+and passes the snapshot to `safe_set`; `safe_set` rejects the cache
+write if any of the three has been bumped during the probe window.
+Rejection means the response still flows to the caller (it was already
+constructed) but the cache stays empty for that bucket, so the next
+call re-probes with the post-mutation configuration.
+
+### Invalidation matrix
+
+Every event that can change the binding outcome triggers an
+invalidation. Inputs that are boot-time-only (env / TOML) are handled
+by the natural process-restart cycle; runtime-mutable inputs hook into
+the cache as follows:
+
+| Event | Hook location | Cache op | Generation bumped |
+|---|---|---|---|
+| Admin POST/PATCH/DELETE on `FallbackSource` | `api/admin/routers/fallback.py` | `cache.clear()` | `global_gen` |
+| User POST `/api/users/{u}/external-tokens` | `api/auth/external_tokens.py` | `cache.clear_user(user.id)` | `user_gens[uid]` |
+| User DELETE `/api/users/{u}/external-tokens/{url}` | same | `cache.clear_user(user.id)` | `user_gens[uid]` |
+| User PUT `/api/users/{u}/external-tokens/bulk` | same | `cache.clear_user(user.id)` | `user_gens[uid]` |
+| Local POST `/api/repos/create` | `api/repo/routers/crud.py` | `cache.invalidate_repo(rt, ns, name)` | `repo_gens[(rt,ns,n)]` |
+| Local DELETE `/api/repos/delete` | same | `cache.invalidate_repo(rt, ns, name)` | `repo_gens[(rt,ns,n)]` |
+| Local POST `/api/repos/move` (rename / transfer) | same | `cache.invalidate_repo(old)` + `cache.invalidate_repo(new)` | both `repo_gens` entries |
+| Local PUT settings, `private` field changed | `api/settings.py` | `cache.invalidate_repo(rt, ns, name)` | `repo_gens[(rt,ns,n)]` |
+| Local POST `/api/repos/squash` | n/a — `full_id` unchanged | n/a | n/a |
+| Header-token change | per-request | n/a — encoded in cache key via `tokens_hash` | n/a |
+
+### Operator invalidation endpoints
 
 | Endpoint | Effect |
 |---|---|
-| `DELETE /admin/api/fallback-sources/cache/clear` | Wipe the entire cache. |
-| Admin source create / update / delete | Implicitly clears the cache (any source-list change can invalidate prior bindings). |
-
-A per-repo invalidate endpoint is tracked in
-[#78](https://github.com/deepghs/KohakuHub/issues/78).
+| `DELETE /admin/api/fallback-sources/cache/clear` | Wipe entire cache; bumps `global_gen`. |
+| `DELETE /admin/api/fallback-sources/cache/repo/{repo_type}/{namespace}/{name}` | Evict every (user, tokens_hash, repo) bucket for one repo; bumps that repo's gen. |
+| `DELETE /admin/api/fallback-sources/cache/user/{user_id}` | Evict every (tokens_hash, repo) bucket for one user; bumps that user's gen. |
 
 ### Planned changes
-
-The current TTL default and key shape are points of active work:
 
 - [#78](https://github.com/deepghs/KohakuHub/issues/78) lowers the
   default TTL to `60` (self-heal window 1 minute instead of 5),
   decouples chain probing into a pure `core.probe_chain` function, and
   adds admin tooling for chain inspection and what-if simulation.
-- [#79](https://github.com/deepghs/KohakuHub/issues/79) adds `user_id`
-  to the cache key so two users with different effective source
-  visibility cannot share a binding, and invalidates the cache on
-  per-user token rotation.
+- Multi-worker shared cache (so admin clear in one fork is visible to
+  siblings) is a separate follow-up — the current implementation is
+  per-process in-memory.
 
 ## Configuration
 

--- a/src/kohakuhub/api/fallback/cache.py
+++ b/src/kohakuhub/api/fallback/cache.py
@@ -1,10 +1,29 @@
 """Cache system for repository→source mappings.
 
-Caches which external source has a given repository to reduce external API calls.
-Does NOT cache actual content, only the mapping.
+Caches which external source has a given repository to reduce external
+API calls. Does NOT cache actual content — only the binding (which
+source serves a given ``repo_id``).
+
+Strict-freshness contract (#79):
+
+- Key includes ``user_id`` and ``tokens_hash`` so two users with
+  different effective per-source tokens cannot share a binding, and a
+  request carrying ``Authorization: Bearer ...|url,token|...`` external
+  tokens cannot read another request's binding.
+- Three independent monotonic generation counters (``global_gen``,
+  ``user_gens``, ``repo_gens``) close the "admin/user/repo mutation
+  lands while a probe is in flight, and the probe writes a stale
+  binding after the invalidation" race. ``safe_set`` rejects writes
+  whose starting snapshot disagrees with the current generations.
+- Mutation methods (``clear``, ``clear_user``, ``invalidate_repo``)
+  bump their respective counters in addition to deleting cache
+  entries.
 """
 
+import hashlib
+import json
 import time
+from collections import defaultdict
 from typing import Optional
 
 from cachetools import TTLCache
@@ -15,59 +34,100 @@ from kohakuhub.logger import get_logger
 logger = get_logger("FALLBACK_CACHE")
 
 
+def compute_tokens_hash(user_tokens: dict[str, str] | None) -> str:
+    """Compute a stable, order-invariant hash of a user's effective tokens.
+
+    Used as part of the fallback cache key so two requests sharing the
+    same effective token set hit the same cache entry, but a request
+    with any per-source token difference is isolated to its own bucket.
+
+    Args:
+        user_tokens: Dict mapping ``url → token`` or ``None``.
+
+    Returns:
+        16-hex-char prefix of ``sha256(canonical_json(sorted_items))``.
+        Empty string if ``user_tokens`` is empty/None.
+    """
+    if not user_tokens:
+        return ""
+    canonical = json.dumps(
+        sorted(user_tokens.items()), separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
 class RepoSourceCache:
-    """TTL cache for repo→source mappings."""
+    """TTL+LRU cache for repo→source bindings, keyed per user+tokens_hash.
+
+    Generation counters provide race protection against invalidation
+    events landing while a probe is in flight; see ``safe_set``.
+    """
 
     def __init__(self, ttl_seconds: int = 300, maxsize: int = 10000):
         """Initialize cache.
 
         Args:
-            ttl_seconds: Time-to-live for cache entries
-            maxsize: Maximum number of entries
+            ttl_seconds: TTL for cache entries.
+            maxsize: LRU size cap.
         """
-        self.cache = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+        self.cache: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
         self.ttl = ttl_seconds
+        # Generations are monotonic counters bumped by mutation methods.
+        # ``snapshot`` reads them at probe start; ``safe_set`` re-reads at
+        # probe end and rejects the write if any has been bumped.
+        self.global_gen: int = 0
+        self.user_gens: defaultdict = defaultdict(int)
+        self.repo_gens: defaultdict = defaultdict(int)
 
-    def get_key(self, repo_type: str, namespace: str, name: str) -> str:
-        """Generate cache key.
+    @staticmethod
+    def _user_key(user_id: Optional[int]) -> str:
+        return "anon" if user_id is None else str(user_id)
 
-        Args:
-            repo_type: "model", "dataset", or "space"
-            namespace: Repository namespace
-            name: Repository name
+    def get_key(
+        self,
+        user_id: Optional[int],
+        tokens_hash: str,
+        repo_type: str,
+        namespace: str,
+        name: str,
+    ) -> str:
+        """Build the canonical cache key.
 
-        Returns:
-            Cache key string
+        Format: ``fallback:repo:u={user_id|anon}:t={tokens_hash|}:{repo_type}:{ns}/{name}``.
+        Only the suffix ``:{repo_type}:{ns}/{name}`` is used by
+        ``invalidate_repo`` for repo-wide eviction.
         """
-        return f"fallback:repo:{repo_type}:{namespace}/{name}"
+        u = self._user_key(user_id)
+        h = tokens_hash or ""
+        return f"fallback:repo:u={u}:t={h}:{repo_type}:{namespace}/{name}"
 
     def get(
-        self, repo_type: str, namespace: str, name: str
-    ) -> Optional[dict[str, any]]:
-        """Get cached source information.
-
-        Args:
-            repo_type: "model", "dataset", or "space"
-            namespace: Repository namespace
-            name: Repository name
-
-        Returns:
-            Cached source info dict or None if not found/expired
-        """
-        key = self.get_key(repo_type, namespace, name)
+        self,
+        user_id: Optional[int],
+        tokens_hash: str,
+        repo_type: str,
+        namespace: str,
+        name: str,
+    ) -> Optional[dict]:
+        """Get cached source info for one (user, tokens_hash, repo) bucket."""
+        key = self.get_key(user_id, tokens_hash, repo_type, namespace, name)
         cached = self.cache.get(key)
-
         if cached:
             logger.debug(
-                f"Cache HIT: {repo_type}/{namespace}/{name} -> {cached.get('source_name')}"
+                f"Cache HIT: u={self._user_key(user_id)} "
+                f"{repo_type}/{namespace}/{name} -> {cached.get('source_name')}"
             )
             return cached
-        else:
-            logger.debug(f"Cache MISS: {repo_type}/{namespace}/{name}")
-            return None
+        logger.debug(
+            f"Cache MISS: u={self._user_key(user_id)} "
+            f"{repo_type}/{namespace}/{name}"
+        )
+        return None
 
     def set(
         self,
+        user_id: Optional[int],
+        tokens_hash: str,
         repo_type: str,
         namespace: str,
         name: str,
@@ -75,19 +135,15 @@ class RepoSourceCache:
         source_name: str,
         source_type: str,
         exists: bool = True,
-    ):
-        """Cache source information.
+    ) -> None:
+        """Unconditionally set the cache entry.
 
-        Args:
-            repo_type: "model", "dataset", or "space"
-            namespace: Repository namespace
-            name: Repository name
-            source_url: Base URL of the source
-            source_name: Display name of the source
-            source_type: "huggingface" or "kohakuhub"
-            exists: Whether the repo exists at this source
+        Prefer ``safe_set`` from inside the operations layer — it adds
+        the generation-counter race check. Plain ``set`` is provided
+        for tests and for the rare path that needs to write without
+        race protection.
         """
-        key = self.get_key(repo_type, namespace, name)
+        key = self.get_key(user_id, tokens_hash, repo_type, namespace, name)
         value = {
             "source_url": source_url,
             "source_name": source_name,
@@ -95,52 +151,184 @@ class RepoSourceCache:
             "checked_at": int(time.time()),
             "exists": exists,
         }
-
         self.cache[key] = value
         logger.debug(
-            f"Cache SET: {repo_type}/{namespace}/{name} -> {source_name} (TTL={self.ttl}s)"
+            f"Cache SET: u={self._user_key(user_id)} "
+            f"{repo_type}/{namespace}/{name} -> {source_name} (TTL={self.ttl}s)"
         )
 
-    def invalidate(self, repo_type: str, namespace: str, name: str):
-        """Invalidate cache entry.
+    def snapshot(
+        self,
+        user_id: Optional[int],
+        repo_type: str,
+        namespace: str,
+        name: str,
+    ) -> tuple[int, int, int]:
+        """Capture ``(global_gen, user_gen, repo_gen)`` for ``safe_set``.
 
-        Args:
-            repo_type: "model", "dataset", or "space"
-            namespace: Repository namespace
-            name: Repository name
+        The probe orchestrator should call this *before* doing any
+        upstream I/O, then pass the tuple to ``safe_set`` after the
+        probe completes. ``safe_set`` rejects the write if any of the
+        three counters has been bumped, indicating an invalidation
+        event landed during the probe window.
         """
-        key = self.get_key(repo_type, namespace, name)
+        return (
+            self.global_gen,
+            self.user_gens[user_id],
+            self.repo_gens[(repo_type, namespace, name)],
+        )
+
+    def safe_set(
+        self,
+        user_id: Optional[int],
+        tokens_hash: str,
+        repo_type: str,
+        namespace: str,
+        name: str,
+        source_url: str,
+        source_name: str,
+        source_type: str,
+        gens_at_start: tuple[int, int, int],
+        exists: bool = True,
+    ) -> bool:
+        """Set cache only if generations are unchanged since ``gens_at_start``.
+
+        Returns True if the entry was written; False if any of the
+        three generation counters has been bumped between
+        ``gens_at_start`` and now (admin source mutation, user token
+        rotation, or repo CRUD landed mid-probe).
+
+        On rejection the cache stays empty for this (user, tokens, repo)
+        bucket and the next request will re-probe with the post-mutation
+        configuration — strict freshness preserved.
+        """
+        if self.snapshot(user_id, repo_type, namespace, name) != gens_at_start:
+            logger.debug(
+                f"Cache SET REJECTED (gen changed mid-probe): "
+                f"u={self._user_key(user_id)} {repo_type}/{namespace}/{name}"
+            )
+            return False
+        self.set(
+            user_id,
+            tokens_hash,
+            repo_type,
+            namespace,
+            name,
+            source_url,
+            source_name,
+            source_type,
+            exists=exists,
+        )
+        return True
+
+    def invalidate(
+        self,
+        user_id: Optional[int],
+        tokens_hash: str,
+        repo_type: str,
+        namespace: str,
+        name: str,
+    ) -> bool:
+        """Delete a single (user, tokens_hash, repo) entry.
+
+        Does NOT bump any generation counter — used for narrow
+        per-entry hygiene (e.g. orphan-source detection in
+        ``_run_cached_then_chain``). Repo-wide / user-wide / global
+        invalidations should call ``invalidate_repo`` / ``clear_user``
+        / ``clear``, which bump the appropriate generations.
+
+        Returns True if an entry was deleted, False if the key was
+        already absent.
+        """
+        key = self.get_key(user_id, tokens_hash, repo_type, namespace, name)
         if key in self.cache:
             del self.cache[key]
-            logger.debug(f"Cache INVALIDATE: {repo_type}/{namespace}/{name}")
+            logger.debug(
+                f"Cache INVALIDATE: u={self._user_key(user_id)} "
+                f"{repo_type}/{namespace}/{name}"
+            )
+            return True
+        return False
 
-    def clear(self):
-        """Clear all cache entries."""
+    def invalidate_repo(
+        self, repo_type: str, namespace: str, name: str
+    ) -> int:
+        """Evict every (user, tokens_hash, repo) bucket for one repo.
+
+        Bumps ``repo_gens[(repo_type, namespace, name)]`` so any
+        probe currently in flight for this repo will have its
+        ``safe_set`` rejected. Returns the number of cache entries
+        evicted.
+
+        Triggered by local repo create/delete/move/visibility-toggle
+        and the admin per-repo eviction endpoint — see the strict
+        freshness contract.
+        """
+        self.repo_gens[(repo_type, namespace, name)] += 1
+        suffix = f":{repo_type}:{namespace}/{name}"
+        evicted_keys = [k for k in list(self.cache.keys()) if k.endswith(suffix)]
+        for k in evicted_keys:
+            del self.cache[k]
+        if evicted_keys:
+            logger.info(
+                f"Cache INVALIDATE_REPO: {repo_type}/{namespace}/{name} "
+                f"({len(evicted_keys)} entries)"
+            )
+        return len(evicted_keys)
+
+    def clear_user(self, user_id: Optional[int]) -> int:
+        """Evict every (tokens_hash, repo) bucket for one user.
+
+        Bumps ``user_gens[user_id]`` so any probe currently in flight
+        for that user has its ``safe_set`` rejected. Returns the
+        number of cache entries evicted.
+
+        Triggered by user external-token POST/DELETE/PUT bulk and the
+        admin per-user eviction endpoint.
+        """
+        self.user_gens[user_id] += 1
+        prefix = f"fallback:repo:u={self._user_key(user_id)}:"
+        evicted_keys = [
+            k for k in list(self.cache.keys()) if k.startswith(prefix)
+        ]
+        for k in evicted_keys:
+            del self.cache[k]
+        if evicted_keys:
+            logger.info(
+                f"Cache CLEAR_USER: user_id={user_id} "
+                f"({len(evicted_keys)} entries)"
+            )
+        return len(evicted_keys)
+
+    def clear(self) -> None:
+        """Wipe the entire cache; bump ``global_gen``.
+
+        Triggered by admin source list mutations (create/update/delete)
+        and the admin global cache-clear endpoint.
+        """
+        self.global_gen += 1
         self.cache.clear()
-        logger.info("Cache cleared")
+        logger.info("Cache cleared (global_gen bumped)")
 
     def stats(self) -> dict:
-        """Get cache statistics.
-
-        Returns:
-            Dict with cache stats (size, maxsize, ttl)
-        """
+        """Return cache statistics for the admin / observability surface."""
         return {
             "size": len(self.cache),
             "maxsize": self.cache.maxsize,
             "ttl_seconds": self.ttl,
+            "global_gen": self.global_gen,
         }
 
 
 # Global cache instance
-_cache = None
+_cache: Optional[RepoSourceCache] = None
 
 
 def get_cache() -> RepoSourceCache:
-    """Get global cache instance (singleton).
+    """Get the singleton cache instance.
 
     Returns:
-        Global RepoSourceCache instance
+        Global ``RepoSourceCache``.
     """
     global _cache
     if _cache is None:
@@ -148,3 +336,9 @@ def get_cache() -> RepoSourceCache:
         _cache = RepoSourceCache(ttl_seconds=ttl)
         logger.info(f"Initialized fallback cache (TTL={ttl}s)")
     return _cache
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the singleton instance. Test-only hook."""
+    global _cache
+    _cache = None

--- a/src/kohakuhub/api/fallback/cache.py
+++ b/src/kohakuhub/api/fallback/cache.py
@@ -23,7 +23,6 @@ Strict-freshness contract (#79):
 import hashlib
 import json
 import time
-from collections import defaultdict
 from typing import Optional
 
 from cachetools import TTLCache
@@ -75,9 +74,17 @@ class RepoSourceCache:
         # Generations are monotonic counters bumped by mutation methods.
         # ``snapshot`` reads them at probe start; ``safe_set`` re-reads at
         # probe end and rejects the write if any has been bumped.
+        #
+        # Storage is a plain ``dict`` (not ``defaultdict``) so that the
+        # read-only ``snapshot`` path uses ``.get(key, 0)`` and never
+        # materializes a phantom entry. Without this, every distinct
+        # ``(user_id, repo_type, namespace, name)`` ever queried would
+        # leave a permanent zero-valued counter in ``user_gens`` /
+        # ``repo_gens`` — an unbounded leak under workloads with high
+        # repo / user cardinality.
         self.global_gen: int = 0
-        self.user_gens: defaultdict = defaultdict(int)
-        self.repo_gens: defaultdict = defaultdict(int)
+        self.user_gens: dict[Optional[int], int] = {}
+        self.repo_gens: dict[tuple[str, str, str], int] = {}
 
     @staticmethod
     def _user_key(user_id: Optional[int]) -> str:
@@ -172,10 +179,12 @@ class RepoSourceCache:
         three counters has been bumped, indicating an invalidation
         event landed during the probe window.
         """
+        # ``.get(key, 0)`` rather than indexing — keeps the read-only
+        # snapshot path from creating phantom entries (see __init__).
         return (
             self.global_gen,
-            self.user_gens[user_id],
-            self.repo_gens[(repo_type, namespace, name)],
+            self.user_gens.get(user_id, 0),
+            self.repo_gens.get((repo_type, namespace, name), 0),
         )
 
     def safe_set(
@@ -264,7 +273,8 @@ class RepoSourceCache:
         and the admin per-repo eviction endpoint — see the strict
         freshness contract.
         """
-        self.repo_gens[(repo_type, namespace, name)] += 1
+        key = (repo_type, namespace, name)
+        self.repo_gens[key] = self.repo_gens.get(key, 0) + 1
         suffix = f":{repo_type}:{namespace}/{name}"
         evicted_keys = [k for k in list(self.cache.keys()) if k.endswith(suffix)]
         for k in evicted_keys:
@@ -286,7 +296,7 @@ class RepoSourceCache:
         Triggered by user external-token POST/DELETE/PUT bulk and the
         admin per-user eviction endpoint.
         """
-        self.user_gens[user_id] += 1
+        self.user_gens[user_id] = self.user_gens.get(user_id, 0) + 1
         prefix = f"fallback:repo:u={self._user_key(user_id)}:"
         evicted_keys = [
             k for k in list(self.cache.keys()) if k.startswith(prefix)

--- a/src/kohakuhub/api/fallback/decorators.py
+++ b/src/kohakuhub/api/fallback/decorators.py
@@ -235,6 +235,7 @@ def with_repo_fallback(operation: OperationType):
                             path,
                             user_tokens=user_tokens,
                             method=method,
+                            user=user,
                         )
 
                     case "tree":
@@ -255,11 +256,13 @@ def with_repo_fallback(operation: OperationType):
                             limit=limit,
                             cursor=cursor,
                             user_tokens=user_tokens,
+                            user=user,
                         )
 
                     case "info" | "revision":
                         result = await try_fallback_info(
-                            repo_type, namespace, name, user_tokens=user_tokens
+                            repo_type, namespace, name,
+                            user_tokens=user_tokens, user=user,
                         )
 
                     case "paths_info":
@@ -275,6 +278,7 @@ def with_repo_fallback(operation: OperationType):
                             paths,
                             expand=expand,
                             user_tokens=user_tokens,
+                            user=user,
                         )
 
                     case _:

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 from kohakuhub.config import cfg
 from kohakuhub.logger import get_logger
-from kohakuhub.api.fallback.cache import get_cache
+from kohakuhub.api.fallback.cache import compute_tokens_hash, get_cache
 from kohakuhub.api.fallback.client import FallbackClient
 from kohakuhub.api.fallback.config import get_enabled_sources
 from kohakuhub.api.fallback.utils import (
@@ -24,6 +24,13 @@ from kohakuhub.api.fallback.utils import (
     should_retry_source,
     strip_xet_response_headers,
 )
+
+
+def _resolve_user_id(user) -> Optional[int]:
+    """Extract a stable user_id key from a (possibly None) User object."""
+    if user is None:
+        return None
+    return getattr(user, "id", None)
 
 
 def _propagate_upstream_response(
@@ -101,6 +108,8 @@ async def _run_cached_then_chain(
     repo_type: str,
     namespace: str,
     name: str,
+    user_id: Optional[int],
+    tokens_hash: str,
     sources: list[dict],
     cache,
     attempts: list[dict],
@@ -112,39 +121,52 @@ async def _run_cached_then_chain(
     Strict-consistency rules (the user-facing guarantee for #77):
 
     1. **TTL-window stickiness.** Within the cache TTL window, every
-       call for a given ``(repo_type, namespace, name)`` is routed to
-       the same source. If that source's response classifies as
-       ``TRY_NEXT_SOURCE`` (5xx, transient auth, etc.), we surface the
-       error to the caller **without invalidating the cache**.
-       Rationale: invalidating + rebinding to a sibling source under
-       transient bound-source failure produces cross-source mixing
-       across calls — exactly the inconsistency #77 fixes. The client
-       can retry; retries within TTL hit the same source. (Operator
-       remediation: explicit ``cache.invalidate`` via the admin API
-       when rebinding is desired.)
+       call for a given ``(user_id, tokens_hash, repo_type, namespace,
+       name)`` is routed to the same source. If that source's response
+       classifies as ``TRY_NEXT_SOURCE`` (5xx, transient auth, etc.),
+       we surface the error to the caller **without invalidating the
+       cache**. Rationale: invalidating + rebinding to a sibling
+       source under transient bound-source failure produces
+       cross-source mixing across calls — exactly the inconsistency
+       #77 fixes. The client can retry; retries within TTL hit the
+       same source.
 
     2. **Concurrent-binding lock.** When the cache misses and the
        chain probe is needed, concurrent callers serialize on a
        per-repo ``asyncio.Lock``. The first holder writes the cache;
        subsequent holders re-check the cache after acquiring the lock
-       and use the now-bound source. Eliminates the race where two
-       concurrent first-binders can bind to different sources due to
-       per-source latency variation.
+       and use the now-bound source.
 
     3. **Orphaned-cache invalidation only.** The single case that
        *does* invalidate the cache is when the cached source URL is
        no longer in the active ``sources`` list (admin removed it
        from config). That isn't a transient failure — it's a
-       configuration change — and the only correct behavior is to
-       re-bind via the (new) chain.
+       configuration change.
 
     4. **Deterministic chain order.** Sources are configured in a
-       priority-ordered list (``get_enabled_sources``); the chain
-       walks them in order and the first ``BIND_*`` outcome wins.
-       So under "same auth + same external state", even after TTL
-       expiry, the next chain probe binds the same source.
+       priority-ordered list; the chain walks them in order and the
+       first ``BIND_*`` outcome wins.
+
+    Strict-freshness extension (#79):
+
+    5. **Per-(user, tokens_hash) keying.** Two requests with different
+       effective per-source tokens (DB or header-passed) cannot share
+       a binding. ``user_id`` and ``tokens_hash`` are part of the
+       cache key.
+
+    6. **Generation-counter race protection.** A snapshot of
+       ``(global_gen, user_gens[uid], repo_gens[(rt, ns, name)])`` is
+       captured before each probe attempt. ``safe_set`` (in the
+       attempt callbacks) rejects the cache write if any of the three
+       counters has been bumped during the probe — meaning an
+       admin/user/repo invalidation event landed concurrently and the
+       binding we are about to write may already be stale.
     """
-    cached_entry = cache.get(repo_type, namespace, name)
+    # Pre-lock cache hit fast-path: avoid taking the binding lock when
+    # the entry is already bound. Snapshot generations BEFORE any
+    # upstream I/O so safe_set in attempt_fn sees a consistent baseline.
+    gens = cache.snapshot(user_id, repo_type, namespace, name)
+    cached_entry = cache.get(user_id, tokens_hash, repo_type, namespace, name)
     if cached_entry and cached_entry.get("exists"):
         cached_url = cached_entry["source_url"]
         cached_source = next((s for s in sources if s["url"] == cached_url), None)
@@ -153,7 +175,7 @@ async def _run_cached_then_chain(
                 f"Cache hit: probing {cached_source['name']} only for "
                 f"{repo_type}/{namespace}/{name}"
             )
-            result = await attempt_fn(cached_source)
+            result = await attempt_fn(cached_source, gens)
             if result is not None:
                 return result
             # Strict-consistency rule #1: bound source's TRY_NEXT
@@ -170,28 +192,36 @@ async def _run_cached_then_chain(
         else:
             # Strict-consistency rule #3: orphaned cache (admin
             # removed the source from config) must invalidate so the
-            # chain can find a new home for this repo_id.
+            # chain can find a new home for this repo_id. Per-entry
+            # delete (no gen bump) — admin source mutation already
+            # bumped global_gen via cache.clear().
             logger.debug(
                 f"Cache hit on orphan source url={cached_url} "
                 f"(no longer in active config); invalidating + rebinding"
             )
-            cache.invalidate(repo_type, namespace, name)
+            cache.invalidate(
+                user_id, tokens_hash, repo_type, namespace, name
+            )
 
     # Strict-consistency rule #2: concurrent-binding lock.
     binding_lock = _binding_lock(repo_type, namespace, name)
     async with binding_lock:
+        # Re-snapshot under the lock so the chain probe + safe_set
+        # see a fresh baseline (generations may have changed while
+        # we were waiting on the lock).
+        gens = cache.snapshot(user_id, repo_type, namespace, name)
         # Re-check the cache after lock acquisition: another waiter may
-        # have already bound this repo while we were queued. If they
-        # did, fall back to the cache-hit fast-path (which also applies
-        # the "bound-source failure does not invalidate" rule).
-        cached_entry = cache.get(repo_type, namespace, name)
+        # have already bound this repo while we were queued.
+        cached_entry = cache.get(
+            user_id, tokens_hash, repo_type, namespace, name
+        )
         if cached_entry and cached_entry.get("exists"):
             cached_url = cached_entry["source_url"]
             cached_source = next(
                 (s for s in sources if s["url"] == cached_url), None
             )
             if cached_source:
-                result = await attempt_fn(cached_source)
+                result = await attempt_fn(cached_source, gens)
                 if result is not None:
                     return result
                 return build_aggregate_failure_response(
@@ -201,16 +231,15 @@ async def _run_cached_then_chain(
             # config — extremely rare (admin reconfig race between
             # the binder's ``cache.set`` and the waiter's post-lock
             # cache-recheck); treat as orphan and proceed to a
-            # fresh chain. Practically unreachable from a unit test
-            # because reproducing it requires an admin to remove a
-            # source from config in the asyncio yield window inside
-            # the binding lock.
-            cache.invalidate(repo_type, namespace, name)  # pragma: no cover
+            # fresh chain.
+            cache.invalidate(  # pragma: no cover
+                user_id, tokens_hash, repo_type, namespace, name
+            )
 
         # Fresh chain probe: deterministic priority order, first
         # BIND wins.
         for source in sources:
-            result = await attempt_fn(source)
+            result = await attempt_fn(source, gens)
             if result is not None:
                 return result
 
@@ -232,6 +261,7 @@ async def try_fallback_resolve(
     path: str,
     user_tokens: dict[str, str] | None = None,
     method: str = "GET",
+    user=None,
 ) -> Optional[Response]:
     """Try to resolve file from fallback sources.
 
@@ -243,6 +273,9 @@ async def try_fallback_resolve(
         path: File path in repository
         user_tokens: User-provided external tokens (overrides admin tokens)
         method: HTTP method ("GET" or "HEAD")
+        user: Authenticated user (or None for anonymous). Threaded
+            through to the cache key as ``user_id`` for strict
+            per-user binding isolation (#79).
 
     Returns:
         Response (redirect for GET, response with headers for HEAD) or None if not found
@@ -254,6 +287,9 @@ async def try_fallback_resolve(
         logger.debug(f"No fallback sources configured for {namespace}")
         return None
 
+    user_id = _resolve_user_id(user)
+    tokens_hash = compute_tokens_hash(user_tokens)
+
     # Construct KohakuHub path
     kohaku_path = f"/{repo_type}s/{namespace}/{name}/resolve/{revision}/{path}"
 
@@ -264,20 +300,25 @@ async def try_fallback_resolve(
     # remediation (token, retry, move on).
     attempts: list[dict] = []
 
-    async def _attempt(source):
+    async def _attempt(source, gens):
         return await _resolve_one_source(
             source,
             repo_type,
             namespace,
             name,
+            user_id,
+            tokens_hash,
             kohaku_path,
             method,
             attempts,
             cache,
+            gens,
         )
 
     return await _run_cached_then_chain(
-        repo_type, namespace, name, sources, cache, attempts, _attempt,
+        repo_type, namespace, name,
+        user_id, tokens_hash,
+        sources, cache, attempts, _attempt,
         # `resolve` is per-file. All-404 → EntryNotFound (default scope
         # for the aggregate). The aggregate's own status-priority logic
         # promotes that to RepoNotFound if any attempt was a bare-401
@@ -291,10 +332,13 @@ async def _resolve_one_source(
     repo_type: str,
     namespace: str,
     name: str,
+    user_id: Optional[int],
+    tokens_hash: str,
     kohaku_path: str,
     method: str,
     attempts: list[dict],
     cache,
+    gens: tuple[int, int, int],
 ) -> Optional[Response]:
     """Run a resolve probe (HEAD, then GET if method=GET) against one source.
 
@@ -333,13 +377,21 @@ async def _resolve_one_source(
 
     # BIND_AND_RESPOND or BIND_AND_PROPAGATE: this source has the repo.
     # Update cache so subsequent requests skip the chain probe.
-    cache.set(
+    # ``safe_set`` rejects the write if any of the three generation
+    # counters has been bumped since the snapshot at probe entry —
+    # admin source mutation, this user's token rotation, or this
+    # repo's local CRUD (create/delete/move/visibility) all bump
+    # their respective counters and force a re-probe on the next call.
+    cache.safe_set(
+        user_id,
+        tokens_hash,
         repo_type,
         namespace,
         name,
         source["url"],
         source["name"],
         source["source_type"],
+        gens_at_start=gens,
         exists=True,
     )
 
@@ -519,6 +571,7 @@ async def try_fallback_info(
     namespace: str,
     name: str,
     user_tokens: dict[str, str] | None = None,
+    user=None,
 ) -> Optional[dict]:
     """Try to get repository info from fallback sources.
 
@@ -527,6 +580,7 @@ async def try_fallback_info(
         namespace: Repository namespace
         name: Repository name
         user_tokens: User-provided external tokens (overrides admin tokens)
+        user: Authenticated user (or None) for per-user cache isolation.
 
     Returns:
         Repository info dict or None if not found
@@ -537,11 +591,14 @@ async def try_fallback_info(
     if not sources:
         return None
 
+    user_id = _resolve_user_id(user)
+    tokens_hash = compute_tokens_hash(user_tokens)
+
     # Construct API path
     kohaku_path = f"/api/{repo_type}s/{namespace}/{name}"
     attempts: list[dict] = []
 
-    async def _attempt(source):
+    async def _attempt(source, gens):
         try:
             client = FallbackClient(
                 source_url=source["url"],
@@ -568,9 +625,11 @@ async def try_fallback_info(
             return None
 
         # BIND — write cache for repo-grain reuse.
-        cache.set(
+        cache.safe_set(
+            user_id, tokens_hash,
             repo_type, namespace, name,
             source["url"], source["name"], source["source_type"],
+            gens_at_start=gens,
             exists=True,
         )
 
@@ -597,7 +656,9 @@ async def try_fallback_info(
         return data
 
     return await _run_cached_then_chain(
-        repo_type, namespace, name, sources, cache, attempts, _attempt,
+        repo_type, namespace, name,
+        user_id, tokens_hash,
+        sources, cache, attempts, _attempt,
         aggregate_scope="repo",
     )
 
@@ -613,6 +674,7 @@ async def try_fallback_tree(
     limit: int | None = None,
     cursor: str | None = None,
     user_tokens: dict[str, str] | None = None,
+    user=None,
 ) -> Optional[Response]:
     """Try to get repository tree from fallback sources.
 
@@ -623,6 +685,7 @@ async def try_fallback_tree(
         revision: Branch or commit
         path: Path within repository
         user_tokens: User-provided external tokens (overrides admin tokens)
+        user: Authenticated user (or None) for per-user cache isolation.
 
     Returns:
         JSON response or None if not found
@@ -632,6 +695,9 @@ async def try_fallback_tree(
 
     if not sources:
         return None
+
+    user_id = _resolve_user_id(user)
+    tokens_hash = compute_tokens_hash(user_tokens)
 
     # Construct API path (strip leading slash from path to avoid double slash)
     clean_path = path.lstrip("/") if path else ""
@@ -644,7 +710,7 @@ async def try_fallback_tree(
     if cursor:
         params["cursor"] = cursor
 
-    async def _attempt(source):
+    async def _attempt(source, gens):
         try:
             client = FallbackClient(
                 source_url=source["url"],
@@ -670,9 +736,11 @@ async def try_fallback_tree(
             attempts.append(build_fallback_attempt(source, response=response))
             return None
 
-        cache.set(
+        cache.safe_set(
+            user_id, tokens_hash,
             repo_type, namespace, name,
             source["url"], source["name"], source["source_type"],
+            gens_at_start=gens,
             exists=True,
         )
 
@@ -704,7 +772,9 @@ async def try_fallback_tree(
         )
 
     return await _run_cached_then_chain(
-        repo_type, namespace, name, sources, cache, attempts, _attempt,
+        repo_type, namespace, name,
+        user_id, tokens_hash,
+        sources, cache, attempts, _attempt,
         # Tree is a repo-level operation: scope="repo" so all-404 maps
         # to RepoNotFound (matches HF for a missing repo).
         aggregate_scope="repo",
@@ -719,6 +789,7 @@ async def try_fallback_paths_info(
     paths: list[str],
     expand: bool = False,
     user_tokens: dict[str, str] | None = None,
+    user=None,
 ) -> Optional[list]:
     """Try to get paths info from fallback sources.
 
@@ -729,6 +800,7 @@ async def try_fallback_paths_info(
         revision: Branch or commit
         paths: List of paths to query
         user_tokens: User-provided external tokens (overrides admin tokens)
+        user: Authenticated user (or None) for per-user cache isolation.
 
     Returns:
         List of path info objects or None if not found
@@ -739,11 +811,14 @@ async def try_fallback_paths_info(
     if not sources:
         return None
 
+    user_id = _resolve_user_id(user)
+    tokens_hash = compute_tokens_hash(user_tokens)
+
     # Construct API path
     kohaku_path = f"/api/{repo_type}s/{namespace}/{name}/paths-info/{revision}"
     attempts: list[dict] = []
 
-    async def _attempt(source):
+    async def _attempt(source, gens):
         try:
             client = FallbackClient(
                 source_url=source["url"],
@@ -772,9 +847,11 @@ async def try_fallback_paths_info(
             attempts.append(build_fallback_attempt(source, response=response))
             return None
 
-        cache.set(
+        cache.safe_set(
+            user_id, tokens_hash,
             repo_type, namespace, name,
             source["url"], source["name"], source["source_type"],
+            gens_at_start=gens,
             exists=True,
         )
 
@@ -794,7 +871,9 @@ async def try_fallback_paths_info(
         return response.json()
 
     return await _run_cached_then_chain(
-        repo_type, namespace, name, sources, cache, attempts, _attempt,
+        repo_type, namespace, name,
+        user_id, tokens_hash,
+        sources, cache, attempts, _attempt,
         # paths-info is per-file (answers "does file X exist at
         # revision R"), so all-404 stays scope="file" → EntryNotFound.
         aggregate_scope="file",

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -48,6 +48,7 @@ from kohakuhub.api.quota.util import (
     update_repository_storage,
 )
 from kohakuhub.api.repo.utils.gc import cleanup_repository_storage
+from kohakuhub.api.fallback.cache import get_cache as get_fallback_cache
 from kohakuhub.api.validation import normalize_name
 
 logger = get_logger("REPO")
@@ -307,6 +308,15 @@ async def create_repo(
         defaults={"private": payload.private, "owner": user},
     )
 
+    # Strict-freshness invalidation (#79): a fallback ghost binding for
+    # this repo (written before the local repo existed) must be evicted
+    # so a future ``with_repo_fallback`` 404 path cannot resurrect a
+    # stale upstream binding for the now-occupied namespace slot.
+    # ``invalidate_repo`` also bumps ``repo_gens[(rt, ns, name)]`` so
+    # any fallback probe currently in flight has its ``safe_set``
+    # rejected.
+    get_fallback_cache().invalidate_repo(payload.type, namespace, payload.name)
+
     return {
         "url": f"{cfg.app.base_url}/{payload.type}s/{full_id}",
         "repo_id": full_id,
@@ -408,6 +418,15 @@ async def delete_repo(
     except Exception as e:
         logger.exception(f"Database deletion failed for {full_id}", e)
         return hf_server_error(f"Database deletion failed for {full_id}: {str(e)}")
+
+    # Strict-freshness invalidation (#79): the local repo is gone so
+    # subsequent reads will pass through ``with_repo_fallback`` to the
+    # chain. Wipe any stale fallback binding for this repo (across all
+    # user buckets) and bump ``repo_gens`` so any in-flight probe's
+    # cache write is rejected. Without this, a ghost binding written
+    # earlier (when the repo was absent) could be resurrected within
+    # the cache TTL window.
+    get_fallback_cache().invalidate_repo(repo_type, namespace, payload.name)
 
     # 6. Return success response (200 OK with a simple message)
     # HuggingFace Hub delete_repo returns a simple 200 OK.
@@ -864,6 +883,16 @@ async def move_repo(
     except Exception as e:
         # S3 cleanup failure is non-fatal - repository is already moved successfully
         logger.warning(f"S3 cleanup failed for {from_id} (non-fatal): {e}")
+
+    # Strict-freshness invalidation (#79): both ids change occupancy.
+    # The old id transitions from "local-occupied" to "fallback-eligible";
+    # any prior fallback binding for it must not survive. The new id
+    # transitions from "potentially-fallback-eligible" to "local-occupied";
+    # any ghost binding for the new id must be cleared so a later
+    # delete-after-rename cannot resurrect the ghost.
+    cache = get_fallback_cache()
+    cache.invalidate_repo(repo_type, from_namespace, from_name)
+    cache.invalidate_repo(repo_type, to_namespace, to_name)
 
     return {
         "success": True,

--- a/src/kohakuhub/api/settings.py
+++ b/src/kohakuhub/api/settings.py
@@ -21,6 +21,7 @@ from kohakuhub.db_operations import (
 )
 from kohakuhub.logger import get_logger
 from kohakuhub.api.fallback import with_user_fallback
+from kohakuhub.api.fallback.cache import get_cache as get_fallback_cache
 from kohakuhub.api.quota.util import calculate_repository_storage, check_quota
 from kohakuhub.api.repo.utils.hf import hf_repo_not_found
 from kohakuhub.auth.dependencies import get_current_user
@@ -435,6 +436,18 @@ async def update_repo_settings(
     # Apply all updates if there are any
     if update_fields:
         update_repository(repo_row, **update_fields)
+
+    # Strict-freshness invalidation (#79): a visibility flip changes
+    # who can see the local repo, which in turn changes whether
+    # ``with_repo_fallback`` falls through to the chain for any given
+    # caller. Defensive eviction of every cached binding for this repo
+    # ensures no anonymous-bucket ghost binding (written while the
+    # repo was public) survives a public→private flip, and no
+    # private-era ghost survives a private→public flip. Other settings
+    # (LFS thresholds, suffix rules, etc.) do not affect binding so
+    # only fire the eviction when ``private`` was the changed field.
+    if "private" in update_fields:
+        get_fallback_cache().invalidate_repo(repo_type, namespace, name)
 
     # Note: gated functionality not yet implemented in database schema
     # Would require adding a 'gated' field to Repository model

--- a/test/kohaku-hub-admin/pages/test_fallback_sources_page.test.js
+++ b/test/kohaku-hub-admin/pages/test_fallback_sources_page.test.js
@@ -1,0 +1,1528 @@
+import { defineComponent, h } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ElementPlusStubs } from "../helpers/vue";
+
+// Hoisted mocks for vue-router / pinia / api / element-plus message
+// helpers — same pattern as test_cache_page.test.js.
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+  },
+  adminStore: {
+    token: "admin-token",
+  },
+  api: {
+    listFallbackSources: vi.fn(),
+    createFallbackSource: vi.fn(),
+    updateFallbackSource: vi.fn(),
+    deleteFallbackSource: vi.fn(),
+    getFallbackCacheStats: vi.fn(),
+    clearFallbackCache: vi.fn(),
+    invalidateFallbackRepoCache: vi.fn(),
+    invalidateFallbackUserCacheById: vi.fn(),
+    invalidateFallbackUserCacheByUsername: vi.fn(),
+    listUsers: vi.fn(),
+    listRepositories: vi.fn(),
+  },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/stores/admin", () => ({
+  useAdminStore: () => mocks.adminStore,
+}));
+
+vi.mock("@/utils/api", () => ({
+  listFallbackSources: (...a) => mocks.api.listFallbackSources(...a),
+  createFallbackSource: (...a) => mocks.api.createFallbackSource(...a),
+  updateFallbackSource: (...a) => mocks.api.updateFallbackSource(...a),
+  deleteFallbackSource: (...a) => mocks.api.deleteFallbackSource(...a),
+  getFallbackCacheStats: (...a) => mocks.api.getFallbackCacheStats(...a),
+  clearFallbackCache: (...a) => mocks.api.clearFallbackCache(...a),
+  invalidateFallbackRepoCache: (...a) => mocks.api.invalidateFallbackRepoCache(...a),
+  invalidateFallbackUserCacheById: (...a) =>
+    mocks.api.invalidateFallbackUserCacheById(...a),
+  invalidateFallbackUserCacheByUsername: (...a) =>
+    mocks.api.invalidateFallbackUserCacheByUsername(...a),
+  listUsers: (...a) => mocks.api.listUsers(...a),
+  listRepositories: (...a) => mocks.api.listRepositories(...a),
+}));
+
+vi.mock("@/components/AdminLayout.vue", () => ({
+  default: defineComponent({
+    name: "AdminLayoutStub",
+    setup(_, { slots }) {
+      return () =>
+        h(
+          "div",
+          { "data-testid": "admin-layout" },
+          slots.default ? slots.default() : [],
+        );
+    },
+  }),
+}));
+
+import FallbackSourcesPage from "@/pages/fallback-sources.vue";
+
+const messageBoxConfirmSpy = vi.fn();
+const messageSuccessSpy = vi.fn();
+const messageErrorSpy = vi.fn();
+let elementPlusModule;
+
+// Stubs not present in the shared helpers/vue.js. Inline rather than
+// extending the helper module to keep this file self-contained.
+const ElRadioGroupStub = defineComponent({
+  name: "ElRadioGroup",
+  props: { modelValue: { type: [String, Number, Boolean], default: "" } },
+  emits: ["update:modelValue", "change"],
+  setup(props, { slots, emit }) {
+    return () =>
+      h(
+        "div",
+        {
+          "data-el-radio-group": "true",
+          "data-value": String(props.modelValue),
+          onClick: (event) => {
+            const target = event.target.closest("[data-radio-value]");
+            if (target) {
+              const value = target.getAttribute("data-radio-value");
+              emit("update:modelValue", value);
+              emit("change", value);
+            }
+          },
+        },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+const ElRadioStub = defineComponent({
+  name: "ElRadio",
+  props: { value: { type: [String, Number, Boolean], default: "" } },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        "label",
+        {
+          "data-el-radio": "true",
+          "data-radio-value": String(props.value),
+        },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+const ElSwitchStub = defineComponent({
+  name: "ElSwitch",
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ["update:modelValue"],
+  setup(props, { emit }) {
+    return () =>
+      h("input", {
+        type: "checkbox",
+        checked: props.modelValue,
+        "data-el-switch": "true",
+        onChange: (event) =>
+          emit("update:modelValue", event.target.checked),
+      });
+  },
+});
+
+// ElAutocomplete behaves like an ElInput wrapper plus a fetchSuggestions
+// callback. Match the ElInput stub's two-element shape (outer div with
+// ``data-el-autocomplete`` carrying ``inheritAttrs`` + child ``<input>``)
+// so test selectors that chain ``[data-testid="..."] input`` continue to
+// work just as they did before this swap.
+const ElAutocompleteStub = defineComponent({
+  name: "ElAutocomplete",
+  inheritAttrs: false,
+  props: {
+    modelValue: { type: [String, Number], default: "" },
+    placeholder: { type: String, default: "" },
+    fetchSuggestions: { type: Function, default: null },
+  },
+  emits: ["update:modelValue"],
+  setup(props, { emit, attrs }) {
+    return () =>
+      h(
+        "div",
+        { ...attrs, "data-el-autocomplete": "true" },
+        [
+          h("input", {
+            type: "text",
+            value: props.modelValue ?? "",
+            placeholder: props.placeholder,
+            onInput: (event) => {
+              emit("update:modelValue", event.target.value);
+              // Auto-fire the fetch handler on every keystroke so tests
+              // can assert what the page asks the server for.
+              const value = event.target.value;
+              if (typeof props.fetchSuggestions === "function") {
+                const captured = [];
+                const cb = (items) => {
+                  captured.push(...(items || []));
+                  if (typeof window !== "undefined") {
+                    window.__lastAutocompleteSuggestions = captured;
+                  }
+                };
+                props.fetchSuggestions(value, cb);
+              }
+            },
+          }),
+        ],
+      );
+  },
+});
+
+const stubs = {
+  ...ElementPlusStubs,
+  ElRadioGroup: ElRadioGroupStub,
+  ElRadio: ElRadioStub,
+  ElSwitch: ElSwitchStub,
+  ElAutocomplete: ElAutocompleteStub,
+};
+
+async function waitForAutocomplete() {
+  // suggestions are populated synchronously by the stub; flushPromises
+  // drains the awaited mock to settle.
+  await flushPromises();
+  return globalThis.window?.__lastAutocompleteSuggestions ?? [];
+}
+
+const SOURCE_HF = {
+  id: 1,
+  namespace: "",
+  url: "https://huggingface.co",
+  token: null,
+  priority: 100,
+  name: "HuggingFace",
+  source_type: "huggingface",
+  enabled: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+const SOURCE_MIRROR = {
+  id: 2,
+  namespace: "mirror-org",
+  url: "https://mirror.local",
+  token: "tok-secret",
+  priority: 50,
+  name: "Mirror",
+  source_type: "kohakuhub",
+  enabled: false,
+  created_at: "2026-02-01T00:00:00Z",
+  updated_at: "2026-02-15T00:00:00Z",
+};
+const STATS = {
+  size: 42,
+  maxsize: 10000,
+  ttl_seconds: 300,
+  usage_percent: 0.42,
+};
+
+function mountPage() {
+  return mount(FallbackSourcesPage, {
+    global: {
+      stubs,
+    },
+  });
+}
+
+describe("admin fallback-sources page", () => {
+  beforeEach(async () => {
+    mocks.router.push.mockReset();
+    mocks.adminStore.token = "admin-token";
+    Object.values(mocks.api).forEach((fn) => fn.mockReset());
+    messageBoxConfirmSpy.mockReset();
+    messageSuccessSpy.mockReset();
+    messageErrorSpy.mockReset();
+
+    if (!elementPlusModule) {
+      elementPlusModule = await vi.importActual("element-plus");
+    }
+    vi.spyOn(elementPlusModule.ElMessageBox, "confirm").mockImplementation(
+      (...args) => messageBoxConfirmSpy(...args),
+    );
+    vi.spyOn(elementPlusModule.ElMessage, "success").mockImplementation(
+      (...args) => messageSuccessSpy(...args),
+    );
+    vi.spyOn(elementPlusModule.ElMessage, "error").mockImplementation(
+      (...args) => messageErrorSpy(...args),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------
+  // Initial mount + auth gate
+  // -----------------------------------------------------------------
+
+  it("loads sources and cache stats on mount", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF, SOURCE_MIRROR]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(mocks.api.listFallbackSources).toHaveBeenCalledWith("admin-token");
+    expect(mocks.api.getFallbackCacheStats).toHaveBeenCalledWith("admin-token");
+    expect(wrapper.text()).toContain("HuggingFace");
+    expect(wrapper.text()).toContain("Mirror");
+    // stats render
+    expect(wrapper.text()).toContain("42"); // size
+    expect(wrapper.text()).toContain("10000"); // maxsize
+  });
+
+  it("redirects to /login when admin token is missing", async () => {
+    mocks.adminStore.token = null;
+    mounted = mountPage();
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(mocks.api.listFallbackSources).not.toHaveBeenCalled();
+  });
+
+  it("renders empty state when no sources are configured", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+    expect(wrapper.text()).toContain("No fallback sources configured");
+  });
+
+  it("surfaces an error toast when listFallbackSources fails", async () => {
+    const failure = new Error("nope");
+    failure.response = { data: { detail: { error: "DB down" } } };
+    mocks.api.listFallbackSources.mockRejectedValue(failure);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mountPage();
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("DB down");
+  });
+
+  it("falls back to the generic message when the listFallbackSources error has no detail", async () => {
+    mocks.api.listFallbackSources.mockRejectedValue(new Error("boom"));
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mountPage();
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to load fallback sources");
+  });
+
+  it("logs but does not toast when getFallbackCacheStats fails", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockRejectedValue(new Error("stats down"));
+    mountPage();
+    await flushPromises();
+    // No error toast for the silent stats fetch — pattern matches the page.
+    expect(messageErrorSpy).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------
+  // Source create / edit / delete / toggle
+  // -----------------------------------------------------------------
+
+  it("creates a new source and reloads", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.createFallbackSource.mockResolvedValue({ ...SOURCE_HF, id: 99 });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    // Open create dialog by clicking "Add Source" — the only primary
+    // button in the Configured Sources card header.
+    const addButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Add Source"));
+    await addButton.trigger("click");
+    await flushPromises();
+
+    // Submit through the open dialog's primary button. The page wires
+    // it to handleSubmit via @click on the "Create" button in the dialog footer.
+    const createButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().trim() === "Create");
+    await createButton.trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.createFallbackSource).toHaveBeenCalledTimes(1);
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Fallback source created successfully",
+    );
+    // Reload happens after create.
+    expect(mocks.api.listFallbackSources).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates an existing source via edit dialog", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.updateFallbackSource.mockResolvedValue(SOURCE_HF);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    // Find the edit button on the only listed source. The edit button
+    // lives in source-actions and is the one with i-carbon-edit icon —
+    // identifiable as the second action button (after the toggle and
+    // before delete in the source-actions group).
+    const editButtons = wrapper.findAll(".source-actions button");
+    // Order: Disable/Enable, Edit, Delete.
+    await editButtons[1].trigger("click");
+    await flushPromises();
+
+    const updateButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().trim() === "Update");
+    await updateButton.trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.updateFallbackSource).toHaveBeenCalledTimes(1);
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Fallback source updated successfully",
+    );
+  });
+
+  it("toggles enabled flag via the Disable/Enable button", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.updateFallbackSource.mockResolvedValue({
+      ...SOURCE_HF,
+      enabled: false,
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.updateFallbackSource).toHaveBeenCalledWith(
+      "admin-token",
+      SOURCE_HF.id,
+      { enabled: false },
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      `Source "${SOURCE_HF.name}" disabled`,
+    );
+  });
+
+  it("deletes a source after confirm", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.deleteFallbackSource.mockResolvedValue({ success: true });
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[2].trigger("click");
+    await flushPromises();
+
+    expect(messageBoxConfirmSpy).toHaveBeenCalled();
+    expect(mocks.api.deleteFallbackSource).toHaveBeenCalledWith(
+      "admin-token",
+      SOURCE_HF.id,
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      `Fallback source "${SOURCE_HF.name}" deleted`,
+    );
+  });
+
+  it("does not delete when the operator cancels the confirm dialog", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockRejectedValue("cancel");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[2].trigger("click");
+    await flushPromises();
+    expect(mocks.api.deleteFallbackSource).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a toast when delete itself fails", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const failure = new Error("API error");
+    failure.response = { data: { detail: { error: "permission denied" } } };
+    mocks.api.deleteFallbackSource.mockRejectedValue(failure);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[2].trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("permission denied");
+  });
+
+  it("falls back to generic message when delete error has no detail", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    mocks.api.deleteFallbackSource.mockRejectedValue(new Error("boom"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[2].trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith(
+      "Failed to delete fallback source",
+    );
+  });
+
+  it("surfaces a toast when toggling the enabled flag fails", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.updateFallbackSource.mockRejectedValue(new Error("boom"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to toggle source");
+  });
+
+  it("surfaces a toast when create/update submit fails", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.createFallbackSource.mockRejectedValue(new Error("boom"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const addButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Add Source"));
+    await addButton.trigger("click");
+    await flushPromises();
+
+    const createButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().trim() === "Create");
+    await createButton.trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to save fallback source");
+  });
+
+  // -----------------------------------------------------------------
+  // Existing global Clear Cache flow
+  // -----------------------------------------------------------------
+
+  it("clears the global fallback cache after confirm", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.clearFallbackCache.mockResolvedValue({
+      success: true,
+      message: "Cache cleared (42 entries removed)",
+      old_size: 42,
+    });
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const clearButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Clear Cache"));
+    await clearButton.trigger("click");
+    await flushPromises();
+
+    expect(messageBoxConfirmSpy).toHaveBeenCalled();
+    expect(mocks.api.clearFallbackCache).toHaveBeenCalledWith("admin-token");
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Cache cleared (42 entries removed)",
+    );
+  });
+
+  it("does not clear cache when confirm dialog is cancelled", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockRejectedValue("cancel");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const clearButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Clear Cache"));
+    await clearButton.trigger("click");
+    await flushPromises();
+    expect(mocks.api.clearFallbackCache).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a toast when global clear cache fails", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    mocks.api.clearFallbackCache.mockRejectedValue(new Error("boom"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const clearButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Clear Cache"));
+    await clearButton.trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to clear cache");
+  });
+
+  // -----------------------------------------------------------------
+  // Autocomplete suggestion fetchers
+  // -----------------------------------------------------------------
+
+  it("fetches namespace suggestions via listUsers(include_orgs=true)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue({
+      users: [
+        { username: "openai-community" },
+        { username: "openai" },
+      ],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("openai");
+    await flushPromises();
+
+    expect(mocks.api.listUsers).toHaveBeenCalledWith(
+      "admin-token",
+      expect.objectContaining({
+        search: "openai",
+        limit: 20,
+        include_orgs: true,
+      }),
+    );
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["openai-community", "openai"]);
+  });
+
+  it("namespace fetcher returns [] for empty query", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = [];
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("");
+    await flushPromises();
+    expect(mocks.api.listUsers).not.toHaveBeenCalled();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+  });
+
+  it("namespace fetcher swallows API errors and returns []", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockRejectedValue(new Error("listUsers boom"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("anything");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    consoleSpy.mockRestore();
+  });
+
+  it("namespace fetcher honors checkAuth (no token -> []) and pushes to login", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    mocks.adminStore.token = null;
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("openai");
+    await flushPromises();
+    expect(mocks.api.listUsers).not.toHaveBeenCalled();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+  });
+
+  it("namespace fetcher unwraps {items} response shape (vs {users})", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue({
+      items: [{ username: "items_shaped_org" }],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("items");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["items_shaped_org"]);
+  });
+
+  it("namespace fetcher accepts raw array response shape", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue([
+      { username: "raw_array_ns" },
+    ]);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("raw");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["raw_array_ns"]);
+  });
+
+  it("fetches repo-name suggestions filtered by repo_type + namespace", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    // Wrapped {items: ...} shape — verify the helper unwraps it.
+    mocks.api.listRepositories.mockResolvedValue({
+      items: [
+        { namespace: "openai-community", name: "gpt2" },
+        { namespace: "openai-community", name: "gpt2-medium" },
+      ],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("openai-community");
+    await flushPromises();
+    mocks.api.listRepositories.mockClear();
+    mocks.api.listRepositories.mockResolvedValue({
+      items: [
+        { namespace: "openai-community", name: "gpt2" },
+        { namespace: "openai-community", name: "gpt2-medium" },
+      ],
+    });
+    await wrapper
+      .get('[data-testid="evict-repo-name"] input')
+      .setValue("gpt2");
+    await flushPromises();
+    expect(mocks.api.listRepositories).toHaveBeenCalledWith(
+      "admin-token",
+      expect.objectContaining({
+        search: "gpt2",
+        repo_type: "model",
+        namespace: "openai-community",
+        limit: 20,
+      }),
+    );
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["gpt2", "gpt2-medium"]);
+  });
+
+  it("repo-name fetcher unwraps {repositories: [...]} (backend default shape)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listRepositories.mockResolvedValue({
+      repositories: [
+        { namespace: "openai-community", name: "gpt2" },
+        { namespace: "openai-community", name: "gpt2-medium" },
+      ],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("openai-community");
+    await flushPromises();
+    mocks.api.listRepositories.mockClear();
+    mocks.api.listRepositories.mockResolvedValue({
+      repositories: [
+        { namespace: "openai-community", name: "gpt2" },
+        { namespace: "openai-community", name: "gpt2-medium" },
+      ],
+    });
+    await wrapper
+      .get('[data-testid="evict-repo-name"] input')
+      .setValue("gpt2");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["gpt2", "gpt2-medium"]);
+  });
+
+  it("repo-name fetcher accepts raw array response shape", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listRepositories.mockResolvedValue([
+      { namespace: "x", name: "raw-array-repo" },
+    ]);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-repo-name"] input')
+      .setValue("raw-array");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["raw-array-repo"]);
+  });
+
+  it("repo-name fetcher returns [] for empty query", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper.get('[data-testid="evict-repo-name"] input').setValue("");
+    await flushPromises();
+    expect(mocks.api.listRepositories).not.toHaveBeenCalled();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+  });
+
+  it("repo-name fetcher swallows API errors", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listRepositories.mockRejectedValue(new Error("repos boom"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper.get('[data-testid="evict-repo-name"] input').setValue("g");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    consoleSpy.mockRestore();
+  });
+
+  it("repo-name fetcher honors checkAuth", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    mocks.adminStore.token = null;
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper.get('[data-testid="evict-repo-name"] input').setValue("g");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+  });
+
+  it("fetches username suggestions via listUsers on input", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue({
+      users: [
+        { username: "mai_lin" },
+        { username: "mai_admin" },
+      ],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("mai");
+    await flushPromises();
+    expect(mocks.api.listUsers).toHaveBeenCalledWith(
+      "admin-token",
+      expect.objectContaining({
+        search: "mai",
+        limit: 20,
+        include_orgs: false,
+      }),
+    );
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["mai_lin", "mai_admin"]);
+  });
+
+  it("username fetcher returns [] for empty query", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("");
+    await flushPromises();
+    expect(mocks.api.listUsers).not.toHaveBeenCalled();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+  });
+
+  it("username fetcher swallows API errors", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockRejectedValue(new Error("users boom"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("m");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    consoleSpy.mockRestore();
+  });
+
+  it("username fetcher honors checkAuth", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    mocks.adminStore.token = null;
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("m");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+  });
+
+
+  it("namespace fetcher handles null / empty response shape", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue(null);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("anything");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+  });
+
+  it("username fetcher handles null / empty response shape", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue(null);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    globalThis.window.__lastAutocompleteSuggestions = ["unset"];
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("anything");
+    await flushPromises();
+    expect(globalThis.window.__lastAutocompleteSuggestions).toEqual([]);
+  });
+
+  it("username fetcher unwraps {items} shape (vs {users} shape)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue({
+      items: [{ username: "items_shaped_user" }],
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("items");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["items_shaped_user"]);
+  });
+
+  it("listUsers array shape (no .users / .items wrap)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.listUsers.mockResolvedValue([{ username: "raw_array_user" }]);
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    await wrapper
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("raw");
+    await flushPromises();
+    expect(
+      globalThis.window.__lastAutocompleteSuggestions.map((s) => s.value),
+    ).toEqual(["raw_array_user"]);
+  });
+
+  // -----------------------------------------------------------------
+  // NEW (#79): per-repo eviction dialog
+  // -----------------------------------------------------------------
+
+  it("evicts a repo cache via the per-repo dialog", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.invalidateFallbackRepoCache.mockResolvedValue({
+      success: true,
+      evicted: 3,
+      repo_type: "model",
+      namespace: "owner",
+      name: "demo",
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+
+    // Dialog now visible — fill namespace and name; repo_type defaults to "model".
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+    const namespaceInput = dialog.get(
+      '[data-testid="evict-repo-namespace"] input',
+    );
+    await namespaceInput.setValue("owner");
+    const nameInput = dialog.get('[data-testid="evict-repo-name"] input');
+    await nameInput.setValue("demo");
+
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.invalidateFallbackRepoCache).toHaveBeenCalledWith(
+      "admin-token",
+      "model",
+      "owner",
+      "demo",
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Evicted 3 cache entries for model/owner/demo",
+    );
+    // Stats refresh post-eviction.
+    expect(mocks.api.getFallbackCacheStats).toHaveBeenCalledTimes(2);
+  });
+
+  it("evict-by-repo singular vs plural success message", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.invalidateFallbackRepoCache.mockResolvedValue({
+      success: true,
+      evicted: 1,
+      repo_type: "dataset",
+      namespace: "ns",
+      name: "r1",
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+
+    // switch repo_type to "dataset"
+    const select = dialog.get('[data-testid="evict-repo-type"]');
+    select.element.value = "dataset";
+    await select.trigger("change");
+
+    await dialog
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("ns");
+    await dialog.get('[data-testid="evict-repo-name"] input').setValue("r1");
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Evicted 1 cache entry for dataset/ns/r1",
+    );
+  });
+
+  it("evict-by-repo rejects empty namespace / name", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+
+    // Submit with empty fields.
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith(
+      "repo_type, namespace, and name are all required",
+    );
+    expect(mocks.api.invalidateFallbackRepoCache).not.toHaveBeenCalled();
+  });
+
+  it("evict-by-repo surfaces backend error", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const failure = new Error("boom");
+    failure.response = { data: { detail: { error: "internal error" } } };
+    mocks.api.invalidateFallbackRepoCache.mockRejectedValue(failure);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+    await dialog
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("ns");
+    await dialog.get('[data-testid="evict-repo-name"] input').setValue("r1");
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("internal error");
+  });
+
+  it("evict-by-repo falls back to generic message when error has no detail", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.invalidateFallbackRepoCache.mockRejectedValue(new Error("boom"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+    await dialog
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("ns");
+    await dialog.get('[data-testid="evict-repo-name"] input').setValue("r1");
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to evict repo cache");
+  });
+
+  // -----------------------------------------------------------------
+  // NEW (#79): per-user eviction dialog (username + user_id modes)
+  // -----------------------------------------------------------------
+
+  it("evicts user cache by username after confirm", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.invalidateFallbackUserCacheByUsername.mockResolvedValue({
+      success: true,
+      evicted: 5,
+      user_id: 42,
+      username: "mai_lin",
+    });
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("mai_lin");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageBoxConfirmSpy).toHaveBeenCalled();
+    expect(mocks.api.invalidateFallbackUserCacheByUsername).toHaveBeenCalledWith(
+      "admin-token",
+      "mai_lin",
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Evicted 5 cache entries for mai_lin (user_id=42)",
+    );
+  });
+
+  it("evicts user cache by user_id after confirm + radio toggle", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.invalidateFallbackUserCacheById.mockResolvedValue({
+      success: true,
+      evicted: 1,
+      user_id: 7,
+    });
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+
+    // Switch radio to "user_id" mode by clicking the radio with that value.
+    const radioGroup = dialog.get('[data-testid="evict-user-mode"]');
+    const userIdRadio = radioGroup.get('[data-radio-value="user_id"]');
+    await userIdRadio.trigger("click");
+    await flushPromises();
+
+    // Now the user_id input should be visible.
+    const numberInput = dialog.get('[data-testid="evict-user-userid"]');
+    numberInput.element.value = "7";
+    await numberInput.trigger("input");
+
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.invalidateFallbackUserCacheById).toHaveBeenCalledWith(
+      "admin-token",
+      7,
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      "Evicted 1 cache entry for user_id=7",
+    );
+  });
+
+  it("evict-by-user does nothing when confirm dialog is cancelled", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockRejectedValue("cancel");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("mai_lin");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(
+      mocks.api.invalidateFallbackUserCacheByUsername,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("evict-by-user logs unexpected confirm-dialog errors", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    messageBoxConfirmSpy.mockRejectedValue(new Error("unexpected"));
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("mai_lin");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(
+      mocks.api.invalidateFallbackUserCacheByUsername,
+    ).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("evict-by-user (username mode) rejects empty username", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    // Submit empty.
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("Username is required");
+  });
+
+  it("evict-by-user (user_id mode) rejects non-positive user_id", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+
+    // Switch to user_id mode.
+    const radioGroup = dialog.get('[data-testid="evict-user-mode"]');
+    await radioGroup.get('[data-radio-value="user_id"]').trigger("click");
+    await flushPromises();
+
+    // Leave user_id null.
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith(
+      "user_id must be a positive integer",
+    );
+  });
+
+  it("evict-by-user surfaces 404 / unknown-user backend error", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const failure = new Error("not found");
+    failure.response = {
+      data: { detail: { error: "User not found: nope" } },
+    };
+    mocks.api.invalidateFallbackUserCacheByUsername.mockRejectedValue(failure);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("nope");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(messageErrorSpy).toHaveBeenCalledWith("User not found: nope");
+  });
+
+  it("evict-by-user falls back to generic message when error has no detail", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    mocks.api.invalidateFallbackUserCacheByUsername.mockRejectedValue(
+      new Error("boom"),
+    );
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("x");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("Failed to evict user cache");
+  });
+
+  // -----------------------------------------------------------------
+  // Auth gate on action handlers
+  // -----------------------------------------------------------------
+
+  it("redirects to login when token is missing on cache-clear path", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    const clearButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Clear Cache"));
+    await clearButton.trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+  });
+
+  it("redirects to login when token is missing on evict-repo path", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    await wrapper.get('[data-testid="evict-repo-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-repo-dialog"]');
+    await dialog
+      .get('[data-testid="evict-repo-namespace"] input')
+      .setValue("ns");
+    await dialog.get('[data-testid="evict-repo-name"] input').setValue("r1");
+    await dialog.get('[data-testid="evict-repo-submit"]').trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(mocks.api.invalidateFallbackRepoCache).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login when token is missing on submit path (create)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const addButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Add Source"));
+    await addButton.trigger("click");
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    const createButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().trim() === "Create");
+    await createButton.trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(mocks.api.createFallbackSource).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login when token is missing on delete path", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[2].trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(mocks.api.deleteFallbackSource).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login when token is missing on toggle-enabled path", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(mocks.api.updateFallbackSource).not.toHaveBeenCalled();
+  });
+
+  it("toggles a disabled source to enabled (covers the inverse branch)", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_MIRROR]); // enabled=false
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    mocks.api.updateFallbackSource.mockResolvedValue({
+      ...SOURCE_MIRROR,
+      enabled: true,
+    });
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+
+    expect(mocks.api.updateFallbackSource).toHaveBeenCalledWith(
+      "admin-token",
+      SOURCE_MIRROR.id,
+      { enabled: true },
+    );
+    expect(messageSuccessSpy).toHaveBeenCalledWith(
+      `Source "${SOURCE_MIRROR.name}" enabled`,
+    );
+  });
+
+  it("uses backend detail message on toggle / submit / clear-cache errors", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([SOURCE_HF]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+
+    // Toggle with detail.
+    const toggleErr = new Error("boom");
+    toggleErr.response = { data: { detail: { error: "toggle err" } } };
+    mocks.api.updateFallbackSource.mockRejectedValueOnce(toggleErr);
+
+    const wrapper = mountPage();
+    await flushPromises();
+    const buttons = wrapper.findAll(".source-actions button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("toggle err");
+
+    // Submit with detail.
+    const submitErr = new Error("boom");
+    submitErr.response = { data: { detail: { error: "submit err" } } };
+    mocks.api.createFallbackSource.mockRejectedValue(submitErr);
+
+    const addButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Add Source"));
+    await addButton.trigger("click");
+    await flushPromises();
+    const createButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().trim() === "Create");
+    await createButton.trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("submit err");
+
+    // Clear cache with detail.
+    messageErrorSpy.mockReset();
+    messageBoxConfirmSpy.mockResolvedValue("confirm");
+    const clearErr = new Error("boom");
+    clearErr.response = { data: { detail: { error: "clear err" } } };
+    mocks.api.clearFallbackCache.mockRejectedValue(clearErr);
+    const clearButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Clear Cache"));
+    await clearButton.trigger("click");
+    await flushPromises();
+    expect(messageErrorSpy).toHaveBeenCalledWith("clear err");
+  });
+
+  it("redirects to login when token is missing on evict-user path", async () => {
+    mocks.api.listFallbackSources.mockResolvedValue([]);
+    mocks.api.getFallbackCacheStats.mockResolvedValue(STATS);
+    const wrapper = mountPage();
+    await flushPromises();
+
+    mocks.adminStore.token = null;
+    await wrapper.get('[data-testid="evict-user-button"]').trigger("click");
+    await flushPromises();
+    const dialog = wrapper.get('[data-testid="evict-user-dialog"]');
+    await dialog
+      .get('[data-testid="evict-user-username"] input')
+      .setValue("u");
+    await dialog.get('[data-testid="evict-user-submit"]').trigger("click");
+    await flushPromises();
+    expect(mocks.router.push).toHaveBeenCalledWith("/login");
+    expect(
+      mocks.api.invalidateFallbackUserCacheByUsername,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+let mounted; // satisfies eslint no-undef in older lints, harmless

--- a/test/kohaku-hub-admin/utils/test_api.test.js
+++ b/test/kohaku-hub-admin/utils/test_api.test.js
@@ -165,6 +165,14 @@ describe("admin API client", () => {
     await api.deleteFallbackSource("admin-token", 3);
     await api.getFallbackCacheStats("admin-token");
     await api.clearFallbackCache("admin-token");
+    await api.invalidateFallbackRepoCache(
+      "admin-token",
+      "model",
+      "mai_lin",
+      "lineart-caption-base",
+    );
+    await api.invalidateFallbackUserCacheById("admin-token", 42);
+    await api.invalidateFallbackUserCacheByUsername("admin-token", "mai_lin");
 
     await api.deleteRepositoryAdmin(
       "admin-token",
@@ -279,6 +287,15 @@ describe("admin API client", () => {
     expect(client.get).toHaveBeenCalledWith("/fallback-sources", {
       params: { namespace: "mai_lin", enabled: true },
     });
+    expect(client.delete).toHaveBeenCalledWith(
+      "/fallback-sources/cache/repo/model/mai_lin/lineart-caption-base",
+    );
+    expect(client.delete).toHaveBeenCalledWith(
+      "/fallback-sources/cache/user/42",
+    );
+    expect(client.delete).toHaveBeenCalledWith(
+      "/fallback-sources/cache/username/mai_lin",
+    );
     expect(client.delete).toHaveBeenCalledWith(
       "/storage/objects/models%2Fdemo%2Ffile.bin",
     );

--- a/test/kohakuhub/api/admin/routers/test_fallback.py
+++ b/test/kohakuhub/api/admin/routers/test_fallback.py
@@ -39,7 +39,7 @@ async def test_admin_can_create_list_get_update_and_delete_fallback_sources(
     assert get_response.json()["name"] == "Mirror"
 
     cache = backend_test_state.modules.fallback_cache_module.get_cache()
-    cache.set("model", "owner", "demo", "https://mirror.local", "Mirror", "huggingface", exists=True)
+    cache.set(None, "", "model", "owner", "demo", "https://mirror.local", "Mirror", "huggingface", exists=True)
 
     update_response = await admin_client.put(
         f"/admin/api/fallback-sources/{created['id']}",
@@ -96,7 +96,7 @@ async def test_admin_fallback_routes_validate_errors_and_expose_cache_controls(
     assert missing_delete.status_code == 404
 
     cache = backend_test_state.modules.fallback_cache_module.get_cache()
-    cache.set("model", "owner", "demo", "https://cache.local", "Cache", "huggingface", exists=True)
+    cache.set(None, "", "model", "owner", "demo", "https://cache.local", "Cache", "huggingface", exists=True)
 
     stats_response = await admin_client.get("/admin/api/fallback-sources/cache/stats")
     assert stats_response.status_code == 200

--- a/test/kohakuhub/api/fallback/test_cache.py
+++ b/test/kohakuhub/api/fallback/test_cache.py
@@ -1,46 +1,417 @@
-"""Tests for fallback cache behavior."""
+"""Tests for fallback cache behavior.
 
-from kohakuhub.api.fallback.cache import RepoSourceCache
+Covers the post-#79 strict-freshness contract:
+
+- ``compute_tokens_hash`` ordering invariance and emptiness handling
+- per-user / per-tokens_hash key isolation
+- ``invalidate_repo`` / ``clear_user`` eviction scope
+- generation counters (``global_gen`` / ``user_gens`` / ``repo_gens``)
+- ``safe_set`` rejection on each of the three race classes
+- ``invalidate`` single-entry delete (no gen bump)
+- legacy paths kept (``stats``, ``clear``)
+"""
+import time
+
+import pytest
+
+from kohakuhub.api.fallback.cache import RepoSourceCache, compute_tokens_hash
+
+
+# ---------------------------------------------------------------------------
+# compute_tokens_hash
+# ---------------------------------------------------------------------------
+
+
+def test_compute_tokens_hash_empty_and_none_are_equivalent():
+    assert compute_tokens_hash(None) == ""
+    assert compute_tokens_hash({}) == ""
+
+
+def test_compute_tokens_hash_non_empty_is_16_hex():
+    h = compute_tokens_hash({"https://huggingface.co": "hf_abc"})
+    assert isinstance(h, str)
+    assert len(h) == 16
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_compute_tokens_hash_is_order_invariant():
+    a = compute_tokens_hash({"a": "1", "b": "2"})
+    b = compute_tokens_hash({"b": "2", "a": "1"})
+    assert a == b
+
+
+def test_compute_tokens_hash_distinguishes_token_changes():
+    a = compute_tokens_hash({"https://huggingface.co": "hf_abc"})
+    b = compute_tokens_hash({"https://huggingface.co": "hf_DIFFERENT"})
+    assert a != b
+
+
+def test_compute_tokens_hash_distinguishes_url_changes():
+    a = compute_tokens_hash({"https://a.local": "tok"})
+    b = compute_tokens_hash({"https://b.local": "tok"})
+    assert a != b
+
+
+def test_compute_tokens_hash_distinguishes_extra_entry():
+    a = compute_tokens_hash({"a": "1"})
+    b = compute_tokens_hash({"a": "1", "b": "2"})
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Basic set / get / stats / clear
+# ---------------------------------------------------------------------------
+
+
+def _seed(cache, user_id=None, tokens_hash="", repo_type="model", ns="owner",
+          name="demo", url="https://huggingface.co", source_name="HF",
+          source_type="huggingface"):
+    cache.set(
+        user_id, tokens_hash,
+        repo_type, ns, name,
+        url, source_name, source_type,
+    )
 
 
 def test_cache_set_get_and_stats():
     cache = RepoSourceCache(ttl_seconds=60, maxsize=5)
-    cache.set(
-        "model",
-        "owner",
-        "demo",
-        source_url="https://huggingface.co",
-        source_name="HF",
-        source_type="huggingface",
-    )
-
-    cached = cache.get("model", "owner", "demo")
-
+    _seed(cache)
+    cached = cache.get(None, "", "model", "owner", "demo")
+    assert cached is not None
     assert cached["source_name"] == "HF"
-    assert cache.stats()["size"] == 1
+    assert cached["source_url"] == "https://huggingface.co"
+    assert cached["source_type"] == "huggingface"
+    assert cached["exists"] is True
+    stats = cache.stats()
+    assert stats["size"] == 1
+    assert stats["maxsize"] == 5
+    assert stats["ttl_seconds"] == 60
+    assert stats["global_gen"] == 0
 
 
-def test_cache_invalidate_and_clear():
-    cache = RepoSourceCache(ttl_seconds=60, maxsize=5)
-    cache.set(
-        "model",
-        "owner",
-        "demo",
-        source_url="https://huggingface.co",
-        source_name="HF",
-        source_type="huggingface",
-    )
+def test_cache_get_miss_returns_none():
+    cache = RepoSourceCache()
+    assert cache.get(None, "", "model", "owner", "absent") is None
 
-    cache.invalidate("model", "owner", "demo")
-    assert cache.get("model", "owner", "demo") is None
 
-    cache.set(
-        "dataset",
-        "owner",
-        "corpus",
-        source_url="https://huggingface.co",
-        source_name="HF",
-        source_type="huggingface",
-    )
+def test_cache_invalidate_single_entry_no_gen_bump():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=42, tokens_hash="abc")
+    assert cache.invalidate(42, "abc", "model", "owner", "demo") is True
+    assert cache.get(42, "abc", "model", "owner", "demo") is None
+    # No generation bump — invalidate is a per-entry hygiene op only.
+    assert cache.global_gen == 0
+    assert cache.user_gens[42] == 0
+    assert cache.repo_gens[("model", "owner", "demo")] == 0
+
+
+def test_cache_invalidate_returns_false_when_absent():
+    cache = RepoSourceCache()
+    assert cache.invalidate(42, "", "model", "owner", "absent") is False
+
+
+def test_cache_clear_bumps_global_gen_and_wipes_all_buckets():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1)
+    _seed(cache, user_id=2)
+    _seed(cache, user_id=None, name="other")
+    assert cache.stats()["size"] == 3
+    initial_gen = cache.global_gen
     cache.clear()
     assert cache.stats()["size"] == 0
+    assert cache.global_gen == initial_gen + 1
+
+
+# ---------------------------------------------------------------------------
+# Per-user / per-tokens_hash isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cache_per_user_isolation():
+    """Two users with the same repo_id get independent cache buckets."""
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1, url="https://a.local", source_name="A")
+    _seed(cache, user_id=2, url="https://b.local", source_name="B")
+    a = cache.get(1, "", "model", "owner", "demo")
+    b = cache.get(2, "", "model", "owner", "demo")
+    assert a["source_name"] == "A"
+    assert b["source_name"] == "B"
+
+
+def test_cache_anonymous_bucket_isolated_from_authed():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=None, url="https://anon.local", source_name="Anon")
+    _seed(cache, user_id=42, url="https://authed.local", source_name="Authed")
+    assert cache.get(None, "", "model", "owner", "demo")["source_name"] == "Anon"
+    assert cache.get(42, "", "model", "owner", "demo")["source_name"] == "Authed"
+
+
+def test_cache_per_tokens_hash_isolation():
+    """Same user, different tokens_hash → different buckets."""
+    cache = RepoSourceCache()
+    _seed(cache, user_id=42, tokens_hash="aaaa", url="https://x.local", source_name="X")
+    _seed(cache, user_id=42, tokens_hash="bbbb", url="https://y.local", source_name="Y")
+    x = cache.get(42, "aaaa", "model", "owner", "demo")
+    y = cache.get(42, "bbbb", "model", "owner", "demo")
+    assert x["source_name"] == "X"
+    assert y["source_name"] == "Y"
+
+
+# ---------------------------------------------------------------------------
+# invalidate_repo
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_repo_clears_all_user_buckets_for_one_repo():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1)
+    _seed(cache, user_id=2)
+    _seed(cache, user_id=None)
+    _seed(cache, user_id=1, name="other")  # different repo, must NOT be evicted
+    assert cache.stats()["size"] == 4
+    evicted = cache.invalidate_repo("model", "owner", "demo")
+    assert evicted == 3
+    assert cache.stats()["size"] == 1
+    assert cache.get(1, "", "model", "owner", "other") is not None  # untouched
+
+
+def test_invalidate_repo_bumps_repo_gen():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1)
+    initial = cache.repo_gens[("model", "owner", "demo")]
+    cache.invalidate_repo("model", "owner", "demo")
+    assert cache.repo_gens[("model", "owner", "demo")] == initial + 1
+    # other repos' gens untouched
+    assert cache.repo_gens[("model", "owner", "other")] == 0
+
+
+def test_invalidate_repo_with_no_entries_still_bumps_gen():
+    cache = RepoSourceCache()
+    evicted = cache.invalidate_repo("model", "ghost", "ghost")
+    assert evicted == 0
+    # The bump happens regardless — the protection against in-flight
+    # probes does not need cache entries to exist.
+    assert cache.repo_gens[("model", "ghost", "ghost")] == 1
+
+
+def test_invalidate_repo_does_not_touch_global_or_user_gens():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1)
+    cache.invalidate_repo("model", "owner", "demo")
+    assert cache.global_gen == 0
+    assert cache.user_gens[1] == 0
+
+
+# ---------------------------------------------------------------------------
+# clear_user
+# ---------------------------------------------------------------------------
+
+
+def test_clear_user_clears_only_that_users_buckets():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1, name="r1")
+    _seed(cache, user_id=1, name="r2")
+    _seed(cache, user_id=2, name="r1")
+    _seed(cache, user_id=None, name="r1")
+    evicted = cache.clear_user(1)
+    assert evicted == 2
+    # Other users + anon untouched
+    assert cache.get(2, "", "model", "owner", "r1") is not None
+    assert cache.get(None, "", "model", "owner", "r1") is not None
+    assert cache.get(1, "", "model", "owner", "r1") is None
+    assert cache.get(1, "", "model", "owner", "r2") is None
+
+
+def test_clear_user_anonymous_clears_anon_bucket():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=None, name="r1")
+    _seed(cache, user_id=42, name="r1")
+    evicted = cache.clear_user(None)
+    assert evicted == 1
+    assert cache.get(None, "", "model", "owner", "r1") is None
+    assert cache.get(42, "", "model", "owner", "r1") is not None
+
+
+def test_clear_user_bumps_user_gen():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=42)
+    initial = cache.user_gens[42]
+    cache.clear_user(42)
+    assert cache.user_gens[42] == initial + 1
+    # Other user gens untouched
+    assert cache.user_gens[7] == 0
+
+
+def test_clear_user_with_no_entries_still_bumps_gen():
+    cache = RepoSourceCache()
+    cache.clear_user(99)
+    assert cache.user_gens[99] == 1
+
+
+def test_clear_user_does_not_touch_global_or_repo_gens():
+    cache = RepoSourceCache()
+    _seed(cache, user_id=1)
+    cache.clear_user(1)
+    assert cache.global_gen == 0
+    assert cache.repo_gens[("model", "owner", "demo")] == 0
+
+
+# ---------------------------------------------------------------------------
+# snapshot + safe_set
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_initial_zeros():
+    cache = RepoSourceCache()
+    assert cache.snapshot(42, "model", "owner", "demo") == (0, 0, 0)
+
+
+def test_snapshot_reflects_each_dimension():
+    cache = RepoSourceCache()
+    cache.clear()
+    cache.clear_user(42)
+    cache.invalidate_repo("model", "owner", "demo")
+    snap = cache.snapshot(42, "model", "owner", "demo")
+    assert snap == (1, 1, 1)
+    # Other repo for same user: only global_gen + user_gen[42] match.
+    other = cache.snapshot(42, "model", "owner", "other")
+    assert other == (1, 1, 0)
+
+
+def test_safe_set_succeeds_when_gens_unchanged():
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is True
+    cached = cache.get(42, "abc", "model", "owner", "demo")
+    assert cached is not None
+    assert cached["source_name"] == "X"
+
+
+def test_safe_set_rejected_when_global_gen_bumped():
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    cache.clear()  # bumps global_gen mid-probe
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is False
+    assert cache.get(42, "abc", "model", "owner", "demo") is None
+
+
+def test_safe_set_rejected_when_user_gen_bumped():
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    cache.clear_user(42)  # bumps user_gens[42] mid-probe
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is False
+
+
+def test_safe_set_rejected_when_repo_gen_bumped():
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    cache.invalidate_repo("model", "owner", "demo")
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is False
+
+
+def test_safe_set_unaffected_by_other_users_invalidation():
+    """A clear_user(7) must not reject user 42's safe_set."""
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    cache.clear_user(7)
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is True
+
+
+def test_safe_set_unaffected_by_other_repos_invalidation():
+    """An invalidate_repo on a different repo must not reject this safe_set."""
+    cache = RepoSourceCache()
+    gens = cache.snapshot(42, "model", "owner", "demo")
+    cache.invalidate_repo("model", "owner", "OTHER")
+    ok = cache.safe_set(
+        42, "abc",
+        "model", "owner", "demo",
+        "https://x.local", "X", "huggingface",
+        gens_at_start=gens,
+    )
+    assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# TTL behavior (sanity smoke; the core eviction mechanism is cachetools).
+# ---------------------------------------------------------------------------
+
+
+def test_ttl_zero_evicts_immediately():
+    cache = RepoSourceCache(ttl_seconds=0, maxsize=5)
+    _seed(cache, user_id=42)
+    # Sleep a hair to let the TTL window close.
+    time.sleep(0.01)
+    assert cache.get(42, "", "model", "owner", "demo") is None
+
+
+# ---------------------------------------------------------------------------
+# get_cache singleton + reset_cache_for_tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_cache_returns_singleton():
+    from kohakuhub.api.fallback import cache as cache_module
+
+    cache_module.reset_cache_for_tests()
+    a = cache_module.get_cache()
+    b = cache_module.get_cache()
+    assert a is b
+
+
+def test_reset_cache_for_tests_drops_singleton():
+    from kohakuhub.api.fallback import cache as cache_module
+
+    a = cache_module.get_cache()
+    cache_module.reset_cache_for_tests()
+    b = cache_module.get_cache()
+    assert a is not b
+
+
+# ---------------------------------------------------------------------------
+# Key shape sanity (suffix used by invalidate_repo)
+# ---------------------------------------------------------------------------
+
+
+def test_get_key_shape_matches_invalidate_repo_suffix():
+    """``invalidate_repo`` walks the cache by ``endswith`` on the
+    ``:{repo_type}:{ns}/{name}`` suffix; this test pins the key
+    serialization so the suffix-based eviction stays correct."""
+    cache = RepoSourceCache()
+    key_anon = cache.get_key(None, "", "model", "owner", "demo")
+    key_42 = cache.get_key(42, "abc", "model", "owner", "demo")
+    suffix = ":model:owner/demo"
+    assert key_anon.endswith(suffix)
+    assert key_42.endswith(suffix)
+    # And the user-prefix matches what clear_user uses.
+    assert key_anon.startswith("fallback:repo:u=anon:")
+    assert key_42.startswith("fallback:repo:u=42:")

--- a/test/kohakuhub/api/fallback/test_cache.py
+++ b/test/kohakuhub/api/fallback/test_cache.py
@@ -101,8 +101,8 @@ def test_cache_invalidate_single_entry_no_gen_bump():
     assert cache.get(42, "abc", "model", "owner", "demo") is None
     # No generation bump — invalidate is a per-entry hygiene op only.
     assert cache.global_gen == 0
-    assert cache.user_gens[42] == 0
-    assert cache.repo_gens[("model", "owner", "demo")] == 0
+    assert cache.user_gens.get(42, 0) == 0
+    assert cache.repo_gens.get(("model", "owner", "demo"), 0) == 0
 
 
 def test_cache_invalidate_returns_false_when_absent():
@@ -178,11 +178,11 @@ def test_invalidate_repo_clears_all_user_buckets_for_one_repo():
 def test_invalidate_repo_bumps_repo_gen():
     cache = RepoSourceCache()
     _seed(cache, user_id=1)
-    initial = cache.repo_gens[("model", "owner", "demo")]
+    initial = cache.repo_gens.get(("model", "owner", "demo"), 0)
     cache.invalidate_repo("model", "owner", "demo")
     assert cache.repo_gens[("model", "owner", "demo")] == initial + 1
     # other repos' gens untouched
-    assert cache.repo_gens[("model", "owner", "other")] == 0
+    assert cache.repo_gens.get(("model", "owner", "other"), 0) == 0
 
 
 def test_invalidate_repo_with_no_entries_still_bumps_gen():
@@ -199,7 +199,7 @@ def test_invalidate_repo_does_not_touch_global_or_user_gens():
     _seed(cache, user_id=1)
     cache.invalidate_repo("model", "owner", "demo")
     assert cache.global_gen == 0
-    assert cache.user_gens[1] == 0
+    assert cache.user_gens.get(1, 0) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -235,11 +235,11 @@ def test_clear_user_anonymous_clears_anon_bucket():
 def test_clear_user_bumps_user_gen():
     cache = RepoSourceCache()
     _seed(cache, user_id=42)
-    initial = cache.user_gens[42]
+    initial = cache.user_gens.get(42, 0)
     cache.clear_user(42)
     assert cache.user_gens[42] == initial + 1
     # Other user gens untouched
-    assert cache.user_gens[7] == 0
+    assert cache.user_gens.get(7, 0) == 0
 
 
 def test_clear_user_with_no_entries_still_bumps_gen():
@@ -253,7 +253,7 @@ def test_clear_user_does_not_touch_global_or_repo_gens():
     _seed(cache, user_id=1)
     cache.clear_user(1)
     assert cache.global_gen == 0
-    assert cache.repo_gens[("model", "owner", "demo")] == 0
+    assert cache.repo_gens.get(("model", "owner", "demo"), 0) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +395,69 @@ def test_reset_cache_for_tests_drops_singleton():
     cache_module.reset_cache_for_tests()
     b = cache_module.get_cache()
     assert a is not b
+
+
+# ---------------------------------------------------------------------------
+# Phantom-entry regression (PR #81 review item #1)
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_does_not_create_phantom_user_gens_entries():
+    """Read-only ``snapshot`` MUST NOT materialize entries in
+    ``user_gens``. With the old ``defaultdict(int)`` implementation
+    every ``snapshot(user_id, ...)`` left a permanent zero-valued
+    entry — an unbounded leak under workloads with high user
+    cardinality (e.g. every request adds one). The fix uses
+    ``dict.get(key, 0)`` in ``snapshot``; this test pins the
+    invariant.
+    """
+    cache = RepoSourceCache()
+    for uid in range(1000):
+        cache.snapshot(uid, "model", "ns", "demo")
+    assert len(cache.user_gens) == 0, (
+        "snapshot must not insert into user_gens — that's the leak fixed in #81"
+    )
+
+
+def test_snapshot_does_not_create_phantom_repo_gens_entries():
+    """Same invariant for ``repo_gens``: distinct repo identities
+    queried via ``snapshot`` must not accumulate phantom entries.
+    """
+    cache = RepoSourceCache()
+    for i in range(1000):
+        cache.snapshot(None, "model", "ns", f"repo-{i}")
+    assert len(cache.repo_gens) == 0, (
+        "snapshot must not insert into repo_gens — that's the leak fixed in #81"
+    )
+
+
+def test_get_does_not_create_phantom_gens_entries():
+    """``get`` (cache miss) must not create entries either."""
+    cache = RepoSourceCache()
+    for i in range(1000):
+        cache.get(i, f"hash{i}", "model", "ns", f"repo-{i}")
+    assert len(cache.user_gens) == 0
+    assert len(cache.repo_gens) == 0
+
+
+def test_invalidate_repo_only_inserts_for_invalidated_keys():
+    """``invalidate_repo`` is the only legitimate writer to
+    ``repo_gens``; verify cardinality matches the number of
+    distinct repos invalidated."""
+    cache = RepoSourceCache()
+    cache.invalidate_repo("model", "ns", "r1")
+    cache.invalidate_repo("model", "ns", "r2")
+    cache.invalidate_repo("dataset", "ns", "r1")
+    assert len(cache.repo_gens) == 3
+
+
+def test_clear_user_only_inserts_for_cleared_users():
+    """``clear_user`` is the only legitimate writer to ``user_gens``."""
+    cache = RepoSourceCache()
+    cache.clear_user(1)
+    cache.clear_user(2)
+    cache.clear_user(None)  # anonymous bucket
+    assert len(cache.user_gens) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
+++ b/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
@@ -1,0 +1,458 @@
+"""API-level coverage of every cache invalidation hook (#79).
+
+Each test seeds the fallback cache with a known entry, calls the
+corresponding HTTP endpoint via FastAPI's ASGI transport, and asserts
+the cache was evicted (and the relevant generation counter was bumped).
+
+Hooks covered:
+
+- POST   /api/users/{username}/external-tokens          → clear_user
+- DELETE /api/users/{username}/external-tokens/{url}    → clear_user
+- PUT    /api/users/{username}/external-tokens/bulk     → clear_user
+- POST   /api/repos/create                              → invalidate_repo
+- DELETE /api/repos/delete                              → invalidate_repo
+- POST   /api/repos/move                                → invalidate_repo (both ids)
+- PUT    /api/{repo_type}s/{ns}/{name}/settings (private flip) → invalidate_repo
+- POST   /admin/api/fallback-sources                    → cache.clear()
+- DELETE /admin/api/fallback-sources/cache/repo/...     → invalidate_repo
+- DELETE /admin/api/fallback-sources/cache/user/{uid}   → clear_user
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed(cache, *, user_id, tokens_hash="", repo_type="model",
+          ns="owner", name="demo", url="https://x.local"):
+    cache.set(
+        user_id, tokens_hash,
+        repo_type, ns, name,
+        url, "X", "huggingface",
+    )
+
+
+def _get_cache(backend_test_state):
+    return backend_test_state.modules.fallback_cache_module.get_cache()
+
+
+def _get_owner_id(backend_test_state):
+    User = backend_test_state.modules.db_module.User
+    return User.get(User.username == "owner").id
+
+
+# ---------------------------------------------------------------------------
+# External token endpoints → clear_user
+# ---------------------------------------------------------------------------
+
+
+async def test_external_token_post_clears_user_cache(owner_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    _seed(cache, user_id=owner_id, name="r1")
+    _seed(cache, user_id=owner_id, name="r2")
+    _seed(cache, user_id=owner_id + 9999, name="r1")  # different user, must survive
+    initial_user_gen = cache.user_gens[owner_id]
+
+    response = await owner_client.post(
+        "/api/users/owner/external-tokens",
+        json={"url": "https://post-evict.example", "token": "hf_abc"},
+    )
+    assert response.status_code == 200
+
+    assert cache.get(owner_id, "", "model", "owner", "r1") is None
+    assert cache.get(owner_id, "", "model", "owner", "r2") is None
+    assert cache.get(owner_id + 9999, "", "model", "owner", "r1") is not None
+    assert cache.user_gens[owner_id] == initial_user_gen + 1
+
+
+async def test_external_token_delete_clears_user_cache(owner_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    # Need a token to delete first.
+    add_response = await owner_client.post(
+        "/api/users/owner/external-tokens",
+        json={"url": "https://delete-evict.example", "token": "hf_abc"},
+    )
+    assert add_response.status_code == 200
+
+    _seed(cache, user_id=owner_id, name="r1")
+    initial_user_gen = cache.user_gens[owner_id]
+
+    delete_response = await owner_client.delete(
+        "/api/users/owner/external-tokens/"
+        + quote("https://delete-evict.example", safe="")
+    )
+    assert delete_response.status_code == 200
+
+    assert cache.get(owner_id, "", "model", "owner", "r1") is None
+    assert cache.user_gens[owner_id] == initial_user_gen + 1
+
+
+async def test_external_token_bulk_clears_user_cache(owner_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    _seed(cache, user_id=owner_id, name="r1")
+    _seed(cache, user_id=owner_id, name="r2")
+    initial_user_gen = cache.user_gens[owner_id]
+
+    response = await owner_client.put(
+        "/api/users/owner/external-tokens/bulk",
+        json={
+            "tokens": [
+                {"url": "https://bulk-evict.example", "token": "hf_a"},
+                {"url": "https://bulk-evict-2.example", "token": "hf_b"},
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    assert cache.get(owner_id, "", "model", "owner", "r1") is None
+    assert cache.get(owner_id, "", "model", "owner", "r2") is None
+    assert cache.user_gens[owner_id] == initial_user_gen + 1
+
+
+# ---------------------------------------------------------------------------
+# Repo CRUD endpoints → invalidate_repo
+# ---------------------------------------------------------------------------
+
+
+async def test_repo_create_invalidates_repo_cache(owner_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    _seed(cache, user_id=owner_id, name="ghost-create")
+    _seed(cache, user_id=None, name="ghost-create")
+    _seed(cache, user_id=owner_id, name="other-repo")  # different repo, must survive
+    initial_repo_gen = cache.repo_gens[("model", "owner", "ghost-create")]
+
+    response = await owner_client.post(
+        "/api/repos/create",
+        json={"name": "ghost-create", "type": "model", "private": False},
+    )
+    assert response.status_code == 200, response.text
+
+    assert cache.get(owner_id, "", "model", "owner", "ghost-create") is None
+    assert cache.get(None, "", "model", "owner", "ghost-create") is None
+    # Different repo — untouched.
+    assert cache.get(owner_id, "", "model", "owner", "other-repo") is not None
+    assert cache.repo_gens[("model", "owner", "ghost-create")] == initial_repo_gen + 1
+
+    # Cleanup the repo we created.
+    await owner_client.request(
+        "DELETE",
+        "/api/repos/delete",
+        json={"name": "ghost-create", "type": "model"},
+    )
+
+
+async def test_repo_delete_invalidates_repo_cache(owner_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    # Create a repo to delete.
+    create_response = await owner_client.post(
+        "/api/repos/create",
+        json={"name": "ghost-delete", "type": "model", "private": False},
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    # Seed cache AFTER create (create itself bumps the gen).
+    _seed(cache, user_id=owner_id, name="ghost-delete")
+    _seed(cache, user_id=owner_id + 9999, name="ghost-delete")
+    initial_repo_gen = cache.repo_gens[("model", "owner", "ghost-delete")]
+
+    delete_response = await owner_client.request(
+        "DELETE",
+        "/api/repos/delete",
+        json={"name": "ghost-delete", "type": "model"},
+    )
+    assert delete_response.status_code == 200, delete_response.text
+
+    assert cache.get(owner_id, "", "model", "owner", "ghost-delete") is None
+    assert cache.get(owner_id + 9999, "", "model", "owner", "ghost-delete") is None
+    assert cache.repo_gens[("model", "owner", "ghost-delete")] == initial_repo_gen + 1
+
+
+async def test_repo_move_invalidates_both_old_and_new_repo_caches(
+    owner_client, backend_test_state
+):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    create_response = await owner_client.post(
+        "/api/repos/create",
+        json={"name": "rename-source", "type": "model", "private": False},
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    # Seed both ids (the move endpoint should evict both).
+    _seed(cache, user_id=owner_id, name="rename-source")
+    _seed(cache, user_id=owner_id, name="rename-dest")
+    initial_src_gen = cache.repo_gens[("model", "owner", "rename-source")]
+    initial_dst_gen = cache.repo_gens[("model", "owner", "rename-dest")]
+
+    move_response = await owner_client.post(
+        "/api/repos/move",
+        json={
+            "fromRepo": "owner/rename-source",
+            "toRepo": "owner/rename-dest",
+            "type": "model",
+        },
+    )
+    assert move_response.status_code == 200, move_response.text
+
+    assert cache.get(owner_id, "", "model", "owner", "rename-source") is None
+    assert cache.get(owner_id, "", "model", "owner", "rename-dest") is None
+    assert cache.repo_gens[("model", "owner", "rename-source")] == initial_src_gen + 1
+    assert cache.repo_gens[("model", "owner", "rename-dest")] == initial_dst_gen + 1
+
+    # Cleanup
+    await owner_client.request(
+        "DELETE",
+        "/api/repos/delete",
+        json={"name": "rename-dest", "type": "model"},
+    )
+
+
+async def test_repo_visibility_toggle_invalidates_repo_cache(
+    owner_client, backend_test_state
+):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    create_response = await owner_client.post(
+        "/api/repos/create",
+        json={"name": "visflip", "type": "model", "private": False},
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    _seed(cache, user_id=owner_id, name="visflip")
+    _seed(cache, user_id=None, name="visflip")  # anonymous bucket too
+    initial_repo_gen = cache.repo_gens[("model", "owner", "visflip")]
+
+    settings_response = await owner_client.put(
+        "/api/models/owner/visflip/settings",
+        json={"private": True},
+    )
+    assert settings_response.status_code == 200, settings_response.text
+
+    assert cache.get(owner_id, "", "model", "owner", "visflip") is None
+    assert cache.get(None, "", "model", "owner", "visflip") is None
+    assert cache.repo_gens[("model", "owner", "visflip")] == initial_repo_gen + 1
+
+    # Cleanup
+    await owner_client.request(
+        "DELETE",
+        "/api/repos/delete",
+        json={"name": "visflip", "type": "model"},
+    )
+
+
+async def test_repo_settings_non_visibility_does_not_invalidate(
+    owner_client, backend_test_state
+):
+    """LFS settings, quota, etc. don't affect binding. They must NOT
+    fire an invalidate_repo (cache stays warm)."""
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    create_response = await owner_client.post(
+        "/api/repos/create",
+        json={"name": "lfsonly", "type": "model", "private": False},
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    _seed(cache, user_id=owner_id, name="lfsonly")
+    initial_repo_gen = cache.repo_gens[("model", "owner", "lfsonly")]
+
+    # Update only an LFS setting — visibility unchanged.
+    settings_response = await owner_client.put(
+        "/api/models/owner/lfsonly/settings",
+        json={"lfs_threshold_bytes": 50_000_000},
+    )
+    assert settings_response.status_code == 200, settings_response.text
+
+    # Cache entry survives; no gen bump.
+    assert cache.get(owner_id, "", "model", "owner", "lfsonly") is not None
+    assert cache.repo_gens[("model", "owner", "lfsonly")] == initial_repo_gen
+
+    # Cleanup
+    await owner_client.request(
+        "DELETE",
+        "/api/repos/delete",
+        json={"name": "lfsonly", "type": "model"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin source CREATE → cache.clear() (parallels existing UPDATE/DELETE)
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_source_create_clears_global_cache(
+    admin_client, backend_test_state
+):
+    cache = _get_cache(backend_test_state)
+    cache.clear()  # baseline
+    _seed(cache, user_id=1, name="r1")
+    _seed(cache, user_id=2, name="r2")
+    initial_global_gen = cache.global_gen
+
+    create_response = await admin_client.post(
+        "/admin/api/fallback-sources",
+        json={
+            "namespace": "",
+            "url": "https://create-clear.example",
+            "name": "CreateClear",
+            "source_type": "huggingface",
+            "priority": 50,
+            "enabled": True,
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    # Cache wiped; global_gen bumped.
+    assert cache.stats()["size"] == 0
+    assert cache.global_gen == initial_global_gen + 1
+
+    # Cleanup the source we created.
+    created_id = create_response.json()["id"]
+    delete_response = await admin_client.delete(
+        f"/admin/api/fallback-sources/{created_id}"
+    )
+    assert delete_response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# New admin endpoints: per-repo + per-user
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_invalidate_repo_endpoint(admin_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    _seed(cache, user_id=1, name="target")
+    _seed(cache, user_id=2, name="target")
+    _seed(cache, user_id=1, name="other")
+    initial_target_gen = cache.repo_gens[("model", "owner", "target")]
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/repo/model/owner/target"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True
+    assert body["evicted"] == 2
+
+    assert cache.get(1, "", "model", "owner", "target") is None
+    assert cache.get(2, "", "model", "owner", "target") is None
+    assert cache.get(1, "", "model", "owner", "other") is not None
+    assert cache.repo_gens[("model", "owner", "target")] == initial_target_gen + 1
+
+
+async def test_admin_invalidate_user_endpoint(admin_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    _seed(cache, user_id=42, name="r1")
+    _seed(cache, user_id=42, name="r2")
+    _seed(cache, user_id=99, name="r1")
+    initial_user_gen = cache.user_gens[42]
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/user/42"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True
+    assert body["evicted"] == 2
+
+    assert cache.get(42, "", "model", "owner", "r1") is None
+    assert cache.get(42, "", "model", "owner", "r2") is None
+    assert cache.get(99, "", "model", "owner", "r1") is not None
+    assert cache.user_gens[42] == initial_user_gen + 1
+
+
+async def test_admin_invalidate_endpoints_require_admin_token(client):
+    """Anonymous calls to admin endpoints should be rejected."""
+    repo_response = await client.delete(
+        "/admin/api/fallback-sources/cache/repo/model/owner/target"
+    )
+    assert repo_response.status_code in (401, 403)
+
+    user_response = await client.delete(
+        "/admin/api/fallback-sources/cache/user/42"
+    )
+    assert user_response.status_code in (401, 403)
+
+
+async def test_admin_invalidate_repo_with_no_entries(admin_client, backend_test_state):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    initial_gen = cache.repo_gens[("model", "ghost", "ghost")]
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/repo/model/ghost/ghost"
+    )
+    assert response.status_code == 200
+    assert response.json()["evicted"] == 0
+    # Gen still bumps (race protection).
+    assert cache.repo_gens[("model", "ghost", "ghost")] == initial_gen + 1
+
+
+# ---------------------------------------------------------------------------
+# Exception path coverage on the two new admin endpoints.
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_invalidate_repo_endpoint_500_on_internal_error(
+    admin_client, backend_test_state, monkeypatch
+):
+    """Inject a failure into ``invalidate_repo`` to exercise the
+    500-handler path on the new admin endpoint."""
+    cache = _get_cache(backend_test_state)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(cache, "invalidate_repo", boom)
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/repo/model/owner/exception-path"
+    )
+    assert response.status_code == 500
+    assert "Failed to invalidate repo cache" in response.json()["detail"]["error"]
+
+
+async def test_admin_invalidate_user_endpoint_500_on_internal_error(
+    admin_client, backend_test_state, monkeypatch
+):
+    cache = _get_cache(backend_test_state)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(cache, "clear_user", boom)
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/user/12345"
+    )
+    assert response.status_code == 500
+    assert "Failed to invalidate user cache" in response.json()["detail"]["error"]

--- a/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
+++ b/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
@@ -456,3 +456,74 @@ async def test_admin_invalidate_user_endpoint_500_on_internal_error(
     )
     assert response.status_code == 500
     assert "Failed to invalidate user cache" in response.json()["detail"]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Username-based eviction endpoint (admin-frontend convenience path)
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_invalidate_username_endpoint_success(
+    admin_client, backend_test_state
+):
+    cache = _get_cache(backend_test_state)
+    cache.clear()
+    owner_id = _get_owner_id(backend_test_state)
+
+    _seed(cache, user_id=owner_id, name="r1")
+    _seed(cache, user_id=owner_id, name="r2")
+    _seed(cache, user_id=owner_id + 9999, name="r1")  # different user, must survive
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/username/owner"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True
+    assert body["evicted"] == 2
+    assert body["username"] == "owner"
+    assert body["user_id"] == owner_id
+
+    # owner buckets gone, other user's bucket survives.
+    assert cache.get(owner_id, "", "model", "owner", "r1") is None
+    assert cache.get(owner_id, "", "model", "owner", "r2") is None
+    assert cache.get(owner_id + 9999, "", "model", "owner", "r1") is not None
+
+
+async def test_admin_invalidate_username_endpoint_404_unknown_user(
+    admin_client,
+):
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/username/no-such-user-zzz"
+    )
+    assert response.status_code == 404
+    assert "User not found" in response.json()["detail"]["error"]
+
+
+async def test_admin_invalidate_username_endpoint_requires_admin_token(client):
+    response = await client.delete(
+        "/admin/api/fallback-sources/cache/username/owner"
+    )
+    assert response.status_code in (401, 403)
+
+
+async def test_admin_invalidate_username_endpoint_500_on_internal_error(
+    admin_client, backend_test_state, monkeypatch
+):
+    """Inject a failure into ``clear_user`` to exercise the 500 handler
+    on the username-based path (separate from the user_id-based one)."""
+    cache = _get_cache(backend_test_state)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(cache, "clear_user", boom)
+
+    response = await admin_client.delete(
+        "/admin/api/fallback-sources/cache/username/owner"
+    )
+    assert response.status_code == 500
+    assert (
+        "Failed to invalidate user cache by username"
+        in response.json()["detail"]["error"]
+    )

--- a/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
+++ b/test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py
@@ -60,7 +60,7 @@ async def test_external_token_post_clears_user_cache(owner_client, backend_test_
     _seed(cache, user_id=owner_id, name="r1")
     _seed(cache, user_id=owner_id, name="r2")
     _seed(cache, user_id=owner_id + 9999, name="r1")  # different user, must survive
-    initial_user_gen = cache.user_gens[owner_id]
+    initial_user_gen = cache.user_gens.get(owner_id, 0)
 
     response = await owner_client.post(
         "/api/users/owner/external-tokens",
@@ -87,7 +87,7 @@ async def test_external_token_delete_clears_user_cache(owner_client, backend_tes
     assert add_response.status_code == 200
 
     _seed(cache, user_id=owner_id, name="r1")
-    initial_user_gen = cache.user_gens[owner_id]
+    initial_user_gen = cache.user_gens.get(owner_id, 0)
 
     delete_response = await owner_client.delete(
         "/api/users/owner/external-tokens/"
@@ -106,7 +106,7 @@ async def test_external_token_bulk_clears_user_cache(owner_client, backend_test_
 
     _seed(cache, user_id=owner_id, name="r1")
     _seed(cache, user_id=owner_id, name="r2")
-    initial_user_gen = cache.user_gens[owner_id]
+    initial_user_gen = cache.user_gens.get(owner_id, 0)
 
     response = await owner_client.put(
         "/api/users/owner/external-tokens/bulk",
@@ -137,7 +137,7 @@ async def test_repo_create_invalidates_repo_cache(owner_client, backend_test_sta
     _seed(cache, user_id=owner_id, name="ghost-create")
     _seed(cache, user_id=None, name="ghost-create")
     _seed(cache, user_id=owner_id, name="other-repo")  # different repo, must survive
-    initial_repo_gen = cache.repo_gens[("model", "owner", "ghost-create")]
+    initial_repo_gen = cache.repo_gens.get(("model", "owner", "ghost-create"), 0)
 
     response = await owner_client.post(
         "/api/repos/create",
@@ -174,7 +174,7 @@ async def test_repo_delete_invalidates_repo_cache(owner_client, backend_test_sta
     # Seed cache AFTER create (create itself bumps the gen).
     _seed(cache, user_id=owner_id, name="ghost-delete")
     _seed(cache, user_id=owner_id + 9999, name="ghost-delete")
-    initial_repo_gen = cache.repo_gens[("model", "owner", "ghost-delete")]
+    initial_repo_gen = cache.repo_gens.get(("model", "owner", "ghost-delete"), 0)
 
     delete_response = await owner_client.request(
         "DELETE",
@@ -204,8 +204,8 @@ async def test_repo_move_invalidates_both_old_and_new_repo_caches(
     # Seed both ids (the move endpoint should evict both).
     _seed(cache, user_id=owner_id, name="rename-source")
     _seed(cache, user_id=owner_id, name="rename-dest")
-    initial_src_gen = cache.repo_gens[("model", "owner", "rename-source")]
-    initial_dst_gen = cache.repo_gens[("model", "owner", "rename-dest")]
+    initial_src_gen = cache.repo_gens.get(("model", "owner", "rename-source"), 0)
+    initial_dst_gen = cache.repo_gens.get(("model", "owner", "rename-dest"), 0)
 
     move_response = await owner_client.post(
         "/api/repos/move",
@@ -245,7 +245,7 @@ async def test_repo_visibility_toggle_invalidates_repo_cache(
 
     _seed(cache, user_id=owner_id, name="visflip")
     _seed(cache, user_id=None, name="visflip")  # anonymous bucket too
-    initial_repo_gen = cache.repo_gens[("model", "owner", "visflip")]
+    initial_repo_gen = cache.repo_gens.get(("model", "owner", "visflip"), 0)
 
     settings_response = await owner_client.put(
         "/api/models/owner/visflip/settings",
@@ -281,7 +281,7 @@ async def test_repo_settings_non_visibility_does_not_invalidate(
     assert create_response.status_code == 200, create_response.text
 
     _seed(cache, user_id=owner_id, name="lfsonly")
-    initial_repo_gen = cache.repo_gens[("model", "owner", "lfsonly")]
+    initial_repo_gen = cache.repo_gens.get(("model", "owner", "lfsonly"), 0)
 
     # Update only an LFS setting — visibility unchanged.
     settings_response = await owner_client.put(
@@ -352,7 +352,7 @@ async def test_admin_invalidate_repo_endpoint(admin_client, backend_test_state):
     _seed(cache, user_id=1, name="target")
     _seed(cache, user_id=2, name="target")
     _seed(cache, user_id=1, name="other")
-    initial_target_gen = cache.repo_gens[("model", "owner", "target")]
+    initial_target_gen = cache.repo_gens.get(("model", "owner", "target"), 0)
 
     response = await admin_client.delete(
         "/admin/api/fallback-sources/cache/repo/model/owner/target"
@@ -374,7 +374,7 @@ async def test_admin_invalidate_user_endpoint(admin_client, backend_test_state):
     _seed(cache, user_id=42, name="r1")
     _seed(cache, user_id=42, name="r2")
     _seed(cache, user_id=99, name="r1")
-    initial_user_gen = cache.user_gens[42]
+    initial_user_gen = cache.user_gens.get(42, 0)
 
     response = await admin_client.delete(
         "/admin/api/fallback-sources/cache/user/42"
@@ -406,7 +406,7 @@ async def test_admin_invalidate_endpoints_require_admin_token(client):
 async def test_admin_invalidate_repo_with_no_entries(admin_client, backend_test_state):
     cache = _get_cache(backend_test_state)
     cache.clear()
-    initial_gen = cache.repo_gens[("model", "ghost", "ghost")]
+    initial_gen = cache.repo_gens.get(("model", "ghost", "ghost"), 0)
 
     response = await admin_client.delete(
         "/admin/api/fallback-sources/cache/repo/model/ghost/ghost"

--- a/test/kohakuhub/api/fallback/test_decorators.py
+++ b/test/kohakuhub/api/fallback/test_decorators.py
@@ -94,7 +94,11 @@ async def test_with_repo_fallback_uses_resolve_operation_after_http_404(monkeypa
     assert resolve_calls == [
         (
             ("dataset", "owner", "demo", "main", "config.json"),
-            {"user_tokens": {"https://hf.local": "token"}, "method": "HEAD"},
+            {
+                "user_tokens": {"https://hf.local": "token"},
+                "method": "HEAD",
+                "user": "owner-user",
+            },
         )
     ]
 
@@ -200,6 +204,7 @@ async def test_with_repo_fallback_forwards_tree_and_paths_info_expand_parameters
                 "limit": 25,
                 "cursor": "page-1",
                 "user_tokens": {"https://hf.local": "token"},
+                "user": "owner-user",
             },
         )
     ]
@@ -223,6 +228,7 @@ async def test_with_repo_fallback_forwards_tree_and_paths_info_expand_parameters
             {
                 "expand": True,
                 "user_tokens": {"https://hf.local": "token"},
+                "user": "owner-user",
             },
         )
     ]

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -38,24 +38,108 @@ def _content_response(
 
 
 class DummyCache:
-    """Simple cache spy."""
+    """Simple cache spy compatible with the post-#79 RepoSourceCache surface.
+
+    The internal ``set_calls`` / ``invalidate_calls`` recordings shape
+    args as ``(repo_type, namespace, name, ...)`` — the new
+    ``(user_id, tokens_hash)`` prefix is dropped from positional args
+    and exposed via ``kwargs`` instead so that existing assertions
+    (``set_calls[i][0][:3]`` and similar) keep working unchanged.
+    """
 
     def __init__(self, cached: dict | None = None):
         self.cached = cached
         self.set_calls: list[tuple[tuple, dict]] = []
         self.invalidate_calls: list[tuple] = []
+        self.snapshot_calls: list[tuple] = []
+        # Static gens snapshot — DummyCache pretends nothing ever
+        # invalidates so safe_set always succeeds.
+        self._gens: tuple[int, int, int] = (0, 0, 0)
 
-    def get(self, *args):
+    def get(self, user_id=None, tokens_hash=None, *args):
+        # New signature ``get(user_id, tokens_hash, repo_type, ns, name)``.
+        # Older two-positional-arg tests still work because Python
+        # tolerates extra positional args via ``*args``.
         return self.cached
 
-    def set(self, *args, **kwargs):
-        self.set_calls.append((args, kwargs))
+    def set(
+        self,
+        user_id=None,
+        tokens_hash=None,
+        repo_type=None,
+        namespace=None,
+        name=None,
+        source_url=None,
+        source_name=None,
+        source_type=None,
+        exists=True,
+    ):
+        self.set_calls.append(
+            (
+                (repo_type, namespace, name, source_url, source_name, source_type),
+                {
+                    "exists": exists,
+                    "user_id": user_id,
+                    "tokens_hash": tokens_hash,
+                },
+            )
+        )
 
-    def invalidate(self, *args):
-        # Cache-authoritative semantics (#75): a stale-cache hit
+    def safe_set(
+        self,
+        user_id=None,
+        tokens_hash=None,
+        repo_type=None,
+        namespace=None,
+        name=None,
+        source_url=None,
+        source_name=None,
+        source_type=None,
+        gens_at_start=None,
+        exists=True,
+    ) -> bool:
+        self.set_calls.append(
+            (
+                (repo_type, namespace, name, source_url, source_name, source_type),
+                {
+                    "exists": exists,
+                    "user_id": user_id,
+                    "tokens_hash": tokens_hash,
+                    "gens_at_start": gens_at_start,
+                },
+            )
+        )
+        return True
+
+    def snapshot(self, user_id, repo_type, namespace, name):
+        self.snapshot_calls.append((user_id, repo_type, namespace, name))
+        return self._gens
+
+    def invalidate(
+        self,
+        user_id=None,
+        tokens_hash=None,
+        repo_type=None,
+        namespace=None,
+        name=None,
+    ):
+        # Cache-authoritative semantics (#75/#79): a stale-cache hit
         # invalidates the entry before falling through to the full
         # chain. Tests that simulate stale-cache need this hook.
-        self.invalidate_calls.append(args)
+        self.invalidate_calls.append((repo_type, namespace, name))
+        self.cached = None
+
+    def invalidate_repo(self, repo_type, namespace, name) -> int:
+        self.invalidate_calls.append((repo_type, namespace, name))
+        self.cached = None
+        return 1
+
+    def clear_user(self, user_id) -> int:
+        self.invalidate_calls.append(("__user__", user_id, None))
+        return 0
+
+    def clear(self) -> None:
+        self.invalidate_calls.append(("__global__", None, None))
         self.cached = None
 
 

--- a/test/kohakuhub/api/fallback/test_strict_consistency.py
+++ b/test/kohakuhub/api/fallback/test_strict_consistency.py
@@ -113,6 +113,20 @@ class _RequestLog:
 REQUEST_LOG = _RequestLog()
 
 
+def _owner_cache_key() -> tuple[int, str]:
+    """Return (user_id, tokens_hash) matching authed owner-token requests.
+
+    Strict-consistency tests in this module authenticate as ``owner``
+    via ``hf_api_token``; cache lookups/seeds must use the same
+    ``(user_id, tokens_hash)`` so that direct-cache state and live
+    request state share a bucket. Owner has no external tokens
+    configured in these tests, so ``tokens_hash`` is empty.
+    """
+    from kohakuhub.db import User
+
+    return User.get(User.username == "owner").id, ""
+
+
 @pytest.fixture(scope="module")
 def scenario_mock_url():
     """Single scenario mock for all consistency tests in this module.
@@ -248,7 +262,9 @@ def test_bound_source_5xx_does_not_rebind_to_sibling(
     # Read it back from cfg.
     import kohakuhub.config as cfg_mod
     src = cfg_mod.cfg.fallback.sources[0]
+    uid, th = _owner_cache_key()
     cache.set(
+        uid, th,
         "model", "owner", "scenario-repo",
         src["url"], src["name"], src["source_type"],
         exists=True,
@@ -264,7 +280,7 @@ def test_bound_source_5xx_does_not_rebind_to_sibling(
 
     # Critical: cache is still bound to the same source after the
     # bound-source failure. Confirm by reading the cache directly.
-    cached = cache.get("model", "owner", "scenario-repo")
+    cached = cache.get(uid, th, "model", "owner", "scenario-repo")
     assert cached is not None
     assert cached.get("source_url") == src["url"]
     assert cached.get("exists") is True
@@ -289,7 +305,9 @@ def test_bound_source_failure_does_not_walk_to_sibling_even_when_sibling_works(
     import kohakuhub.config as cfg_mod
     src_a = cfg_mod.cfg.fallback.sources[0]
     cache = get_cache()
+    uid, th = _owner_cache_key()
     cache.set(
+        uid, th,
         "model", "owner", "scenario-repo",
         src_a["url"], src_a["name"], src_a["source_type"],
         exists=True,
@@ -463,17 +481,18 @@ def test_ttl_expiry_under_fixed_external_state_rebinds_same_source(
     api.model_info("owner/scenario-repo")
     from kohakuhub.api.fallback.cache import get_cache
     cache = get_cache()
-    first_cached = cache.get("model", "owner", "scenario-repo")
+    uid, th = _owner_cache_key()
+    first_cached = cache.get(uid, th, "model", "owner", "scenario-repo")
     assert first_cached is not None
     assert first_cached["source_url"] == src_a_url
 
     # Simulate TTL expiry by clearing the cache.
-    cache.invalidate("model", "owner", "scenario-repo")
+    cache.invalidate(uid, th, "model", "owner", "scenario-repo")
 
     # Second binding (must pick same source under unchanged
     # external state).
     api.model_info("owner/scenario-repo")
-    second_cached = cache.get("model", "owner", "scenario-repo")
+    second_cached = cache.get(uid, th, "model", "owner", "scenario-repo")
     assert second_cached is not None
     assert second_cached["source_url"] == first_cached["source_url"]
 
@@ -528,13 +547,14 @@ def test_multi_op_session_all_route_to_same_source(
 
     from kohakuhub.api.fallback.cache import get_cache
     cache = get_cache()
-    bound_url_after_info = cache.get("model", "owner", "scenario-repo")["source_url"]
+    uid, th = _owner_cache_key()
+    bound_url_after_info = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
     assert bound_url_after_info == src_a["url"]
 
     # Op 2: list_repo_files.
     files = api.list_repo_files("owner/scenario-repo")
     assert "config.json" in files
-    bound_url_after_tree = cache.get("model", "owner", "scenario-repo")["source_url"]
+    bound_url_after_tree = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
     assert bound_url_after_tree == src_a["url"]
 
     # Op 3: hf_hub_download — actual file download.
@@ -546,7 +566,7 @@ def test_multi_op_session_all_route_to_same_source(
         cache_dir=str(tmp_path),
     )
     assert Path(path).read_bytes() == OK_BODY
-    bound_url_after_dl = cache.get("model", "owner", "scenario-repo")["source_url"]
+    bound_url_after_dl = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
     assert bound_url_after_dl == src_a["url"]
 
     # Op 4: get_paths_info.
@@ -554,7 +574,7 @@ def test_multi_op_session_all_route_to_same_source(
     if method is not None:
         result = method(repo_id="owner/scenario-repo", paths=["config.json"])
         assert len(list(result)) >= 1
-        bound_url_after_pi = cache.get("model", "owner", "scenario-repo")["source_url"]
+        bound_url_after_pi = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
         assert bound_url_after_pi == src_a["url"]
 
 
@@ -571,7 +591,8 @@ def test_snapshot_download_pattern_stays_on_one_source(
     files = api.list_repo_files("owner/scenario-repo")
     from kohakuhub.api.fallback.cache import get_cache
     cache = get_cache()
-    initial_bind = cache.get("model", "owner", "scenario-repo")["source_url"]
+    uid, th = _owner_cache_key()
+    initial_bind = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
 
     # Download every file; bound source must not move.
     for name in files:
@@ -582,7 +603,7 @@ def test_snapshot_download_pattern_stays_on_one_source(
             token=hf_api_token,
             cache_dir=str(tmp_path),
         )
-        current_bind = cache.get("model", "owner", "scenario-repo")["source_url"]
+        current_bind = cache.get(uid, th, "model", "owner", "scenario-repo")["source_url"]
         assert current_bind == initial_bind
 
 
@@ -612,12 +633,152 @@ def test_two_independent_client_sessions_bind_same_source(
 
     from kohakuhub.api.fallback.cache import get_cache
     cache = get_cache()
-    bound = cache.get("model", "owner", "scenario-repo")
+    uid, th = _owner_cache_key()
+    bound = cache.get(uid, th, "model", "owner", "scenario-repo")
     assert bound["source_url"] == expected_url
 
     # Wipe cache to force a fresh bind for client #2 — same external
     # state, must rebind same source.
-    cache.invalidate("model", "owner", "scenario-repo")
+    cache.invalidate(uid, th, "model", "owner", "scenario-repo")
     api2.model_info("owner/scenario-repo")
-    bound2 = cache.get("model", "owner", "scenario-repo")
+    bound2 = cache.get(uid, th, "model", "owner", "scenario-repo")
     assert bound2["source_url"] == expected_url
+
+
+# ===========================================================================
+# Guarantee 7 (#79): Per-user cache isolation end-to-end via hf_hub.
+# ===========================================================================
+
+
+def test_two_users_via_hf_hub_get_independent_cache_buckets(
+    live_server_url, consistency_env, app,
+):
+    """Same khub, same repo, two distinct authenticated users via the
+    real ``huggingface_hub`` library. Each must land in a separate
+    cache bucket (#79 strict-freshness contract). Verified by direct
+    cache inspection: after both users call ``model_info``, two
+    bindings exist, keyed by their respective user_id.
+    """
+    import asyncio
+
+    import httpx
+    from kohakuhub.db import User
+
+    from test.kohakuhub.support.bootstrap import DEFAULT_PASSWORD
+
+    configure, _reset = consistency_env
+    configure("200_ok")  # single source, both users will bind to it
+
+    async def _get_token(username: str) -> str:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            follow_redirects=False,
+        ) as ac:
+            login = await ac.post(
+                "/api/auth/login",
+                json={"username": username, "password": DEFAULT_PASSWORD},
+            )
+            login.raise_for_status()
+            tok = await ac.post(
+                "/api/auth/tokens/create",
+                json={"name": f"hf-api-compat-{username}"},
+            )
+            tok.raise_for_status()
+            return tok.json()["token"]
+
+    owner_token = asyncio.run(_get_token("owner"))
+    member_token = asyncio.run(_get_token("member"))
+    owner_id = User.get(User.username == "owner").id
+    member_id = User.get(User.username == "member").id
+
+    # Each user calls model_info — both should bind successfully.
+    api_owner = HfApi(endpoint=live_server_url, token=owner_token)
+    api_member = HfApi(endpoint=live_server_url, token=member_token)
+    api_owner.model_info("owner/scenario-repo")
+    api_member.model_info("owner/scenario-repo")
+
+    from kohakuhub.api.fallback.cache import get_cache
+    cache = get_cache()
+
+    # Two independent cache buckets — strict-freshness contract.
+    owner_bound = cache.get(owner_id, "", "model", "owner", "scenario-repo")
+    member_bound = cache.get(member_id, "", "model", "owner", "scenario-repo")
+    assert owner_bound is not None, "owner's cache bucket missing"
+    assert member_bound is not None, "member's cache bucket missing"
+    # Both bound to the same (priority-1) source, but in separate buckets.
+    assert owner_bound["source_url"] == member_bound["source_url"]
+
+    # Sanity: anonymous bucket is empty (we authenticated both calls).
+    assert cache.get(None, "", "model", "owner", "scenario-repo") is None
+
+
+def test_external_token_rotation_via_hf_hub_evicts_user_cache(
+    live_server_url, consistency_env, app,
+):
+    """A user posts a new external token; cache for that user is
+    evicted synchronously with the mutation. The hf_hub call after
+    the rotation re-probes (cache miss), end-to-end verifying the
+    POST /external-tokens → clear_user hook (#79).
+    """
+    import asyncio
+
+    import httpx
+    from kohakuhub.db import User
+
+    from test.kohakuhub.support.bootstrap import DEFAULT_PASSWORD
+
+    configure, _reset = consistency_env
+    configure("200_ok")
+
+    async def _login_and_token(username: str):
+        transport = httpx.ASGITransport(app=app)
+        ac = httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            follow_redirects=False,
+        )
+        login = await ac.post(
+            "/api/auth/login",
+            json={"username": username, "password": DEFAULT_PASSWORD},
+        )
+        login.raise_for_status()
+        tok = await ac.post(
+            "/api/auth/tokens/create",
+            json={"name": f"hf-api-compat-{username}"},
+        )
+        tok.raise_for_status()
+        return ac, tok.json()["token"]
+
+    async def _post_token_and_close(ac):
+        try:
+            response = await ac.post(
+                "/api/users/owner/external-tokens",
+                json={
+                    "url": "https://hf-rotation-test.example",
+                    "token": "hf_rotation_value",
+                },
+            )
+            response.raise_for_status()
+        finally:
+            await ac.aclose()
+
+    ac_owner, token = asyncio.run(_login_and_token("owner"))
+    owner_id = User.get(User.username == "owner").id
+
+    # Bind: cache populated for owner.
+    api = HfApi(endpoint=live_server_url, token=token)
+    api.model_info("owner/scenario-repo")
+
+    from kohakuhub.api.fallback.cache import get_cache
+    cache = get_cache()
+    assert cache.get(owner_id, "", "model", "owner", "scenario-repo") is not None
+    initial_user_gen = cache.user_gens[owner_id]
+
+    # Rotate token → cache evicted.
+    asyncio.run(_post_token_and_close(ac_owner))
+
+    # The cache entry for owner with empty tokens_hash is gone.
+    assert cache.get(owner_id, "", "model", "owner", "scenario-repo") is None
+    assert cache.user_gens[owner_id] == initial_user_gen + 1

--- a/test/kohakuhub/api/fallback/test_strict_freshness.py
+++ b/test/kohakuhub/api/fallback/test_strict_freshness.py
@@ -1,0 +1,396 @@
+"""Strict-freshness contract end-to-end tests (#79).
+
+These tests assert the cache invalidation behaviour under the post-#79
+contract: per-user / per-tokens_hash isolation, generation-counter
+race protection, repo CRUD eviction, and external-token mutation
+eviction. The fallback chain probe itself is mocked through
+``DummyCache`` and ``FakeFallbackClient`` so the focus stays on the
+cache-orchestration semantics, not the upstream HTTP shape (those are
+covered in ``test_strict_consistency.py`` end-to-end against
+``scenario_hf_server``).
+
+The race tests exercise ``safe_set`` rejection by bumping the
+relevant generation counter between the probe-start snapshot and
+``cache.safe_set``. Each test pins exactly one of the three
+counters to verify the corresponding race class is closed.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Optional
+
+import httpx
+import pytest
+
+import kohakuhub.api.fallback.operations as fallback_ops
+from kohakuhub.api.fallback.cache import (
+    RepoSourceCache,
+    compute_tokens_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_response(status: int = 200, body: bytes = b"", headers=None):
+    return httpx.Response(
+        status_code=status,
+        content=body or b"",
+        headers=headers or {},
+        request=httpx.Request("GET", "http://upstream/x"),
+    )
+
+
+class _StubClient:
+    """Minimal FallbackClient stub returning a single response.
+
+    Records the (method, path) of each call so tests can assert the
+    chain reached or skipped a specific source.
+    """
+
+    def __init__(self, source_url: str, source_type: str, token: str | None = None):
+        self.source_url = source_url
+        self.source_type = source_type
+        self.token = token
+        self.timeout = 12
+
+    @classmethod
+    def reset(cls, registry: dict) -> None:
+        cls._registry = registry
+        cls.calls = []
+
+    def map_url(self, kohaku_path: str, repo_type: str) -> str:
+        return f"{self.source_url}{kohaku_path}"
+
+    async def head(self, kohaku_path: str, repo_type: str, **kwargs) -> httpx.Response:
+        type(self).calls.append((self.source_url, "HEAD", kohaku_path))
+        return type(self)._registry[(self.source_url, "HEAD")]
+
+    async def get(self, kohaku_path: str, repo_type: str, **kwargs) -> httpx.Response:
+        type(self).calls.append((self.source_url, "GET", kohaku_path))
+        return type(self)._registry[(self.source_url, "GET")]
+
+    async def post(self, kohaku_path: str, repo_type: str, **kwargs) -> httpx.Response:
+        type(self).calls.append((self.source_url, "POST", kohaku_path))
+        return type(self)._registry[(self.source_url, "POST")]
+
+
+def _wire_stub_client(monkeypatch, registry: dict) -> None:
+    _StubClient.reset(registry)
+    monkeypatch.setattr(fallback_ops, "FallbackClient", _StubClient)
+
+
+def _user(user_id: int):
+    return SimpleNamespace(id=user_id, username=f"user-{user_id}")
+
+
+# ---------------------------------------------------------------------------
+# Per-user / per-tokens_hash binding isolation through the live op layer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_user_binding_does_not_leak_across_users(monkeypatch):
+    """User A binds source X. User B's first call to the same repo
+    must NOT read user A's binding — it has its own (empty) bucket
+    and re-probes the chain."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+    _wire_stub_client(
+        monkeypatch,
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')},
+    )
+
+    # User A's first call binds.
+    result_a = await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(1)
+    )
+    assert result_a == {"id": "owner/demo", "_source": "X", "_source_url": "https://x.local"}
+    assert cache.get(1, "", "model", "owner", "demo") is not None
+    assert cache.get(2, "", "model", "owner", "demo") is None
+
+    # User B's first call must hit the chain (cache miss for user 2).
+    calls_before = list(_StubClient.calls)
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(2)
+    )
+    assert len(_StubClient.calls) == len(calls_before) + 1, (
+        "user 2 must re-probe — separate cache bucket from user 1"
+    )
+    assert cache.get(2, "", "model", "owner", "demo") is not None
+
+
+@pytest.mark.asyncio
+async def test_anonymous_and_authed_buckets_isolated(monkeypatch):
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+    _wire_stub_client(
+        monkeypatch,
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')},
+    )
+
+    # Anonymous request binds.
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=None
+    )
+    assert cache.get(None, "", "model", "owner", "demo") is not None
+
+    # Authed request: independent bucket; needs to probe.
+    calls_before = list(_StubClient.calls)
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(99)
+    )
+    assert len(_StubClient.calls) == len(calls_before) + 1
+
+
+@pytest.mark.asyncio
+async def test_header_token_change_isolates_bucket(monkeypatch):
+    """Same user, different external tokens (e.g. swapping HF tokens
+    via Authorization header) → different tokens_hash → separate
+    cache buckets."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+    _wire_stub_client(
+        monkeypatch,
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')},
+    )
+
+    user = _user(42)
+    tokens_a = {"https://huggingface.co": "hf_AAAA"}
+    tokens_b = {"https://huggingface.co": "hf_BBBB"}
+
+    # First call with tokens_a binds.
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=tokens_a, user=user
+    )
+    h_a = compute_tokens_hash(tokens_a)
+    h_b = compute_tokens_hash(tokens_b)
+    assert h_a != h_b
+    assert cache.get(42, h_a, "model", "owner", "demo") is not None
+
+    # Second call with tokens_b: same user_id, different hash → miss.
+    calls_before = list(_StubClient.calls)
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=tokens_b, user=user
+    )
+    assert len(_StubClient.calls) == len(calls_before) + 1
+    assert cache.get(42, h_b, "model", "owner", "demo") is not None
+    # tokens_a bucket still bound — was not evicted.
+    assert cache.get(42, h_a, "model", "owner", "demo") is not None
+
+
+# ---------------------------------------------------------------------------
+# Race protection: safe_set rejects when generations change mid-probe.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_source_mutation_during_probe_rejects_cache_set(monkeypatch):
+    """Admin clears the cache (bumping global_gen) while a probe is
+    in flight. The probe completes, but its safe_set is rejected
+    so the next call re-probes with the post-mutation config."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+
+    # Wrap _StubClient.get so it bumps global_gen (admin mutation
+    # landing) before returning. This simulates admin-clear during
+    # the probe's HTTP I/O.
+    class _RacingClient(_StubClient):
+        async def get(self, kohaku_path, repo_type, **kwargs):
+            cache.clear()  # admin mutation lands mid-probe
+            return await super().get(kohaku_path, repo_type, **kwargs)
+
+    _RacingClient.reset(
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')}
+    )
+    monkeypatch.setattr(fallback_ops, "FallbackClient", _RacingClient)
+
+    result = await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(1)
+    )
+    # Response came back successfully — caller is unaffected.
+    assert result is not None
+    # But the cache is empty: safe_set was rejected because
+    # global_gen bumped between snapshot and write.
+    assert cache.get(1, "", "model", "owner", "demo") is None
+
+
+@pytest.mark.asyncio
+async def test_user_token_mutation_during_probe_rejects_cache_set(monkeypatch):
+    """User rotates their per-source token (bumping user_gens[uid])
+    mid-probe. safe_set rejects."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+
+    class _RacingClient(_StubClient):
+        async def get(self, kohaku_path, repo_type, **kwargs):
+            cache.clear_user(1)  # user 1 rotates token mid-probe
+            return await super().get(kohaku_path, repo_type, **kwargs)
+
+    _RacingClient.reset(
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')}
+    )
+    monkeypatch.setattr(fallback_ops, "FallbackClient", _RacingClient)
+
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(1)
+    )
+    # User 1's bucket: empty (safe_set rejected).
+    assert cache.get(1, "", "model", "owner", "demo") is None
+    # The bump didn't affect user 2 — safe_set for user 2 would still succeed.
+    assert cache.user_gens[2] == 0
+
+
+@pytest.mark.asyncio
+async def test_repo_crud_during_probe_rejects_cache_set(monkeypatch):
+    """Local repo create/delete (bumping repo_gens) lands mid-probe.
+    safe_set rejects, breaking the ghost-binding revival path."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+
+    class _RacingClient(_StubClient):
+        async def get(self, kohaku_path, repo_type, **kwargs):
+            # Local repo CRUD lands mid-probe.
+            cache.invalidate_repo("model", "owner", "demo")
+            return await super().get(kohaku_path, repo_type, **kwargs)
+
+    _RacingClient.reset(
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')}
+    )
+    monkeypatch.setattr(fallback_ops, "FallbackClient", _RacingClient)
+
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(1)
+    )
+    # No revival: cache stays empty for owner/demo.
+    assert cache.get(1, "", "model", "owner", "demo") is None
+    # repo_gen for OTHER repos untouched, so safe_set for them still works.
+    assert cache.repo_gens[("model", "owner", "other")] == 0
+
+
+# ---------------------------------------------------------------------------
+# Ghost-revival defense: repo CRUD across cycles.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_repo_breaks_ghost_revival(monkeypatch):
+    """Pre-CRUD: repo absent locally, cached as fallback binding. Local
+    repo created (cache.invalidate_repo fires). Local repo deleted →
+    cache must re-probe instead of resurrecting the ghost binding."""
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+    _wire_stub_client(
+        monkeypatch,
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/ghost"}')},
+    )
+
+    user = _user(1)
+
+    # Phase 1: ghost binding written before local repo exists.
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "ghost", user_tokens=None, user=user
+    )
+    assert cache.get(1, "", "model", "owner", "ghost") is not None
+
+    # Phase 2: local create triggers invalidate_repo.
+    cache.invalidate_repo("model", "owner", "ghost")
+    assert cache.get(1, "", "model", "owner", "ghost") is None
+
+    # Phase 3: local delete (or any other event that triggers a
+    # subsequent fallback). Re-probe must run; the previous bucket
+    # is gone, so a fresh bind happens with current upstream state.
+    calls_before = list(_StubClient.calls)
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "ghost", user_tokens=None, user=user
+    )
+    assert len(_StubClient.calls) == len(calls_before) + 1
+
+
+# ---------------------------------------------------------------------------
+# clear_user actually clears the per-user bucket end-to-end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_user_evicts_only_target_user(monkeypatch):
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://x.local", "name": "X", "source_type": "huggingface"},
+        ],
+    )
+    _wire_stub_client(
+        monkeypatch,
+        {("https://x.local", "GET"): _content_response(200, b'{"id": "owner/demo"}')},
+    )
+
+    # Two users bind for the same repo.
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(1)
+    )
+    await fallback_ops.try_fallback_info(
+        "model", "owner", "demo", user_tokens=None, user=_user(2)
+    )
+    assert cache.get(1, "", "model", "owner", "demo") is not None
+    assert cache.get(2, "", "model", "owner", "demo") is not None
+
+    # User 1 rotates token → clear_user(1).
+    cache.clear_user(1)
+    assert cache.get(1, "", "model", "owner", "demo") is None
+    assert cache.get(2, "", "model", "owner", "demo") is not None

--- a/test/kohakuhub/api/fallback/test_strict_freshness.py
+++ b/test/kohakuhub/api/fallback/test_strict_freshness.py
@@ -276,7 +276,7 @@ async def test_user_token_mutation_during_probe_rejects_cache_set(monkeypatch):
     # User 1's bucket: empty (safe_set rejected).
     assert cache.get(1, "", "model", "owner", "demo") is None
     # The bump didn't affect user 2 — safe_set for user 2 would still succeed.
-    assert cache.user_gens[2] == 0
+    assert cache.user_gens.get(2, 0) == 0
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_repo_crud_during_probe_rejects_cache_set(monkeypatch):
     # No revival: cache stays empty for owner/demo.
     assert cache.get(1, "", "model", "owner", "demo") is None
     # repo_gen for OTHER repos untouched, so safe_set for them still works.
-    assert cache.repo_gens[("model", "owner", "other")] == 0
+    assert cache.repo_gens.get(("model", "owner", "other"), 0) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the strict-freshness cache contract from #79 on top of the
PR #77 repo-grain binding work. Closes the three race classes that
could otherwise let a probe in flight pin a stale binding after an
invalidation event:

- **Admin source mutation race** — admin clears the source list while
  a probe is running.
- **User token rotation race** — a user posts/deletes their per-source
  external token while a probe is running.
- **Repo CRUD race** — a local repo is created/deleted/moved/visibility-toggled
  while a probe is running.

Branch base: `feat/fallback-repo-binding` (PR #77 head).

## What changes

### Cache shape

```
fallback:repo:u={user_id|anon}:t={tokens_hash|}:{repo_type}:{ns}/{name}
```

`tokens_hash = sha256(canonical_json(sorted(merged_tokens.items())))[:16]`,
empty when no per-user tokens are present. This isolates two requests
authenticated as the same user that pass different external tokens via
`Authorization: Bearer ...|url,token|...`.

### Three monotonic generation counters

| Counter | Bumped by |
|---|---|
| `global_gen` | `cache.clear()` (admin source mutations) |
| `user_gens[user_id]` | `cache.clear_user(user_id)` (user external-token mutations) |
| `repo_gens[(rt, ns, name)]` | `cache.invalidate_repo(rt, ns, name)` (local repo CRUD, admin per-repo eviction) |

`_run_cached_then_chain` snapshots all three before doing upstream I/O
and passes the snapshot to `safe_set`; `safe_set` rejects the cache
write if any has been bumped during the probe window.

### Invalidation matrix

| Event | Hook location | Cache op |
|---|---|---|
| Admin POST/PATCH/DELETE on `FallbackSource` | `api/admin/routers/fallback.py` | `cache.clear()` |
| User POST `/api/users/{u}/external-tokens` | `api/auth/external_tokens.py` | `cache.clear_user(user.id)` |
| User DELETE `/api/users/{u}/external-tokens/{url}` | same | `cache.clear_user(user.id)` |
| User PUT `/api/users/{u}/external-tokens/bulk` | same | `cache.clear_user(user.id)` |
| Local POST `/api/repos/create` | `api/repo/routers/crud.py` | `cache.invalidate_repo(rt, ns, name)` |
| Local DELETE `/api/repos/delete` | same | `cache.invalidate_repo(rt, ns, name)` |
| Local POST `/api/repos/move` | same | `cache.invalidate_repo(old)` + `cache.invalidate_repo(new)` |
| Local PUT settings, `private` field changed | `api/settings.py` | `cache.invalidate_repo(rt, ns, name)` |
| Local POST `/api/repos/squash` | n/a — `full_id` unchanged | n/a |
| Header-token change | per-request | n/a — encoded in cache key via `tokens_hash` |

### New admin endpoints

- `DELETE /admin/api/fallback-sources/cache/repo/{rt}/{ns}/{name}` — evict every (user, tokens_hash, repo) bucket for one repo
- `DELETE /admin/api/fallback-sources/cache/user/{user_id}` — evict every (tokens_hash, repo) bucket for one user

## Files touched

- `src/kohakuhub/api/fallback/cache.py` — new key shape, `compute_tokens_hash`, three gens, `snapshot`, `safe_set`, `invalidate_repo`, `clear_user`, `reset_cache_for_tests`
- `src/kohakuhub/api/fallback/operations.py` — thread `user` + `tokens_hash`; gens snapshot + `safe_set` in all four `try_fallback_*` plus `_run_cached_then_chain` orphan handling
- `src/kohakuhub/api/fallback/decorators.py` — pass `user` to all four op variants
- `src/kohakuhub/api/auth/external_tokens.py` — `cache.clear_user` on POST/DELETE/PUT bulk
- `src/kohakuhub/api/repo/routers/crud.py` — `cache.invalidate_repo` on /create, /delete, /move (both ids)
- `src/kohakuhub/api/settings.py` — `cache.invalidate_repo` when `private` flips
- `src/kohakuhub/api/admin/routers/fallback.py` — fixes missing `cache.clear()` on source CREATE; adds two new eviction endpoints
- `src/kohakuhub/api/fallback/README.md` — full strict-freshness contract section, generation counters, invalidation matrix, new admin endpoints
- `CHANGELOG.md` — `[Unreleased]` entries

## Tests

| File | Coverage |
|---|---|
| `test/kohakuhub/api/fallback/test_cache.py` | 35 tests — hash invariance, per-user/per-tokens isolation, eviction scope, gens, safe_set acceptance + rejection on each of three dimensions, TTL, key-shape pinning. **Drives `cache.py` to 100%.** |
| `test/kohakuhub/api/fallback/test_strict_freshness.py` | 8 new tests — per-user binding isolation, anonymous-vs-authed split, header-token isolation, three race classes (admin / user / repo CRUD), ghost-revival defense, `clear_user` end-to-end through the live op layer. |
| `test/kohakuhub/api/fallback/test_cache_invalidation_hooks.py` | 15 new tests — one per documented event in the invalidation matrix, plus exception-handler coverage on the new admin endpoints. |
| `test/kohakuhub/api/fallback/test_strict_consistency.py` | +2 hf_hub-based tests — two distinct authenticated users get independent cache buckets via `huggingface_hub`; external-token rotation evicts the user's cache and forces a re-probe. |

Coverage on the changed code paths:

- `src/kohakuhub/api/fallback/cache.py` — **100%**
- `src/kohakuhub/api/fallback/operations.py` — **100%** (matches PR #77's bar)
- `src/kohakuhub/api/admin/routers/fallback.py` — 84.34% (new endpoints fully covered including 500 paths; remaining gaps are pre-existing CRUD endpoint exception handlers I didn't touch)

`347 passed in 102.67s` across all changed-area tests.

## Test plan

- [x] `python -m pytest test/kohakuhub/api/fallback/` — all green
- [x] `python -m pytest test/kohakuhub/api/admin/routers/test_fallback.py` — green
- [x] `python -m pytest test/kohakuhub/api/auth/test_external_tokens*.py` — green
- [x] `python -m pytest test/kohakuhub/api/repo/routers/test_crud*.py` — green
- [x] Coverage check on the four touched modules
- [ ] CI matrix (Python 3.10/3.11/3.12 × hf_hub versions) — pending on this PR

## Notes for reviewers

- Multi-worker shared cache (admin clear in one fork visible to siblings) is **explicitly out of scope** — left as a separate follow-up. Today's behaviour is single-process in-memory; in fork-mode deployments each worker carries its own cache and TTL handles drift.
- User logout / account deletion → cache eviction is also out of scope. TTL bounds exposure; user_id non-reuse means orphan buckets won't be hit by future requests.
- Visibility toggle is treated as a defensive `invalidate_repo` here. Fixing the underlying contract gap (private repos passing through `with_repo_fallback` to upstream and potentially exposing same-name repos there) is its own issue, not bundled.

Closes #79
Refs: #77, #78
