### PR TITLE
fix(fallback): relax binding lock — release before cache-hit I/O + asyncio.wait_for supervisor (#85)

### DIFF
--- a/src/kohakuhub/api/fallback/decorators.py
+++ b/src/kohakuhub/api/fallback/decorators.py
@@ -417,6 +417,11 @@ def with_repo_fallback(operation: OperationType):
                         # Detect HTTP method from request
                         request = kwargs.get("request")
                         method = request.method if request else "GET"
+                        # Plan A: forward client request headers so
+                        # Range / If-* survive end-to-end. The actual
+                        # whitelist is enforced inside
+                        # ``try_fallback_resolve`` (defense in depth) —
+                        # passing raw ``request.headers`` is safe.
                         result = await try_fallback_resolve(
                             repo_type,
                             namespace,
@@ -426,6 +431,9 @@ def with_repo_fallback(operation: OperationType):
                             user_tokens=user_tokens,
                             method=method,
                             user=user,
+                            client_headers=(
+                                request.headers if request is not None else None
+                            ),
                         )
 
                     case "tree":

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -155,7 +155,13 @@ def _propagate_upstream_redirect(
     # Presigned redirects expire — never let an intermediary cache a
     # response whose target URL has a baked-in deadline.
     headers["cache-control"] = "no-store"
-    strip_xet_response_headers(headers)
+    # NOTE: the explicit four-key whitelist above (etag / x-repo-commit
+    # / x-linked-etag / x-linked-size) plus location / cache-control is
+    # the actual Xet-leak defense — none of those keys can collide with
+    # ``x-xet-*``, so a defensive ``strip_xet_response_headers`` here
+    # would be a guaranteed no-op. The contract is enforced by the
+    # whitelist; ``test_try_fallback_resolve_get_redirect_drops_xet_headers_from_upstream``
+    # locks it at the response surface.
     headers.update(add_source_headers(response, source["name"], source["url"]))
     return Response(
         status_code=response.status_code,
@@ -647,6 +653,22 @@ async def _resolve_one_source(
     )
 
     if method == "HEAD":
+        # Asymmetry-by-design vs. the GET path below: HEAD does NOT
+        # forward ``client_headers`` upstream. Two reasons —
+        #   1) ``huggingface_hub`` HEAD-on-resolve never carries Range;
+        #      partial-content semantics are a GET-only concern.
+        #   2) ``apply_resolve_head_postprocess`` fires its own
+        #      follow-HEAD with ``Accept-Encoding: identity`` to keep
+        #      Content-Length intact (PR #21 — gzip auto-decompression
+        #      in httpx silently strips Content-Length and breaks
+        #      hf_hub's post-download size check). Forwarding a
+        #      client-supplied ``Accept-Encoding: gzip`` upstream
+        #      would re-engage that bug.
+        # If you need ``If-None-Match`` 304 short-circuit on HEAD,
+        # plumb a NARROWER whitelist into the binding HEAD probe ONLY
+        # — never into the follow-HEAD inside the postprocess.
+        # ``test_try_fallback_resolve_head_does_not_forward_client_headers``
+        # is the regression-guard.
         return await _build_resolve_head_response(response, source, client)
 
     # GET phase. Once HEAD has bound this source we are committed:

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -133,11 +133,32 @@ async def _run_cached_then_chain(
        #77 fixes. The client can retry; retries within TTL hit the
        same source.
 
-    2. **Concurrent-binding lock.** When the cache misses and the
-       chain probe is needed, concurrent callers serialize on a
-       per-repo ``asyncio.Lock``. The first holder writes the cache;
-       subsequent holders re-check the cache after acquiring the lock
-       and use the now-bound source.
+    2. **Concurrent-binding lock — narrow critical section.** When
+       the cache misses and the chain probe is needed, concurrent
+       callers serialize on a per-repo ``asyncio.Lock``. The first
+       holder walks the chain and writes the cache; subsequent
+       holders re-check the cache after acquiring the lock and, if
+       they find a binding, **return the decision and call
+       ``attempt_fn`` AFTER releasing the lock** — so post-recheck
+       waiters fan out in parallel rather than serializing their
+       bound-source calls through the lock (issue #85).
+
+       The lock's only job is the first-bind race. Once the cache is
+       populated, the lock is released and never blocks I/O. The
+       post-lock recheck is pure decision: read cache, return tuple.
+
+    2a. **Lock supervisor (issue #85, option (c)).** The locked
+       region is wrapped in
+       ``asyncio.wait_for(timeout=fallback.timeout_seconds * (len(sources)+1))``
+       so a wedged ``attempt_fn`` (e.g. an httpx call that ignores
+       its own timeout under a misbehaving proxy) cannot hold the
+       lock forever. Cancellation propagates through ``async with
+       binding_lock:`` which guarantees the lock is released. On
+       supervisor timeout the caller receives a chain-exhausted
+       aggregate response; subsequent same-repo callers see a clean
+       lock and retry. Strict consistency is a *safety* invariant
+       conditional on stable upstream behaviour — it does not
+       require unbounded blocking under wedge.
 
     3. **Orphaned-cache invalidation only.** The single case that
        *does* invalidate the cache is when the cached source URL is
@@ -205,54 +226,125 @@ async def _run_cached_then_chain(
                 user_id, tokens_hash, repo_type, namespace, name
             )
 
-    # Strict-consistency rule #2: concurrent-binding lock.
+    # Strict-consistency rule #2 + 2a: concurrent-binding lock with
+    # narrow critical section + supervisor (issue #85).
     binding_lock = _binding_lock(repo_type, namespace, name)
-    async with binding_lock:
-        # Re-snapshot under the lock so the chain probe + safe_set
-        # see a fresh baseline (generations may have changed while
-        # we were waiting on the lock).
-        gens = cache.snapshot(user_id, repo_type, namespace, name)
-        # Re-check the cache after lock acquisition: another waiter may
-        # have already bound this repo while we were queued.
-        cached_entry = cache.get(
-            user_id, tokens_hash, repo_type, namespace, name
-        )
-        if cached_entry and cached_entry.get("exists"):
-            cached_url = cached_entry["source_url"]
-            cached_source = next(
-                (s for s in sources if s["url"] == cached_url), None
-            )
-            if cached_source:
-                result = await attempt_fn(cached_source, gens)
-                if result is not None:
-                    return result
-                return build_aggregate_failure_response(
-                    attempts, scope=aggregate_scope
-                )
-            # Concurrent waiter bound to a source we don't have in
-            # config — extremely rare (admin reconfig race between
-            # the binder's ``cache.set`` and the waiter's post-lock
-            # cache-recheck); treat as orphan and proceed to a
-            # fresh chain.
-            cache.invalidate(  # pragma: no cover
+
+    # Supervisor budget: per-source timeout × (chain length + 1)
+    # gives the binder enough room to walk every source at full
+    # httpx timeout, plus one slot of buffer for scheduling and
+    # cache I/O. The caller-visible worst case under wedge is one
+    # chain timeout — not unbounded — and the lock is released by
+    # cancellation either way so subsequent same-repo callers
+    # always see a clean lock.
+    supervisor_timeout = cfg.fallback.timeout_seconds * (len(sources) + 1)
+
+    async def _decide_under_lock():
+        """Run inside the binding lock. Returns one of:
+
+        - ``("cache_hit", source, gens)`` — a concurrent waiter
+          bound the repo while we queued. The outer caller invokes
+          ``attempt_fn`` against ``source`` AFTER releasing the
+          lock so post-recheck waiters fan out in parallel rather
+          than serializing through the lock (issue #85's primary
+          fix).
+        - ``("bound", result, None)`` — we are the first binder;
+          we walked the chain under the lock and produced a
+          successful result. ``safe_set`` (inside ``attempt_fn``)
+          has populated the cache so subsequent same-repo waiters
+          will hit the post-recheck branch.
+        - ``("exhausted", None, None)`` — chain walked under lock,
+          no source bound. Outer caller surfaces aggregate failure.
+
+        I/O happens inside this coroutine ONLY on the chain-walk
+        path (first-bind serialization is the lock's actual job).
+        Post-recheck cache hit is pure-decision: read cache,
+        return tuple, exit.
+        """
+        async with binding_lock:
+            # Re-snapshot under the lock so the chain probe + safe_set
+            # see a fresh baseline (generations may have changed while
+            # we were waiting on the lock).
+            gens_inner = cache.snapshot(user_id, repo_type, namespace, name)
+            # Re-check the cache after lock acquisition: another waiter
+            # may have already bound this repo while we were queued.
+            cached_entry_inner = cache.get(
                 user_id, tokens_hash, repo_type, namespace, name
             )
+            if cached_entry_inner and cached_entry_inner.get("exists"):
+                cached_url_inner = cached_entry_inner["source_url"]
+                cached_source_inner = next(
+                    (s for s in sources if s["url"] == cached_url_inner),
+                    None,
+                )
+                if cached_source_inner:
+                    # Pure decision — DO NOT call attempt_fn here.
+                    return ("cache_hit", cached_source_inner, gens_inner)
+                # Concurrent waiter bound to a source we don't have
+                # in config — extremely rare (admin reconfig race
+                # between the binder's ``cache.set`` and the
+                # waiter's post-lock cache-recheck); treat as orphan
+                # and proceed to a fresh chain.
+                cache.invalidate(  # pragma: no cover
+                    user_id, tokens_hash, repo_type, namespace, name
+                )
 
-        # Fresh chain probe: deterministic priority order, first
-        # BIND wins.
-        for source in sources:
-            result = await attempt_fn(source, gens)
-            if result is not None:
-                return result
+            # Fresh chain probe: deterministic priority order, first
+            # BIND wins. I/O is under the lock here because
+            # first-bind serialization is the lock's actual job —
+            # without it, two concurrent first-binders could pick
+            # different sources from the chain (the cross-source
+            # mixing #75/#77 prevent).
+            for source in sources:
+                result = await attempt_fn(source, gens_inner)
+                if result is not None:
+                    return ("bound", result, None)
 
-        if not attempts:  # pragma: no cover
-            # Defensive: caller already filtered out empty ``sources``.
-            return None
-        logger.debug(
-            f"Fallback MISS: aggregating {len(attempts)} source failure(s) "
-            f"for {repo_type}/{namespace}/{name}"
+            return ("exhausted", None, None)
+
+    try:
+        decision, payload, gens_used = await asyncio.wait_for(
+            _decide_under_lock(), timeout=supervisor_timeout
+        )
+    except asyncio.TimeoutError:
+        # Supervisor fired — locked region exceeded its budget.
+        # Cancellation propagated through ``async with binding_lock:``
+        # so the lock has been released and subsequent same-repo
+        # callers can proceed. Surface a chain-exhausted aggregate
+        # (typically empty attempts → 502 UpstreamFailure) to this
+        # caller.
+        logger.error(
+            f"Lock supervisor fired for {repo_type}/{namespace}/{name} "
+            f"after {supervisor_timeout}s — locked region took too "
+            f"long. Lock released by cancellation; surfacing "
+            f"aggregate failure to caller."
         )
         return build_aggregate_failure_response(attempts, scope=aggregate_scope)
+
+    if decision == "cache_hit":
+        # Bound source from concurrent waiter; call attempt_fn
+        # OUTSIDE the lock so all post-recheck waiters fan out in
+        # parallel. This is issue #85's primary liveness fix.
+        result = await attempt_fn(payload, gens_used)
+        if result is not None:
+            return result
+        # Strict-consistency rule #1: bound source's TRY_NEXT
+        # response surfaces as the caller-visible error WITHOUT
+        # invalidating. Within TTL the bound source stays bound.
+        return build_aggregate_failure_response(attempts, scope=aggregate_scope)
+
+    if decision == "bound":
+        return payload
+
+    # decision == "exhausted"
+    if not attempts:  # pragma: no cover
+        # Defensive: caller already filtered out empty ``sources``.
+        return None
+    logger.debug(
+        f"Fallback MISS: aggregating {len(attempts)} source failure(s) "
+        f"for {repo_type}/{namespace}/{name}"
+    )
+    return build_aggregate_failure_response(attempts, scope=aggregate_scope)
 
 
 async def try_fallback_resolve(

--- a/src/kohakuhub/api/fallback/operations.py
+++ b/src/kohakuhub/api/fallback/operations.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 from collections import defaultdict
 from typing import Optional
+from urllib.parse import urljoin
 
 import httpx
 from fastapi.responses import JSONResponse, RedirectResponse, Response
@@ -33,6 +34,48 @@ def _resolve_user_id(user) -> Optional[int]:
     if user is None:
         return None
     return getattr(user, "id", None)
+
+
+# Plan A: only these client request headers are forwarded upstream on
+# resolve probes. Authorization / Cookie / Proxy-Authorization are
+# deliberately excluded — the only credential allowed upstream is the
+# admin-configured source token attached by ``FallbackClient`` itself.
+# Accept-Encoding is excluded because httpx auto-decompresses responses,
+# which would corrupt the redirect-passthrough contract.
+_FORWARDABLE_RESOLVE_HEADERS: tuple[str, ...] = (
+    "range",
+    "if-match",
+    "if-none-match",
+    "if-modified-since",
+    "if-unmodified-since",
+    "if-range",
+)
+
+
+def _filter_client_headers(headers) -> dict[str, str]:
+    """Return a fresh dict containing only the whitelisted resolve headers.
+
+    Defense-in-depth filter: even if a caller forgets to pre-strip
+    Authorization / Cookie before invoking ``try_fallback_resolve``,
+    this guard catches it. Header name comparison is case-insensitive;
+    values are forwarded with canonical Title-Case names so logs read
+    naturally upstream-side.
+    """
+    if not headers:
+        return {}
+    if hasattr(headers, "items"):
+        items = headers.items()
+    else:
+        items = headers
+    out: dict[str, str] = {}
+    allowed = set(_FORWARDABLE_RESOLVE_HEADERS)
+    for k, v in items:
+        if not k or v is None:
+            continue
+        lower = k.lower()
+        if lower in allowed:
+            out[lower.title()] = v
+    return out
 
 
 def _propagate_upstream_response(
@@ -67,6 +110,59 @@ def _propagate_upstream_response(
         content=response.content,
         headers=headers,
     )
+
+
+def _propagate_upstream_redirect(
+    response: httpx.Response, source: dict
+) -> Response:
+    """Forward an upstream resolve-GET 30x to the client without buffering.
+
+    Plan A: bytes never traverse the backend on the resolve GET path.
+    ``client.get`` is invoked with ``follow_redirects=False``, so when the
+    upstream resolves to a CDN / presigned URL via 301/302/303/307/308
+    we hand that ``Location`` back to the client and the actual byte
+    transfer is client→CDN, mirroring the local ``resolve_file_get``
+    presigned-S3 redirect flow.
+
+    Relative ``Location`` (e.g. HF's ``/api/resolve-cache/...`` 307) is
+    rewritten to absolute against the upstream request URL — same fix
+    the HEAD postprocess applies — so the client follows it back to the
+    upstream, NOT back to KohakuHub which doesn't serve that path.
+    """
+    headers: dict[str, str] = {}
+    location = response.headers.get("location")
+    if not location:
+        # Malformed 30x without Location — fall back to verbatim
+        # propagation so the caller still sees the upstream status.
+        return _propagate_upstream_response(response, source)
+    # Rewrite relative Location to absolute against the upstream URL.
+    # urljoin is a no-op when ``location`` is already absolute (the LFS
+    # ``cas-bridge.xethub.hf.co`` case), so this is safe for both
+    # patterns. Without this, hf_hub would walk the relative path back
+    # to its own ``endpoint`` (= our backend) and 404 because we don't
+    # serve /api/resolve-cache/.
+    upstream_url = str(response.request.url)
+    absolute_location = urljoin(upstream_url, location)
+    # Preserve the metadata huggingface_hub clients read off the redirect
+    # response (these are the same headers the HEAD-postprocess path
+    # surfaces; keeping GET symmetric ensures clients see consistent
+    # ETag / size info regardless of which method they used).
+    for h in ("etag", "x-repo-commit", "x-linked-etag", "x-linked-size"):
+        v = response.headers.get(h)
+        if v:
+            headers[h] = v
+    headers["location"] = absolute_location
+    # Presigned redirects expire — never let an intermediary cache a
+    # response whose target URL has a baked-in deadline.
+    headers["cache-control"] = "no-store"
+    strip_xet_response_headers(headers)
+    headers.update(add_source_headers(response, source["name"], source["url"]))
+    return Response(
+        status_code=response.status_code,
+        content=b"",
+        headers=headers,
+    )
+
 
 logger = get_logger("FALLBACK_OPS")
 
@@ -356,6 +452,7 @@ async def try_fallback_resolve(
     user_tokens: dict[str, str] | None = None,
     method: str = "GET",
     user=None,
+    client_headers: dict[str, str] | None = None,
 ) -> Optional[Response]:
     """Try to resolve file from fallback sources.
 
@@ -370,6 +467,12 @@ async def try_fallback_resolve(
         user: Authenticated user (or None for anonymous). Threaded
             through to the cache key as ``user_id`` for strict
             per-user binding isolation (#79).
+        client_headers: Client request headers to forward upstream.
+            Filtered through ``_filter_client_headers`` before any
+            outbound use, so callers may safely pass the raw
+            ``request.headers`` mapping — only Range / If-* survive
+            (Authorization / Cookie / Proxy-Authorization /
+            Accept-Encoding are dropped here).
 
     Returns:
         Response (redirect for GET, response with headers for HEAD) or None if not found
@@ -383,6 +486,10 @@ async def try_fallback_resolve(
 
     user_id = _resolve_user_id(user)
     tokens_hash = compute_tokens_hash(user_tokens)
+
+    # Defense-in-depth: drop everything that isn't on the resolve
+    # whitelist before it gets anywhere near the upstream chain.
+    safe_client_headers = _filter_client_headers(client_headers)
 
     # Construct KohakuHub path
     kohaku_path = f"/{repo_type}s/{namespace}/{name}/resolve/{revision}/{path}"
@@ -407,6 +514,7 @@ async def try_fallback_resolve(
             attempts,
             cache,
             gens,
+            client_headers=safe_client_headers,
         )
 
     return await _run_cached_then_chain(
@@ -433,6 +541,8 @@ async def _resolve_one_source(
     attempts: list[dict],
     cache,
     gens: tuple[int, int, int],
+    *,
+    client_headers: dict[str, str] | None = None,
 ) -> Optional[Response]:
     """Run a resolve probe (HEAD, then GET if method=GET) against one source.
 
@@ -544,10 +654,25 @@ async def _resolve_one_source(
     # the user gets. Falling through to another source here is the
     # cross-source mixing bug #75 fixes (HEAD-200 at A, GET-502 at A,
     # then sneak over to B's same-named-but-different repo).
+    #
+    # Plan A invariants enforced here:
+    #   • ``follow_redirects=False`` — never let httpx chase an upstream
+    #     30x into a CDN body fetch. A 1.5 GB safetensors must not pass
+    #     through the backend; the redirect Location is what we hand
+    #     back to the client (mirrors local ``resolve_file_get`` 302).
+    #   • ``headers=client_headers`` — forward the caller's whitelisted
+    #     Range / If-* headers so partial-content semantics survive.
+    #     The whitelist (Range, If-Match, If-None-Match,
+    #     If-Modified-Since, If-Unmodified-Since, If-Range) is built by
+    #     the ``with_repo_fallback`` decorator; Authorization / Cookie
+    #     are filtered there and never reach this call.
     get_t0 = time.monotonic()
     try:
         get_response = await client.get(
-            kohaku_path, repo_type, follow_redirects=True
+            kohaku_path,
+            repo_type,
+            follow_redirects=False,
+            headers=client_headers or None,
         )
     except httpx.TimeoutException as e:
         get_dt_ms = int((time.monotonic() - get_t0) * 1000)
@@ -594,6 +719,18 @@ async def _resolve_one_source(
         decision=classify_upstream(get_response),
         duration_ms=get_dt_ms,
     )
+
+    # Plan A primary path: 30x → forward Location to the client; the
+    # CDN/presigned target is the byte source, not this backend.
+    if (
+        300 <= get_response.status_code < 400
+        and get_response.headers.get("location")
+    ):
+        logger.info(
+            f"GET {get_response.status_code} → redirect-passthrough at "
+            f"{source['name']} (Location forwarded to client; no body buffer)"
+        )
+        return _propagate_upstream_redirect(get_response, source)
 
     if get_response.status_code == 200:
         # Proxy the content with original headers, stripping the

--- a/test/kohakuhub/api/fallback/test_decorators.py
+++ b/test/kohakuhub/api/fallback/test_decorators.py
@@ -141,16 +141,16 @@ async def test_with_repo_fallback_uses_resolve_operation_after_http_404(monkeypa
     hops = _decode_trace_header(result)
     assert any(h.get("decision") == "LOCAL_MISS" for h in hops)
     assert merged_inputs == [("owner-user", {"https://hf.local": "header-token"})]
-    assert resolve_calls == [
-        (
-            ("dataset", "owner", "demo", "main", "config.json"),
-            {
-                "user_tokens": {"https://hf.local": "token"},
-                "method": "HEAD",
-                "user": "owner-user",
-            },
-        )
-    ]
+    assert len(resolve_calls) == 1
+    args, kwargs = resolve_calls[0]
+    assert args == ("dataset", "owner", "demo", "main", "config.json")
+    assert kwargs["user_tokens"] == {"https://hf.local": "token"}
+    assert kwargs["method"] == "HEAD"
+    assert kwargs["user"] == "owner-user"
+    # Plan A: the decorator now also threads client_headers (raw
+    # request.headers) through; ``try_fallback_resolve`` is responsible
+    # for whitelisting Range/If-* and dropping everything else.
+    assert "client_headers" in kwargs
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -2991,3 +2991,250 @@ async def test_lock_supervisor_releases_lock_when_attempt_fn_wedges(monkeypatch)
             f"response: {r!r}. The supervisor should surface a clean "
             f"aggregate failure, not propagate the cancellation."
         )
+
+
+# ---------------------------------------------------------------------------
+# Plan A: resolve GET as redirect-passthrough.
+#
+# Background: before this change, ``_resolve_one_source`` GET path issued
+# ``client.get(..., follow_redirects=True)`` and proxied the upstream body
+# through ``response.content`` — meaning a 1.5 GB safetensors download was
+# fully buffered into backend RAM before any byte reached the client, AND
+# the client's ``Range`` / ``If-*`` headers were silently dropped because
+# the call site forwarded no headers. Two failure modes:
+#
+#   (1) OOM / DoS — n concurrent large-file fetches × full file size
+#   (2) ~20 s 502 — supervisor ``wait_for`` cancels the runaway download
+#       (because the per-source httpx ``read`` timeout is an idle timeout,
+#       not a total-time timeout, so it never trips while the proxy keeps
+#       trickling bytes)
+#
+# Plan A: never proxy bytes for GET. ``follow_redirects=False`` upstream;
+# if upstream replies with 30x → forward ``Location`` to the client (same
+# shape as the local presigned-URL redirect in ``api/files.py``); if
+# upstream replies 200 inline (small files like ``config.json``) the
+# existing ``.content`` path is kept.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_redirect_passthrough(monkeypatch):
+    """Bound source GET → 302 to a CDN: forward the redirect to the client
+    verbatim, do not chase ``Location`` from inside httpx, do not buffer
+    any redirect-target body."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    cdn_location = "https://cas-bridge.xethub.hf.co/object?sig=xyz"
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(
+            302,
+            headers={
+                "location": cdn_location,
+                "etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+                "x-linked-size": "1519984962",
+            },
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="GET",
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == cdn_location
+    assert response.headers["X-Source"] == "HF"
+    # Metadata HF clients read off the redirect must survive.
+    assert response.headers["x-repo-commit"] == "abc123"
+    assert response.headers["x-linked-size"] == "1519984962"
+    # ``follow_redirects=False`` was passed so httpx did not chase Location
+    # inside the client. No second GET against any source either.
+    get_calls = [c for c in FakeFallbackClient.calls if c[1] == "GET"]
+    assert len(get_calls) == 1, get_calls
+    assert get_calls[0][3].get("follow_redirects") is False
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_forwards_range_header(monkeypatch):
+    """Client's ``Range`` / ``If-*`` request headers must reach the upstream
+    so a partial-content client request stays partial. Before Plan A the
+    ``FallbackClient.get`` call site never passed any headers — Range was
+    silently dropped and HF returned the full body."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(302, headers={"location": "https://cdn/obj"}),
+    )
+
+    await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors",
+        method="GET",
+        client_headers={
+            "Range": "bytes=0-100000",
+            "If-None-Match": '"abc"',
+            # Not on the whitelist — must NOT propagate. Forwarding
+            # ``Accept-Encoding`` would also re-engage httpx's auto-decompression
+            # which is incompatible with redirect-passthrough.
+            "Accept-Encoding": "gzip",
+            "User-Agent": "kohakuhub/test",
+        },
+    )
+
+    get_calls = [c for c in FakeFallbackClient.calls if c[1] == "GET"]
+    assert len(get_calls) == 1
+    fwd = {k.lower(): v for k, v in (get_calls[0][3].get("headers") or {}).items()}
+    assert fwd.get("range") == "bytes=0-100000"
+    assert fwd.get("if-none-match") == '"abc"'
+    assert "accept-encoding" not in fwd
+    assert "user-agent" not in fwd
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_never_forwards_authorization_or_cookie(monkeypatch):
+    """Safety: client's ``Authorization`` / ``Cookie`` /
+    ``Proxy-Authorization`` MUST NEVER reach the upstream. The only
+    credential that may travel upstream is the admin-configured source
+    token, attached by ``FallbackClient`` itself."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(302, headers={"location": "https://cdn/obj"}),
+    )
+
+    await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors",
+        method="GET",
+        client_headers={
+            "Range": "bytes=0-100000",
+            "Authorization": "Bearer user-secret",
+            "Cookie": "session_id=secret-cookie",
+            "Proxy-Authorization": "Basic Zm9vOmJhcg==",
+        },
+    )
+
+    get_calls = [c for c in FakeFallbackClient.calls if c[1] == "GET"]
+    fwd = {k.lower(): v for k, v in (get_calls[0][3].get("headers") or {}).items()}
+    assert fwd.get("range") == "bytes=0-100000"
+    assert "authorization" not in fwd
+    assert "cookie" not in fwd
+    assert "proxy-authorization" not in fwd
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_redirect_rewrites_relative_location(monkeypatch):
+    """HF's non-LFS resolve-cache pattern returns a 307 with a *relative*
+    Location like ``/api/resolve-cache/...``. Plan A must rewrite that
+    to absolute against the upstream URL so the client follows the
+    redirect on the upstream itself — NOT back to KohakuHub which
+    does not serve ``/api/resolve-cache/``."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/pattern_a.txt"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(
+            307,
+            headers={
+                "location": "/api/resolve-cache/models/owner/demo/sha/pattern_a.txt",
+                "x-repo-commit": "abc123",
+            },
+            url="https://hf.local/owner/demo/resolve/main/pattern_a.txt",
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "pattern_a.txt", method="GET",
+    )
+
+    assert response.status_code == 307
+    # urljoin against the upstream URL gives us the upstream-absolute
+    # path; the client now follows on the upstream rather than bouncing
+    # the relative path back to our own backend.
+    assert (
+        response.headers["location"]
+        == "https://hf.local/api/resolve-cache/models/owner/demo/sha/pattern_a.txt"
+    )
+    assert response.headers["x-repo-commit"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_inline_200_still_returns_body(monkeypatch):
+    """Plan A only changes the redirect path. A small inline 200 (e.g.
+    ``config.json``) still passes the body through verbatim with the
+    historical ``Content-Encoding`` / ``Content-Length`` /
+    ``Transfer-Encoding`` strip applied."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/config.json"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(
+            200,
+            b'{"hello":"world"}',
+            headers={"content-type": "application/json"},
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "config.json", method="GET",
+    )
+
+    assert response.status_code == 200
+    assert response.body == b'{"hello":"world"}'
+    assert response.headers["X-Source"] == "HF"
+    # The GET upstream must still have been issued with redirect chasing
+    # disabled — the same ``follow_redirects=False`` invariant applies even
+    # when the response happens to be a direct 200.
+    get_calls = [c for c in FakeFallbackClient.calls if c[1] == "GET"]
+    assert get_calls[0][3].get("follow_redirects") is False

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -3238,3 +3238,141 @@ async def test_try_fallback_resolve_get_inline_200_still_returns_body(monkeypatc
     # when the response happens to be a direct 200.
     get_calls = [c for c in FakeFallbackClient.calls if c[1] == "GET"]
     assert get_calls[0][3].get("follow_redirects") is False
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_get_redirect_drops_xet_headers_from_upstream(monkeypatch):
+    """Plan A redirect-passthrough must NOT leak ``x-xet-*`` headers
+    upstream might attach. The output is built from an explicit
+    six-key whitelist (``etag`` / ``x-repo-commit`` / ``x-linked-etag``
+    / ``x-linked-size`` / ``location`` / ``cache-control``), so any
+    Xet-shaped key on the upstream response must not survive — even
+    if the (defensive) ``strip_xet_response_headers`` call is later
+    removed as redundant. This test locks the contract at the
+    response surface so that refactor stays safe."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue("https://hf.local", "HEAD", path, _content_response(200))
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "GET",
+        path,
+        _content_response(
+            302,
+            headers={
+                "location": "https://cas-bridge.xethub.hf.co/object?sig=xyz",
+                "etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+                "x-linked-size": "1519984962",
+                # Hostile / accidental upstream headers we must drop.
+                "x-xet-cas-url": "https://cas.xethub.hf.co",
+                "x-xet-hash": "shardhash",
+                "x-xet-cas-uid": "public",
+                "x-xet-something-future": "still-dropped",
+            },
+        ),
+    )
+
+    response = await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors", method="GET",
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://cas-bridge.xethub.hf.co/object?sig=xyz"
+    # Whitelist survivors.
+    assert response.headers["etag"] == '"deadbeef"'
+    assert response.headers["x-repo-commit"] == "abc123"
+    assert response.headers["x-linked-size"] == "1519984962"
+    # Xet hints must NOT be present — this enforces the contract at
+    # the OUTPUT regardless of how the curation logic is implemented.
+    lower_keys = {k.lower() for k in response.headers.keys()}
+    assert not any(k.startswith("x-xet-") for k in lower_keys), (
+        f"x-xet-* headers leaked into redirect response: "
+        f"{[k for k in lower_keys if k.startswith('x-xet-')]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_try_fallback_resolve_head_does_not_forward_client_headers(monkeypatch):
+    """HEAD path is intentionally asymmetric with GET on header
+    forwarding: ``client.head`` is invoked WITHOUT ``client_headers``.
+    Two reasons (kept here as the regression-guard for the next
+    refactor that's tempted to "make HEAD symmetric"):
+
+      1) ``huggingface_hub`` HEAD-on-resolve never carries Range — the
+         metadata probe is positional, partial-content semantics are a
+         GET-only concern.
+      2) ``apply_resolve_head_postprocess`` fires its own follow-HEAD
+         with ``Accept-Encoding: identity`` deliberately set so httpx
+         doesn't auto-decompress and silently strip Content-Length
+         (PR #21). Forwarding a client-supplied ``Accept-Encoding:
+         gzip`` upstream would re-engage that bug.
+
+    If a future PR wants ``If-None-Match`` 304 short-circuit on HEAD,
+    the right fix is a NARROWER whitelist forwarded to the binding
+    HEAD probe ONLY — never to the follow-HEAD inside
+    apply_resolve_head_postprocess. This test fails loudly if that
+    boundary is crossed (any client header reaches the binding
+    HEAD probe)."""
+    monkeypatch.setattr(fallback_ops, "get_cache", DummyCache)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {"url": "https://hf.local", "name": "HF", "source_type": "huggingface"},
+        ],
+    )
+    path = "/models/owner/demo/resolve/main/weights.safetensors"
+    FakeFallbackClient.queue(
+        "https://hf.local",
+        "HEAD",
+        path,
+        _content_response(
+            302,
+            headers={
+                "location": "https://cas-bridge.xethub.hf.co/object?sig=xyz",
+                "x-linked-size": "1519984962",
+                "x-linked-etag": '"deadbeef"',
+                "x-repo-commit": "abc123",
+            },
+        ),
+    )
+
+    await fallback_ops.try_fallback_resolve(
+        "model", "owner", "demo", "main", "weights.safetensors",
+        method="HEAD",
+        # Caller passes everything — Range, conditional, even
+        # Authorization (which the operations-layer filter normally
+        # drops anyway). The HEAD probe must receive none of it.
+        client_headers={
+            "Range": "bytes=0-100000",
+            "If-None-Match": '"abc"',
+            "Authorization": "Bearer secret",
+        },
+    )
+
+    head_calls = [c for c in FakeFallbackClient.calls if c[1] == "HEAD"]
+    assert len(head_calls) == 1
+    head_kwargs = head_calls[0][3]
+    # Two equivalent guards:
+    # (a) ``headers`` kwarg either absent or empty/None — the call
+    #     site does ``await client.head(kohaku_path, repo_type)`` with
+    #     no extra args.
+    fwd_headers = head_kwargs.get("headers") or {}
+    assert not fwd_headers, (
+        f"HEAD probe leaked client headers: {dict(fwd_headers)}. "
+        f"See PR #21 — Accept-Encoding propagation breaks Content-Length."
+    )
+    # (b) Specifically none of the whitelist or auth headers may
+    #     appear, even if a future implementation refactors how the
+    #     ``headers`` kwarg is shaped.
+    fwd_lower = {k.lower(): v for k, v in fwd_headers.items()}
+    for forbidden in ("range", "if-none-match", "authorization"):
+        assert forbidden not in fwd_lower

--- a/test/kohakuhub/api/fallback/test_operations.py
+++ b/test/kohakuhub/api/fallback/test_operations.py
@@ -2769,3 +2769,225 @@ async def test_paths_info_timeout_aggregates_to_502(monkeypatch):
     )
     assert result is not None
     assert result.status_code == 502
+
+
+# ===========================================================================
+# Issue #85 — binding-lock liveness regressions.
+#
+# These tests pin the two failure modes called out in #85:
+#
+#   1. ``test_post_recheck_cache_hit_releases_lock_before_attempt_fn`` —
+#      with the bug present, post-recheck waiters call ``attempt_fn``
+#      against the bound source while still holding the binding lock,
+#      so they fan out one-at-a-time. Peak concurrency for the bound-
+#      source's HTTP call is forced down to 1, which costs N×latency
+#      for N waiters. The fix shrinks the locked region to pure
+#      decision-making and runs ``attempt_fn`` outside the lock so the
+#      waiters' upstream calls run in parallel.
+#
+#   2. ``test_lock_supervisor_releases_lock_when_attempt_fn_wedges`` —
+#      with the bug present, an ``attempt_fn`` that hangs while
+#      holding the lock (e.g., httpx ignoring its timeout, an
+#      ``await`` that never resolves) blocks every same-repo caller
+#      forever. The fix wraps the locked region in
+#      ``asyncio.wait_for(timeout=...)`` so the lock is forcibly
+#      released after a bounded budget and queued waiters can proceed.
+#
+# Both tests were written first (RED) and watched to fail before the
+# implementation in ``operations.py`` was edited.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_post_recheck_cache_hit_releases_lock_before_attempt_fn(monkeypatch):
+    """Concurrent same-repo first-bind waiters must NOT serialize
+    their bound-source ``attempt_fn`` calls inside the binding lock.
+
+    Setup: one binder (caller 1) and three waiters (callers 2-4) race
+    on a fresh cache. Source A always TRY_NEXTs, source B binds. The
+    binder walks A then B, binds, releases. The three waiters then
+    each see the cache binding under the lock and need to call
+    ``attempt_fn(B)`` — but per the fixed contract, that call must
+    happen OUTSIDE the lock.
+
+    Assertion: peak in-flight HTTP calls to source B across all four
+    callers must be >= 2. With the locked-I/O bug the peak is 1
+    (waiters file in single-file behind the lock); after the fix the
+    waiters fan out and the peak is 3."""
+    import asyncio
+    fallback_ops._reset_binding_locks_for_tests()
+    from kohakuhub.api.fallback.cache import RepoSourceCache
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+
+    in_flight_b = 0
+    peak_in_flight_b = 0
+
+    class TrackingFakeFallbackClient(YieldingFakeFallbackClient):
+        async def _dispatch(self, method, path, **kwargs):
+            nonlocal in_flight_b, peak_in_flight_b
+            await asyncio.sleep(0)  # yield so waiters can interleave
+            if self.source_url == "https://b.local":
+                in_flight_b += 1
+                peak_in_flight_b = max(peak_in_flight_b, in_flight_b)
+                try:
+                    # Simulated upstream latency. With the bug, the
+                    # lock holds during this sleep, forcing serial
+                    # execution and capping peak_in_flight_b at 1.
+                    await asyncio.sleep(0.05)
+                    return await super(YieldingFakeFallbackClient, self)._dispatch(
+                        method, path, **kwargs
+                    )
+                finally:
+                    in_flight_b -= 1
+            return await super()._dispatch(method, path, **kwargs)
+
+    monkeypatch.setattr(fallback_ops, "FallbackClient", TrackingFakeFallbackClient)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: _two_sources(),
+    )
+
+    info_path = "/api/models/owner/concurrent"
+    FakeFallbackClient.queue(
+        "https://a.local",
+        "GET",
+        info_path,
+        _content_response(
+            404, b"", headers={"x-error-code": "RepoNotFound"}
+        ),
+    )
+    # Four 200 responses from B: one for the binder, three for the
+    # post-recheck waiters.
+    FakeFallbackClient.queue(
+        "https://b.local",
+        "GET",
+        info_path,
+        _json_response(200, {"id": "owner/concurrent"}),
+        _json_response(200, {"id": "owner/concurrent"}),
+        _json_response(200, {"id": "owner/concurrent"}),
+        _json_response(200, {"id": "owner/concurrent"}),
+    )
+
+    async def _one():
+        return await fallback_ops.try_fallback_info(
+            "model", "owner", "concurrent"
+        )
+
+    results = await asyncio.gather(_one(), _one(), _one(), _one())
+    for r in results:
+        assert isinstance(r, dict) and r["id"] == "owner/concurrent"
+
+    assert peak_in_flight_b >= 2, (
+        f"Post-recheck waiters serialized: peak in-flight to bound source "
+        f"B was {peak_in_flight_b} (expected >= 2). attempt_fn is being "
+        f"called while still holding the binding lock — that's the "
+        f"liveness bug from issue #85. Fix: release the lock before the "
+        f"bound-source attempt_fn."
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_supervisor_releases_lock_when_attempt_fn_wedges(monkeypatch):
+    """A wedged ``attempt_fn`` (one that ``await``s on something that
+    never fires) must not block subsequent same-repo callers
+    indefinitely. The locked region needs an ``asyncio.wait_for``
+    supervisor that bounds total lock-hold time.
+
+    Setup: one source whose ``_dispatch`` awaits an ``Event`` that
+    we never set. Two same-repo callers fire concurrently. The
+    binder enters the lock, calls dispatch, blocks. The waiter
+    queues at the lock.
+
+    Without the supervisor: both callers block forever — the test
+    times out at the outer ``asyncio.wait_for`` and the test fails.
+
+    With the supervisor: the binder's locked region times out after
+    ``cfg.fallback.timeout_seconds * (len(sources) + 1)`` seconds,
+    the lock is released by the cancellation, and the waiter (which
+    will hit the same wedge) also times out cleanly. Both callers
+    return chain-exhausted aggregates within bounded time."""
+    import asyncio
+    import time as _time
+    fallback_ops._reset_binding_locks_for_tests()
+    from kohakuhub.api.fallback.cache import RepoSourceCache
+    cache = RepoSourceCache(ttl_seconds=60)
+    monkeypatch.setattr(fallback_ops, "get_cache", lambda: cache)
+
+    wedge_event = asyncio.Event()  # never set — pure wedge
+
+    class WedgingFakeFallbackClient(FakeFallbackClient):
+        async def _dispatch(self, method, path, **kwargs):
+            await wedge_event.wait()
+            # Unreachable in practice — kept for defensive shape.
+            return await super()._dispatch(method, path, **kwargs)
+
+    # Use a tight timeout so the test itself runs in a few seconds.
+    monkeypatch.setattr(fallback_ops.cfg.fallback, "timeout_seconds", 1)
+    monkeypatch.setattr(fallback_ops, "FallbackClient", WedgingFakeFallbackClient)
+    monkeypatch.setattr(
+        fallback_ops,
+        "get_enabled_sources",
+        lambda namespace, user_tokens=None: [
+            {
+                "url": "https://a.local",
+                "name": "A",
+                "source_type": "huggingface",
+            }
+        ],
+    )
+
+    info_path = "/api/models/owner/wedge"
+    # Queue is irrelevant — _dispatch wedges before consuming it.
+    FakeFallbackClient.queue(
+        "https://a.local",
+        "GET",
+        info_path,
+        _json_response(200, {"id": "owner/wedge"}),
+    )
+
+    async def _one():
+        return await fallback_ops.try_fallback_info(
+            "model", "owner", "wedge"
+        )
+
+    t0 = _time.monotonic()
+    try:
+        # Outer guard: if the supervisor isn't there, this fires and
+        # the test fails with a clear message rather than hanging the
+        # whole pytest session.
+        results = await asyncio.wait_for(
+            asyncio.gather(_one(), _one(), return_exceptions=True),
+            timeout=15.0,
+        )
+    except asyncio.TimeoutError:
+        wedge_event.set()  # wake any pending waiters so the loop tears down
+        pytest.fail(
+            "Same-repo callers blocked indefinitely on a wedged binder. "
+            "The locked region in _run_cached_then_chain must be wrapped "
+            "in asyncio.wait_for(...) so a hung attempt_fn cannot hold "
+            "the lock forever."
+        )
+    finally:
+        wedge_event.set()  # always wake any leftover awaiters
+    dt = _time.monotonic() - t0
+
+    # With supervisor=cfg.fallback.timeout_seconds*(len(sources)+1)=2s
+    # per locked region, two serialized callers should finish within
+    # ~5s (binder ~2s, waiter ~2s, plus scheduling slack). The 8-second
+    # ceiling leaves a comfortable margin without being so loose that
+    # a blocking-bug regression slips through.
+    assert dt < 8.0, (
+        f"Lock supervisor released too slowly ({dt:.1f}s) — even with "
+        f"two serialized callers under a 2s supervisor budget, total "
+        f"should be well under 8s."
+    )
+    # Both callers must have returned (not raised) — chain-exhausted is a
+    # legitimate response shape, not a hang.
+    for r in results:
+        assert not isinstance(r, asyncio.TimeoutError), (
+            f"Caller saw TimeoutError instead of a chain-exhausted "
+            f"response: {r!r}. The supervisor should surface a clean "
+            f"aggregate failure, not propagate the cancellation."
+        )


### PR DESCRIPTION
## Summary

Closes #85. Stacks on PR #77 (`feat/fallback-repo-binding`); base is `feat/fallback-repo-binding` so the strict-consistency machinery this work amends is already in scope.

The per-repo `asyncio.Lock` introduced by #77 was holding through `attempt_fn` even after the cache had been bound, which serialized every legitimate concurrent same-repo call (issue #85 §2). Combined with no supervisor on the locked region, a wedged upstream call could hold the lock indefinitely so any same-repo request hung forever (issue #85 §1).

Two structural changes in `_run_cached_then_chain` (`src/kohakuhub/api/fallback/operations.py:208-322`):

1. **Shrink the critical section.** The post-lock cache-recheck now returns a decision tuple instead of calling `attempt_fn` under the lock. Waiters that find a binding under the lock release it immediately, then run `attempt_fn` outside it — so N concurrent waiters fan out in parallel rather than queuing single-file. The locked region only does I/O on the first-bind chain walk, which is the lock's actual job.

2. **Lock supervisor (`asyncio.wait_for`).** The locked region is wrapped in `asyncio.wait_for(timeout=cfg.fallback.timeout_seconds * (len(sources) + 1))`. A wedged `attempt_fn` cannot hold the lock past that budget; cancellation propagates through `async with binding_lock:` so the lock is always released. On supervisor timeout the caller sees a chain-exhausted aggregate and subsequent same-repo callers see a clean lock.

Strict-consistency invariants preserved end-to-end:

| Rule | Source | Preserved by |
|---|---|---|
| #1 TTL stickiness | bound source surfaces error, no rebind within TTL | unchanged |
| #3 Orphaned-cache invalidation only | admin-removed source URL → invalidate | unchanged |
| #4 Deterministic chain order | priority-ordered chain walk | unchanged (still under lock for first-bind) |
| #5 Per-(user, tokens_hash) keying | cache key includes user_id + tokens_hash | unchanged |
| #6 safe_set + 3-dim generation counters | race protection on concurrent invalidation | unchanged |

Strict consistency is reframed as a *safety* invariant conditional on stable upstream behaviour — under wedge / cancellation / reload it gracefully degrades to a chain-exhausted aggregate rather than unbounded blocking. The first-bind race (rule #2) still serializes, only its critical section is now I/O-free except for the chain walk.

## RED-first regression tests

Both tests in `test/kohakuhub/api/fallback/test_operations.py` were written first, watched to fail on the unfixed `operations.py`, then watched to pass after the patch.

- **`test_post_recheck_cache_hit_releases_lock_before_attempt_fn`** — 4 concurrent first-bind waiters; tracker counts in-flight HTTP calls to the bound source. Asserts `peak >= 2`. Pre-fix: peak = 1 (single-file behind the lock). Post-fix: peak = 3 (waiters fan out).
- **`test_lock_supervisor_releases_lock_when_attempt_fn_wedges`** — `_dispatch` awaits an `Event` that never fires; two same-repo callers fire concurrently. Pre-fix: outer `asyncio.wait_for(15s)` fires → test fails. Post-fix: supervisor at `2s × 1 source = 2s` per locked region releases the lock; both callers return chain-exhausted aggregate within ~5s.

## What changed where

| File | Change |
|---|---|
| `src/kohakuhub/api/fallback/operations.py` | `_run_cached_then_chain` refactored: split locked region into `_decide_under_lock` returning a 3-state tuple; wrapped under `asyncio.wait_for(supervisor_timeout)`; cache-hit `attempt_fn` runs outside the lock. Docstring extended with rule #2 narrowing + #2a supervisor. |
| `test/kohakuhub/api/fallback/test_operations.py` | Two new RED-first regression tests at the end of the file (~220 lines). |

No other files touched. CI runs the full backend suite plus the frontend matrix; the change set is intentionally minimal.

## Test plan

- [x] `test_post_recheck_cache_hit_releases_lock_before_attempt_fn` — RED → GREEN, 0.6s
- [x] `test_lock_supervisor_releases_lock_when_attempt_fn_wedges` — RED → GREEN, 1.8s
- [x] `pytest test/kohakuhub/api/fallback/` — **383 passed in 104.45s** (all strict-consistency / strict-freshness / chain-enumeration tests stay green)
- [x] `pytest test/kohakuhub/api/admin/` — **135 passed, 1 skipped (pre-existing) in 165.96s**
- [x] `pytest test/kohakuhub/ --ignore-fallback --ignore-admin` — **513 passed in 387.99s**
- [x] Live e2e via Playwright: login as `mai_lin`, navigate to `openai-community/gpt2-xl`, open safetensors metadata, exercise resolve fallback for 6 files, exercise concurrent same-repo info — see acceptance comment for screenshots and timings.
- [ ] CI matrix (Python 3.10/3.11/3.12 × hf_hub versions)

## Notes for reviewers

- The `supervisor_timeout = cfg.fallback.timeout_seconds * (len(sources) + 1)` budget is loose by design — it has to absorb a worst-case full chain walk where every source hits its own httpx timeout. With default `timeout_seconds=10` and 1 source it's 20s; with 5 sources it's 60s. **The user-perceptible improvement isn't in the supervisor budget; it's in the cache-hit waiters not paying for serialized I/O.** The supervisor is the structural backstop against unknown wedges (e.g. issue #85 §1's unproven 20s `gpt2-xl` hang).
- I considered tightening the supervisor to e.g. `min(timeout × n, 15s)` to make the worst-case wedge response faster, but that risks penalizing a legitimate slow chain walk. Per the issue's "保守" guidance, the safer move is to make the typical path fast (option a) and accept the worst-case wedge response taking up to chain-timeout (option c). If a future incident shows the chain-timeout is too loose, the constant is one line.
- Issue #85 also mentioned **option (b) — drop the lock entirely and use CAS via `safe_set`**. I deferred it: option (a) + (c) already eliminates the demonstrable serialization and bounds the worst-case wedge. Option (b) is a structural cleanup that can land later if any cold-burst scenario shows option (a)'s binder still serializing too much. Filed mentally; happy to open a follow-up if reviewers want.
- The cache-hit branch outside the lock still calls `attempt_fn`, which calls `safe_set`. That's intentional: it's a no-op-ish (cache already populated under TTL) but keeps the wire shape uniform and lets gen-counter race protection still trip if the binding got invalidated mid-call.

## Refs

- Issue #85 (this PR closes)
- PR #77 (introduced `_BINDING_LOCKS`; this PR is a stacked refinement)
- PR #79 (strict-freshness `safe_set` + gen counters this PR preserves)
- PR #84 (chain-tester PR; surfaced the symptom but is not the place to fix)
