### PR TITLE
fix(fallback/client): treat caller-supplied headers=None as empty (TypeError on token+empty headers)

### DIFF
--- a/src/kohakuhub/api/fallback/client.py
+++ b/src/kohakuhub/api/fallback/client.py
@@ -107,7 +107,14 @@ class FallbackClient:
             httpx.HTTPError: On request failure
         """
         external_url = self.map_url(kohaku_path, repo_type)
-        headers = kwargs.pop("headers", {})
+        # ``dict.pop(key, default)`` returns the value when the key is
+        # present even if that value is ``None``; the default is only
+        # used when the key is absent. Callers (notably
+        # ``_resolve_one_source`` via ``client_headers or None``) may
+        # pass ``headers=None`` to mean "no extra headers" — coerce
+        # explicitly so the subsequent ``headers["Authorization"] = ...``
+        # cannot land on ``None``.
+        headers = kwargs.pop("headers", None) or {}
 
         # Add authentication if token available
         # IMPORTANT: Only use admin-configured token, NEVER user auth!
@@ -140,7 +147,14 @@ class FallbackClient:
             httpx.HTTPError: On request failure
         """
         external_url = self.map_url(kohaku_path, repo_type)
-        headers = kwargs.pop("headers", {})
+        # ``dict.pop(key, default)`` returns the value when the key is
+        # present even if that value is ``None``; the default is only
+        # used when the key is absent. Callers (notably
+        # ``_resolve_one_source`` via ``client_headers or None``) may
+        # pass ``headers=None`` to mean "no extra headers" — coerce
+        # explicitly so the subsequent ``headers["Authorization"] = ...``
+        # cannot land on ``None``.
+        headers = kwargs.pop("headers", None) or {}
 
         # Add authentication if token available
         if self.token:
@@ -189,7 +203,14 @@ class FallbackClient:
             httpx.HTTPError: On request failure
         """
         external_url = self.map_url(kohaku_path, repo_type)
-        headers = kwargs.pop("headers", {})
+        # ``dict.pop(key, default)`` returns the value when the key is
+        # present even if that value is ``None``; the default is only
+        # used when the key is absent. Callers (notably
+        # ``_resolve_one_source`` via ``client_headers or None``) may
+        # pass ``headers=None`` to mean "no extra headers" — coerce
+        # explicitly so the subsequent ``headers["Authorization"] = ...``
+        # cannot land on ``None``.
+        headers = kwargs.pop("headers", None) or {}
 
         # Add authentication if token available
         if self.token:

--- a/test/kohakuhub/api/fallback/test_client.py
+++ b/test/kohakuhub/api/fallback/test_client.py
@@ -140,3 +140,82 @@ async def test_http_methods_forward_headers_timeouts_and_redirect_flags(monkeypa
     assert FakeAsyncClient.calls[2].kwargs["headers"] == {
         "Authorization": "Bearer user-token"
     }
+
+
+@pytest.mark.asyncio
+async def test_http_methods_treat_explicit_headers_none_as_empty(monkeypatch):
+    """Caller may pass ``headers=None`` to mean "no extra headers".
+
+    Regression: the GET path in ``_resolve_one_source`` collapses an
+    empty ``client_headers`` dict to ``None`` via ``client_headers or
+    None``. Combined with a token-bearing source (admin-configured HF
+    PAT, etc.), the previous ``headers = kwargs.pop("headers", {})``
+    returned ``None`` instead of ``{}`` (``dict.pop`` ignores the
+    default when the key is present), and the next line
+    ``headers["Authorization"] = ...`` raised ``TypeError: 'NoneType'
+    object does not support item assignment``. The exception was then
+    caught by the resolve loop's ``except Exception`` and surfaced to
+    the client as a misleading ``"category": "network"`` 502.
+
+    This test locks ``headers=None`` into a supported input across all
+    three verbs, with the Authorization header still added when the
+    source has a token.
+    """
+    FakeAsyncClient.calls = []
+    monkeypatch.setattr(fallback_client_module.cfg.fallback, "timeout_seconds", 12)
+    monkeypatch.setattr(fallback_client_module.httpx, "AsyncClient", FakeAsyncClient)
+
+    client = fallback_client_module.FallbackClient(
+        "https://huggingface.co",
+        "huggingface",
+        token="user-token",
+    )
+
+    get_response = await client.get(
+        "/datasets/deepghs/zerochan_full/resolve/main/images/0000.json",
+        "dataset",
+        follow_redirects=False,
+        headers=None,
+    )
+    head_response = await client.head(
+        "/datasets/deepghs/zerochan_full/resolve/main/images/0000.json",
+        "dataset",
+        headers=None,
+    )
+    post_response = await client.post(
+        "/api/datasets/deepghs/zerochan_full/paths-info/main",
+        "dataset",
+        headers=None,
+        json={"paths": ["images/0000.json"]},
+    )
+
+    assert get_response.status_code == 200
+    assert head_response.status_code == 204
+    assert post_response.status_code == 201
+    for call in FakeAsyncClient.calls:
+        assert call.kwargs["headers"] == {"Authorization": "Bearer user-token"}
+
+
+@pytest.mark.asyncio
+async def test_http_methods_handle_explicit_headers_none_without_token(monkeypatch):
+    """``headers=None`` is also valid for token-less sources — no
+    Authorization is added and the request still goes out cleanly."""
+    FakeAsyncClient.calls = []
+    monkeypatch.setattr(fallback_client_module.cfg.fallback, "timeout_seconds", 12)
+    monkeypatch.setattr(fallback_client_module.httpx, "AsyncClient", FakeAsyncClient)
+
+    client = fallback_client_module.FallbackClient(
+        "https://mirror.local",
+        "kohakuhub",
+        token=None,
+    )
+
+    response = await client.get(
+        "/models/owner/demo/resolve/main/config.json",
+        "model",
+        follow_redirects=False,
+        headers=None,
+    )
+
+    assert response.status_code == 200
+    assert FakeAsyncClient.calls[0].kwargs["headers"] == {}


### PR DESCRIPTION
## Summary

Fixes a `TypeError: 'NoneType' object does not support item assignment` that surfaces to clients as a 502 with `"category":"network"` whenever a token-bearing fallback source serves a non-Range resolve GET. Stacks on top of #77.

**Empirical trigger** — captured live before the fix:

```
$ curl -b 'session_id=...' http://127.0.0.1:48888/datasets/deepghs/zerochan_full/resolve/main/images/0000.json
HTTP=502
{"error":"UpstreamFailure","sources":[{"name":"HuggingFace","status":null,
  "category":"network","error_code":null,
  "message":"'NoneType' object does not support item assignment"}]}
```

Traceback (captured via temporary instrumentation, reverted before this PR):

```
File ".../fallback/operations.py", line 693, in _resolve_one_source
    get_response = await client.get(...)
File ".../fallback/client.py", line 115, in get
    headers["Authorization"] = f"Bearer {self.token}"
TypeError: 'NoneType' object does not support item assignment
```

## Root cause

Two-edge issue at the operations.py/client.py boundary:

1. `_resolve_one_source` (operations.py:697) calls `client.get(..., headers=client_headers or None)`. The `or None` collapses an empty `client_headers` dict into `None`, intending to mean "no extra headers".
2. `FallbackClient.get/head/post` did `headers = kwargs.pop("headers", {})`. `dict.pop(key, default)` ignores the default when the key is present — even if the value is `None` — so `headers` was `None`, and the next line `headers["Authorization"] = f"Bearer {self.token}"` raised `TypeError`.

The exception was caught by the resolve loop's `except Exception as e: ... build_fallback_attempt(source, network=e)` (operations.py:718-733), which the aggregate-failure builder maps to `"category":"network"`. A Python bug ended up masquerading as a network failure on the wire.

### Why this hit only some traffic

| Path | `client_headers` | Behavior |
|---|---|---|
| Plain GET of a small text file (`config.json`, `README.md`, `.json`) | `{}` (no whitelisted Range / If-* headers) | **502 TypeError** |
| Range GET (parquet metadata preview, safetensors header sniff) | `{"range": "bytes=..."}` | OK — non-empty dict bypasses the `or None` collapse |
| HEAD probe at the bind step | n/a — `client.head(kohaku_path, repo_type)` doesn't pass `headers=` | OK |
| Source without a token | n/a — `if self.token:` short-circuits | OK |

So the bug only triggers when (token set on source) AND (caller's `client_headers` empty) AND (it's the post-bind GET phase). Common in practice — a logged-in user with an HF token reading any non-LFS text file.

## Fix

Hardened the client-layer contract: explicit `headers=None` is now a supported input across `get`/`head`/`post`. One-line change repeated in three symmetric methods:

```python
# before
headers = kwargs.pop("headers", {})

# after
headers = kwargs.pop("headers", None) or {}
```

Caller (`operations.py:697`) intentionally untouched — passing `None` is now a supported input rather than a footgun.

## Tests

Two RED-first regression tests added in `test/kohakuhub/api/fallback/test_client.py`:

- `test_http_methods_treat_explicit_headers_none_as_empty` — with `token="user-token"`, all three verbs accept `headers=None` and the captured request carries the Authorization header. This is the direct regression-guard for the `'NoneType' object does not support item assignment` symptom.
- `test_http_methods_handle_explicit_headers_none_without_token` — the token-less branch also accepts `headers=None` cleanly and emits `headers={}`.

Verified RED before the fix (failed at `client.py:115` with the same TypeError); GREEN after.

## Test plan

- [x] New tests pass (`pytest test/kohakuhub/api/fallback/test_client.py`)
- [x] Full fallback suite green (`pytest test/kohakuhub/api/fallback/` — 392 passed)
- [ ] End-to-end verification against a token-bearing live HF source (held back for hand-off — port released for the maintainer to drive)

## Out of scope

- The misclassification of Python exceptions as `"category":"network"` in the resolve loop's `except Exception as e: ... build_fallback_attempt(source, network=e)` is a separate concern: a `TypeError` / `AttributeError` raised by our own code should not be reported as a network failure to the client. Tracking this and the inverse (loud-fail vs. soft-fall-through on `BUG`-shaped exceptions) is out of scope for this fix; opening a follow-up issue.
- The `headers=client_headers or None` expression in `operations.py:697` is now a no-op style choice — the client layer accepts both `None` and `{}` cleanly. Left untouched to keep this PR's diff minimal.
