### PR TITLE
feat(auth/permissions): privacy-preserving RepoNotFound shape for read denials (#76)

### DIFF
--- a/src/kohakuhub/api/fallback/decorators.py
+++ b/src/kohakuhub/api/fallback/decorators.py
@@ -47,6 +47,31 @@ OperationType = Literal["resolve", "tree", "info", "revision", "paths_info"]
 UserOperationType = Literal["profile", "repos", "avatar"]
 
 
+def _resolve_repo_read_denied_error() -> type:
+    """Resolve ``RepoReadDeniedError`` lazily.
+
+    The test harness in ``test/kohakuhub/support/bootstrap.py`` clears
+    every ``kohakuhub.*`` module from ``sys.modules`` and re-imports
+    them at session start, then returns a fresh ``app`` instance. Tests
+    that exercise the wrapper after the reload may end up with this
+    decorator module bound to a *previous* ``RepoReadDeniedError``
+    class object — different ``id()`` from the one the live
+    ``check_repo_read_permission`` raises. ``isinstance()`` then
+    silently returns False even on legitimate raises, and the generic
+    ``except Exception`` branch below converts the masked-private-repo
+    raise into a 500. The chain-tester probe (``probe_local.py``) hit
+    the same gotcha and uses the same lazy-resolve trick.
+
+    Re-resolving from ``sys.modules`` on every call binds whichever
+    copy is currently live, so the ``except`` clause matches at
+    request time regardless of any reload that happened between
+    decorator import and the route call.
+    """
+    from kohakuhub.auth.permissions import RepoReadDeniedError
+
+    return RepoReadDeniedError
+
+
 def _repo_sort_key(item: dict) -> tuple[str, str, str]:
     return (
         item.get("lastModified") or "",
@@ -358,6 +383,27 @@ def with_repo_fallback(operation: OperationType):
                 # swallow these. No trace recorded (the request itself
                 # is being aborted; the chain tester won't see this
                 # response anyway).
+                raise
+
+            except _resolve_repo_read_denied_error():
+                # ``RepoReadDeniedError`` is the privacy-preserving raise
+                # from ``check_repo_read_permission`` for masked private
+                # repos (post-#76). It must reach the FastAPI global
+                # handler in ``main.py`` to be converted to
+                # ``404 + X-Error-Code: RepoNotFound`` with an empty
+                # body — getting absorbed into the ``except Exception``
+                # branch below would degrade it into a 500 and silently
+                # break the wire-shape contract. Skip the chain probe
+                # entirely (we don't want to leak the existence of a
+                # private local repo by lighting up upstream traffic
+                # for it) and re-raise so the global handler runs.
+                #
+                # The class is resolved lazily because the test harness
+                # reloads ``kohakuhub.auth.permissions`` between
+                # sessions; a module-level import would freeze a stale
+                # class identity and ``isinstance()`` would silently
+                # miss legitimate raises (same gotcha the
+                # ``fallback/probe_local.py`` lazy import documents).
                 raise
 
             except Exception as e:

--- a/src/kohakuhub/api/fallback/probe_local.py
+++ b/src/kohakuhub/api/fallback/probe_local.py
@@ -318,8 +318,35 @@ async def probe_local(
         op, repo_type, namespace, name, revision, file_path, paths, request, user
     )
 
+    # ``RepoReadDeniedError`` is imported lazily here because the test
+    # harness reloads ``kohakuhub.auth.permissions`` between sessions
+    # (per-test backend isolation), giving the *route handler* and this
+    # module two different class objects with the same name —
+    # ``isinstance(exc, ImportedAtModuleLoad)`` then returns False even
+    # though they're "the same" exception. Re-resolving the class on the
+    # call path picks up whichever copy is currently bound to the
+    # handler chain.
+    from kohakuhub.auth.permissions import RepoReadDeniedError
+
     try:
         result = await inner(**kwargs)
+    except RepoReadDeniedError as e:
+        # ``RepoReadDeniedError`` propagates *past* ``with_repo_fallback``
+        # in production (the decorator only catches ``HTTPException``); the
+        # global FastAPI handler in ``main.py`` then converts it to
+        # ``404 + X-Error-Code: RepoNotFound``. The chain-tester probe
+        # bypasses both surfaces (we call the unwrapped inner directly),
+        # so we have to reproduce the conversion here to keep the
+        # simulate output in lockstep with what production would emit.
+        return _attempt_from_response(
+            method=method,
+            upstream_path=upstream_path,
+            started=started,
+            status=404,
+            x_error_code="RepoNotFound",
+            x_error_message=f"Repository '{e.repo_id}' ({e.repo_type}) not found",
+            body_preview=None,
+        )
     except HTTPException as e:
         x_code = (e.headers or {}).get("X-Error-Code") or (e.headers or {}).get(
             "x-error-code"

--- a/src/kohakuhub/api/fallback/probe_local.py
+++ b/src/kohakuhub/api/fallback/probe_local.py
@@ -331,13 +331,18 @@ async def probe_local(
     try:
         result = await inner(**kwargs)
     except RepoReadDeniedError as e:
-        # ``RepoReadDeniedError`` propagates *past* ``with_repo_fallback``
-        # in production (the decorator only catches ``HTTPException``); the
-        # global FastAPI handler in ``main.py`` then converts it to
-        # ``404 + X-Error-Code: RepoNotFound``. The chain-tester probe
-        # bypasses both surfaces (we call the unwrapped inner directly),
-        # so we have to reproduce the conversion here to keep the
-        # simulate output in lockstep with what production would emit.
+        # ``RepoReadDeniedError`` propagates past ``with_repo_fallback``
+        # in production: the decorator's ``except HTTPException`` skips
+        # it (wrong base class) **and** an explicit ``except
+        # RepoReadDeniedError: raise`` re-raises it past the generic
+        # ``except Exception`` catch — see
+        # ``api/fallback/decorators.py``. The global FastAPI handler in
+        # ``main.py`` then converts it to ``404 + X-Error-Code:
+        # RepoNotFound``. The chain-tester probe here bypasses both the
+        # decorator and the global handler (we call the unwrapped inner
+        # directly), so we have to reproduce the conversion locally to
+        # keep the simulate output in lockstep with what production
+        # actually emits for this case.
         return _attempt_from_response(
             method=method,
             upstream_path=upstream_path,

--- a/src/kohakuhub/api/files.py
+++ b/src/kohakuhub/api/files.py
@@ -304,12 +304,12 @@ async def get_revision(
         return hf_repo_not_found(repo_id, repo_type.value)
 
     # Hugging Face Hub hides private repos from unauthorized users.
-    try:
-        check_repo_read_permission(repo_row, user)
-    except HTTPException as exc:
-        if repo_row.private and exc.status_code in {401, 403}:
-            return hf_repo_not_found(repo_id, repo_type.value)
-        raise
+    # ``check_repo_read_permission`` raises ``RepoReadDeniedError`` for
+    # both anonymous-on-private and authed-no-access; the global handler
+    # in ``main.py`` converts that to ``hf_repo_not_found(...)`` so we
+    # don't need an ad-hoc translation here. Preserving the original
+    # behaviour for missing repos (already handled at line ~304 above).
+    check_repo_read_permission(repo_row, user)
 
     lakefs_repo = lakefs_repo_name(repo_type.value, repo_id)
     client = get_lakefs_client()
@@ -398,19 +398,10 @@ async def _get_file_metadata(
             },
         )
 
-    try:
-        check_repo_read_permission(repo_row, user)
-    except HTTPException as exc:
-        if repo_row.private and exc.status_code in {401, 403}:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": f"Repository '{repo_id}' not found"},
-                headers={
-                    "X-Error-Code": HFErrorCode.REPO_NOT_FOUND,
-                    "X-Error-Message": f"Repository '{repo_id}' ({repo_type}) not found",
-                },
-            ) from exc
-        raise
+    # ``check_repo_read_permission`` raises ``RepoReadDeniedError`` for
+    # both anonymous-on-private and authed-no-access; the global handler
+    # in ``main.py`` converts that to ``hf_repo_not_found(...)``.
+    check_repo_read_permission(repo_row, user)
 
     lakefs_repo = lakefs_repo_name(repo_type, repo_id)
     client = get_lakefs_client()

--- a/src/kohakuhub/api/likes.py
+++ b/src/kohakuhub/api/likes.py
@@ -14,7 +14,7 @@ from kohakuhub.db_operations import (
 )
 from kohakuhub.logger import get_logger
 from kohakuhub.auth.dependencies import get_current_user, get_optional_user
-from kohakuhub.auth.permissions import check_repo_read_permission
+from kohakuhub.auth.permissions import RepoReadDeniedError, check_repo_read_permission
 from kohakuhub.api.repo.utils.hf import hf_repo_not_found
 
 logger = get_logger("LIKES")
@@ -245,8 +245,13 @@ async def list_user_likes(
                     },
                 }
             )
-        except HTTPException:
-            # Skip private repos user can't access
+        except (HTTPException, RepoReadDeniedError):
+            # Skip private repos user can't access. Catch both shapes:
+            # ``RepoReadDeniedError`` (the new privacy-preserving raise from
+            # ``check_repo_read_permission`` post-#76) and ``HTTPException``
+            # (any other read-side denial that still raises through that
+            # legacy shape — e.g., the user-not-found 404 from sibling
+            # checks).
             continue
 
     return repos

--- a/src/kohakuhub/api/repo/routers/info.py
+++ b/src/kohakuhub/api/repo/routers/info.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 from peewee import JOIN, fn
 
 from kohakuhub.config import cfg
@@ -219,12 +219,10 @@ async def get_repo_info(
         return hf_repo_not_found(repo_id, repo_type)
 
     # Hugging Face Hub hides private repos from unauthorized users.
-    try:
-        check_repo_read_permission(repo_row, user)
-    except HTTPException as exc:
-        if repo_row.private and exc.status_code in {401, 403}:
-            return hf_repo_not_found(repo_id, repo_type)
-        raise
+    # ``check_repo_read_permission`` raises ``RepoReadDeniedError`` for
+    # both anonymous-on-private and authed-no-access; the global handler
+    # in ``main.py`` converts that to ``hf_repo_not_found(...)``.
+    check_repo_read_permission(repo_row, user)
 
     # Get LakeFS info for default branch
     lakefs_repo = lakefs_repo_name(repo_type, repo_id)

--- a/src/kohakuhub/api/repo/utils/hf.py
+++ b/src/kohakuhub/api/repo/utils/hf.py
@@ -15,24 +15,37 @@ class HFErrorCode:
     These error codes are read by huggingface_hub client's hf_raise_for_status()
     function to provide specific error types.
 
-    HuggingFace Hub officially supports:
-    - RepoNotFound
-    - RevisionNotFound
-    - EntryNotFound
-    - GatedRepo
+    HuggingFace Hub officially supports the four codes below — these are
+    the ones that ``hf_raise_for_status`` dispatches into named exception
+    classes (``RepositoryNotFoundError``, ``RevisionNotFoundError``,
+    ``EntryNotFoundError``, ``GatedRepoError``). **Do not rename them.**
 
-    We add additional codes for KohakuHub-specific errors that don't map to HF codes.
+    Note on the ``DisabledRepo`` case: HF signals it via the
+    ``X-Error-Message`` string ``"Access to this resource is disabled."``
+    rather than an ``X-Error-Code``; the helper for that lives in
+    ``hf_disabled_repo`` below and does not appear in this enum.
+
+    The remaining codes below are **KohakuHub-only extensions**.
+    ``hf_raise_for_status`` does not special-case them; downstream
+    ``huggingface_hub`` clients surface them as generic
+    ``HfHubHTTPError``. They exist so KohakuHub's own UI / SPA / admin
+    tooling can branch on a stable code rather than parsing free-text
+    messages. They are emitted on the wire — clients that don't expect
+    them simply ignore the header.
 
     Reference: huggingface_hub/utils/_http.py
     """
 
-    # HuggingFace official error codes (DO NOT CHANGE)
+    # HuggingFace official error codes (DO NOT CHANGE — these drive
+    # named-exception dispatch in ``hf_raise_for_status``).
     REPO_NOT_FOUND = "RepoNotFound"
     REVISION_NOT_FOUND = "RevisionNotFound"
     ENTRY_NOT_FOUND = "EntryNotFound"
     GATED_REPO = "GatedRepo"
 
-    # KohakuHub custom error codes (not in official HF Hub)
+    # KohakuHub-only extensions (not recognized by hf_raise_for_status —
+    # downstream HF clients see these as generic HfHubHTTPError; our SPA
+    # and admin tooling key off them for branching).
     REPO_EXISTS = "RepoExists"
     BAD_REQUEST = "BadRequest"
     INVALID_REPO_TYPE = "InvalidRepoType"
@@ -133,6 +146,46 @@ def hf_repo_not_found(repo_id: str, repo_type: Optional[str] = None) -> Response
         HFErrorCode.REPO_NOT_FOUND,
         f"Repository '{repo_id}'{type_str} not found",
     )
+
+
+def hf_disabled_repo(repo_id: Optional[str] = None) -> Response:
+    """Shortcut for "this repository is disabled" error (403).
+
+    HuggingFace flags moderation-disabled repositories with an exact
+    ``X-Error-Message`` string — ``"Access to this resource is disabled."``
+    — and **no** ``X-Error-Code`` header. ``huggingface_hub.utils
+    ._http.hf_raise_for_status`` dispatches ``DisabledRepoError`` by
+    matching that exact message string (verified live against
+    ``huggingface_hub`` 1.11.0); changing the casing or punctuation
+    breaks the dispatch.
+
+    No call site wires this helper today — ``DisabledRepoError`` is
+    reserved for a future moderation feature ("admin disables a repo")
+    and the helper is added here so the wire shape is centralized when
+    that feature lands. Keep the message string verbatim.
+
+    Args:
+        repo_id: Optional repository id, included in our
+            ``X-Khub-Repo`` header (debug aid for operators); the
+            HF-canonical message stays exact.
+
+    Returns:
+        403 response with HF's exact ``X-Error-Message``, no
+        ``X-Error-Code``, empty body.
+    """
+    extra: dict[str, str] = {}
+    if repo_id:
+        extra["X-Khub-Repo"] = repo_id
+    response = Response(
+        status_code=403,
+        headers={
+            # HF's exact wire string — DisabledRepoError's dispatch is a
+            # whole-string match, so this must not be paraphrased.
+            "X-Error-Message": "Access to this resource is disabled.",
+            **extra,
+        },
+    )
+    return response
 
 
 def hf_gated_repo(repo_id: str, message: Optional[str] = None) -> Response:

--- a/src/kohakuhub/api/stats.py
+++ b/src/kohakuhub/api/stats.py
@@ -8,7 +8,7 @@ from kohakuhub.db import DailyRepoStats, Repository, User
 from kohakuhub.db_operations import get_repository
 from kohakuhub.logger import get_logger
 from kohakuhub.auth.dependencies import get_optional_user
-from kohakuhub.auth.permissions import check_repo_read_permission
+from kohakuhub.auth.permissions import RepoReadDeniedError, check_repo_read_permission
 from kohakuhub.api.utils.downloads import ensure_stats_up_to_date
 from kohakuhub.api.repo.utils.hf import hf_repo_not_found
 
@@ -173,10 +173,13 @@ async def get_trending_repositories(
         if not repo:
             continue
 
-        # Check read permission (skip private repos user can't access)
+        # Check read permission (skip private repos user can't access).
+        # Catch both shapes: ``RepoReadDeniedError`` (the new privacy-
+        # preserving raise from ``check_repo_read_permission`` post-#76)
+        # and ``HTTPException`` for any legacy paths still raising that.
         try:
             check_repo_read_permission(repo, user)
-        except HTTPException:
+        except (HTTPException, RepoReadDeniedError):
             continue
 
         trending.append(

--- a/src/kohakuhub/auth/permissions.py
+++ b/src/kohakuhub/auth/permissions.py
@@ -9,6 +9,38 @@ from kohakuhub.constants import ERROR_USER_AUTH_REQUIRED
 from kohakuhub.db_operations import get_organization, get_user_organization
 
 
+class RepoReadDeniedError(Exception):
+    """Raised when a caller cannot read a repository.
+
+    Used by ``check_repo_read_permission`` for both anonymous-on-private
+    and authed-no-access cases. Distinct from ``HTTPException`` so the
+    fallback decorator's ``except HTTPException`` does **not** catch it
+    (we want the request to bypass the fallback chain — emitting a
+    privacy-preserving ``RepoNotFound`` to the caller is the local layer's
+    final answer; we shouldn't probe upstream sources for a repo we
+    deliberately want to mask).
+
+    A global FastAPI exception handler (registered in ``main.py``)
+    converts this exception into ``404 + X-Error-Code: RepoNotFound``,
+    aligning hkub's wire shape with HuggingFace's authed-style answer
+    for "repo doesn't exist (to you)" — which ``huggingface_hub.utils
+    ._http.hf_raise_for_status`` dispatches to ``RepositoryNotFoundError``.
+
+    Picking this over the anonymous 401-anti-enum shape (issue #76
+    Option A): privacy-preserving (anon and authed-no-access become
+    indistinguishable on the wire), simpler, and matches the
+    authenticated-caller shape HF returns.
+    """
+
+    def __init__(self, repo: Repository):
+        self.repo = repo
+        self.repo_id = repo.full_id
+        self.repo_type = repo.repo_type
+        super().__init__(
+            f"Read access denied to {self.repo_type} '{self.repo_id}'"
+        )
+
+
 def check_namespace_permission(
     namespace: str,
     user: Optional[User],
@@ -92,11 +124,14 @@ def check_repo_read_permission(
     if not repo.private:
         return True
 
-    # Private repos require authentication
+    # Private repos: anonymous-on-private and authed-no-access both
+    # collapse to ``RepoReadDeniedError`` so the wire shape is identical
+    # for both callers (privacy-preserving Option A from #76 — hides the
+    # private-repo enumeration leak that distinct 401-vs-403 responses
+    # would otherwise expose, and maps cleanly through hf_raise_for_status
+    # to ``RepositoryNotFoundError`` on the client).
     if not user:
-        raise HTTPException(
-            401, detail="Authentication required to access private repository"
-        )
+        raise RepoReadDeniedError(repo)
 
     # Check if user is the creator (namespace matches username)
     if repo.namespace == user.username:
@@ -109,9 +144,7 @@ def check_repo_read_permission(
         if membership:
             return True
 
-    raise HTTPException(
-        403, detail=f"You don't have access to private repository '{repo.full_id}'"
-    )
+    raise RepoReadDeniedError(repo)
 
 
 def check_repo_write_permission(

--- a/src/kohakuhub/auth/permissions.py
+++ b/src/kohakuhub/auth/permissions.py
@@ -13,12 +13,19 @@ class RepoReadDeniedError(Exception):
     """Raised when a caller cannot read a repository.
 
     Used by ``check_repo_read_permission`` for both anonymous-on-private
-    and authed-no-access cases. Distinct from ``HTTPException`` so the
-    fallback decorator's ``except HTTPException`` does **not** catch it
-    (we want the request to bypass the fallback chain — emitting a
-    privacy-preserving ``RepoNotFound`` to the caller is the local layer's
-    final answer; we shouldn't probe upstream sources for a repo we
-    deliberately want to mask).
+    and authed-no-access cases. Inheriting from ``Exception`` (not
+    ``HTTPException``) keeps the fallback decorator's ``except
+    HTTPException`` from absorbing it — but on its own that is **not
+    sufficient** to preserve propagation, because ``with_repo_fallback``
+    also has a generic ``except Exception`` block that converts
+    LakeFS / DB / timeout failures into a 500. Propagation past the
+    decorator depends on the *explicit* ``except RepoReadDeniedError:
+    raise`` clause sitting between the cancellation handler and the
+    generic catch (``api/fallback/decorators.py``). Both pieces — the
+    inheritance choice **and** the decorator's explicit re-raise — are
+    load-bearing. Skipping the chain probe is the intended outcome:
+    we don't want to leak the existence of a masked private local repo
+    by emitting upstream traffic for it.
 
     A global FastAPI exception handler (registered in ``main.py``)
     converts this exception into ``404 + X-Error-Code: RepoNotFound``,
@@ -27,9 +34,18 @@ class RepoReadDeniedError(Exception):
     ._http.hf_raise_for_status`` dispatches to ``RepositoryNotFoundError``.
 
     Picking this over the anonymous 401-anti-enum shape (issue #76
-    Option A): privacy-preserving (anon and authed-no-access become
-    indistinguishable on the wire), simpler, and matches the
-    authenticated-caller shape HF returns.
+    Option A): the **wire shape** is identical for anonymous-on-private
+    and authed-no-access, simpler than mirroring HF's anon-vs-authed
+    branch, and matches what HF returns to authenticated callers. Note
+    that "wire-shape identical" is **not the same as** "fully
+    indistinguishable": the authed-no-access path executes additional
+    DB lookups (``get_organization``, ``get_user_organization``) that
+    the anon path doesn't, leaving a sub-millisecond timing-side-channel
+    that could in principle be exploited at scale. Treating that as
+    out-of-scope for now — HF's own backend has the equivalent
+    asymmetry, and a constant-time path would mean adding 2 always-
+    needless DB hits to every anon read. Document the gap honestly
+    rather than overclaim equivalence.
     """
 
     def __init__(self, repo: Repository):

--- a/src/kohakuhub/main.py
+++ b/src/kohakuhub/main.py
@@ -18,7 +18,7 @@ from kohakuhub.api import (
     stats,
     validation,
 )
-from kohakuhub.api.repo.utils.hf import HFErrorCode
+from kohakuhub.api.repo.utils.hf import HFErrorCode, hf_repo_not_found
 from kohakuhub.api.invitation import router as invitation
 from kohakuhub.auth import router as auth_router
 from kohakuhub.api.auth import external_tokens
@@ -33,6 +33,7 @@ from kohakuhub.api.files import resolve_file_get, resolve_file_head
 from kohakuhub.api.org import router as org
 from kohakuhub.api.quota import router as quota
 from kohakuhub.auth.dependencies import get_optional_user
+from kohakuhub.auth.permissions import RepoReadDeniedError
 from kohakuhub.utils.s3 import init_storage
 from kohakuhub.api.git.routers import http as git_http
 from kohakuhub.api.git.routers import lfs, ssh_keys
@@ -116,6 +117,28 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(RequestIdMiddleware)
+
+
+@app.exception_handler(RepoReadDeniedError)
+async def _repo_read_denied_handler(request: Request, exc: RepoReadDeniedError):
+    """Convert ``RepoReadDeniedError`` into HF's ``RepoNotFound`` wire shape.
+
+    Centralizing the conversion here gives every endpoint that calls
+    ``check_repo_read_permission`` the same privacy-preserving wire shape
+    for free — info / tree / paths-info / resolve HEAD/GET / commits /
+    likes / stats / xet-lookup all stop emitting raw ``HTTPException(401|403)``
+    bodies and start emitting ``404 + X-Error-Code: RepoNotFound`` with an
+    empty body. ``huggingface_hub.utils._http.hf_raise_for_status`` then
+    raises ``RepositoryNotFoundError`` on the client, which is what
+    downstream libraries (``transformers``, ``datasets``, …) key off for
+    actionable error messages.
+
+    See ``RepoReadDeniedError``'s docstring for why this is a non-
+    ``HTTPException`` exception class — keeping the fallback decorator's
+    ``except HTTPException`` from catching it is what makes the chain
+    skip upstream lookups for masked private repos.
+    """
+    return hf_repo_not_found(exc.repo_id, exc.repo_type)
 
 app.add_middleware(
     CORSMiddleware,

--- a/src/kohakuhub/main.py
+++ b/src/kohakuhub/main.py
@@ -133,10 +133,17 @@ async def _repo_read_denied_handler(request: Request, exc: RepoReadDeniedError):
     downstream libraries (``transformers``, ``datasets``, …) key off for
     actionable error messages.
 
-    See ``RepoReadDeniedError``'s docstring for why this is a non-
-    ``HTTPException`` exception class — keeping the fallback decorator's
-    ``except HTTPException`` from catching it is what makes the chain
-    skip upstream lookups for masked private repos.
+    See ``RepoReadDeniedError``'s docstring for the full propagation
+    story. Short version: the inheritance choice (``Exception``, not
+    ``HTTPException``) keeps the fallback decorator's ``except
+    HTTPException`` from translating it into a 4xx, **and** an explicit
+    ``except RepoReadDeniedError: raise`` in
+    ``api/fallback/decorators.py`` keeps the generic ``except
+    Exception`` from collapsing it into a 500. Both are needed; missing
+    either degrades the wire shape silently. The chain probe is
+    intentionally not entered for this case — the strict-consistency
+    "local namespace wins absolutely" rule applies even when the local
+    layer is hiding the repo.
     """
     return hf_repo_not_found(exc.repo_id, exc.repo_type)
 

--- a/test/kohakuhub/api/repo/routers/test_info_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_info_unit.py
@@ -339,17 +339,25 @@ async def test_get_repo_info_covers_invalid_type_not_found_siblings_and_storage_
 
     repo_row.private = True
 
-    def _raise_unauthorized(repo, user):
-        raise HTTPException(status_code=401, detail="auth required")
+    # Privacy translation now lives in main.py's global handler post-#76;
+    # ``get_repo_info`` itself just propagates ``RepoReadDeniedError``.
+    # The on-the-wire 404 + RepoNotFound shape is integration-tested in
+    # ``test_repo_read_denial_hf_alignment.py``.
+    from kohakuhub.auth.permissions import RepoReadDeniedError
 
-    monkeypatch.setattr(repo_info, "check_repo_read_permission", _raise_unauthorized)
-    hidden_private = await repo_info.get_repo_info.__wrapped__(
-        "alice",
-        "demo",
-        request=_request("/api/models/alice/demo"),
-        user=None,
-    )
-    assert hidden_private.status_code == 404
+    def _raise_read_denied(repo, user):
+        raise RepoReadDeniedError(
+            SimpleNamespace(full_id="alice/demo", repo_type="model")
+        )
+
+    monkeypatch.setattr(repo_info, "check_repo_read_permission", _raise_read_denied)
+    with pytest.raises(RepoReadDeniedError):
+        await repo_info.get_repo_info.__wrapped__(
+            "alice",
+            "demo",
+            request=_request("/api/models/alice/demo"),
+            user=None,
+        )
 
     def _raise_conflict(repo, user):
         raise HTTPException(status_code=409, detail="unexpected")

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -88,9 +88,25 @@ def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub()
     """End-to-end: a real ``hf_raise_for_status`` against our wire shape
     must dispatch to ``DisabledRepoError``. This is what proves the
     helper's contract — without this assertion, we're just guessing at
-    HF's parsing rules."""
+    HF's parsing rules.
+
+    ``DisabledRepoError`` was added to ``huggingface_hub`` around
+    v0.21 / v0.22; CI still tests against v0.20.3 where the symbol is
+    not exported. Skip on those versions — the helper itself is still
+    valid (the unit tests above pin its on-the-wire shape); we just
+    can't assert the round-trip dispatch class on a client that
+    doesn't define the named exception.
+    """
     import httpx
-    from huggingface_hub.errors import DisabledRepoError
+
+    try:
+        # ``huggingface_hub.errors`` landed around v0.22; older versions
+        # keep these exceptions under ``huggingface_hub.utils``. Try the
+        # version-portable path, fall back to skip if unavailable.
+        from huggingface_hub.utils import DisabledRepoError
+    except ImportError:
+        pytest.skip("DisabledRepoError not exported by this hf_hub version")
+
     from huggingface_hub.utils._http import hf_raise_for_status
 
     response = hf_utils.hf_disabled_repo("acme-labs/private-dataset")

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -90,12 +90,23 @@ def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub()
     helper's contract — without this assertion, we're just guessing at
     HF's parsing rules.
 
-    ``DisabledRepoError`` was added to ``huggingface_hub`` around
-    v0.21 / v0.22; CI still tests against v0.20.3 where the symbol is
-    not exported. Skip on those versions — the helper itself is still
-    valid (the unit tests above pin its on-the-wire shape); we just
-    can't assert the round-trip dispatch class on a client that
-    doesn't define the named exception.
+    Two skip-worthy gaps in ``huggingface_hub``'s rollout history:
+
+    - ``DisabledRepoError`` itself wasn't exported until ~v0.21; v0.20.3
+      (still in the CI matrix) doesn't define the symbol at all.
+    - ``hf_raise_for_status`` didn't gain the
+      ``X-Error-Message == "Access to this resource is disabled."``
+      dispatch branch until ~v1.0; v0.30.x and v0.36.x export the
+      ``DisabledRepoError`` class but never raise it from
+      ``hf_raise_for_status`` — they fall through to httpx's generic
+      ``HTTPStatusError`` instead.
+
+    The combined skip condition is "the round-trip actually produces a
+    ``DisabledRepoError``". Probe once at the top of the test and skip
+    if the dispatch branch isn't wired in this hf_hub version. The
+    helper's on-the-wire shape (status, exact message string, no
+    X-Error-Code) is still pinned by the two unit tests above for every
+    version.
     """
     import httpx
 
@@ -111,17 +122,37 @@ def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub()
 
     response = hf_utils.hf_disabled_repo("acme-labs/private-dataset")
 
-    # Re-pack our FastAPI response into an httpx.Response so
-    # hf_raise_for_status can inspect it the way it would a real wire
-    # response from huggingface.co.
-    fake = httpx.Response(
-        status_code=response.status_code,
-        headers=dict(response.headers),
-        content=bytes(response.body),
-        request=httpx.Request("GET", "https://huggingface.co/api/models/acme-labs/private-dataset"),
-    )
-    with pytest.raises(DisabledRepoError):
-        hf_raise_for_status(fake)
+    def _build_fake() -> httpx.Response:
+        # Re-pack our FastAPI response into an httpx.Response so
+        # hf_raise_for_status can inspect it the way it would a real
+        # wire response from huggingface.co.
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            content=bytes(response.body),
+            request=httpx.Request(
+                "GET",
+                "https://huggingface.co/api/models/acme-labs/private-dataset",
+            ),
+        )
+
+    # Probe whether this hf_hub version actually wires the
+    # disabled-message dispatch. v0.30 / v0.36 export DisabledRepoError
+    # but the dispatch branch in hf_raise_for_status only landed ~v1.0,
+    # so older versions raise a non-DisabledRepoError on the same wire.
+    try:
+        hf_raise_for_status(_build_fake())
+    except DisabledRepoError:
+        # Already proved the round-trip works; the assertion below would
+        # have raised on the next call if we let it.
+        return
+    except Exception:
+        pytest.skip(
+            "hf_raise_for_status in this version does not dispatch the "
+            "X-Error-Message=='Access to this resource is disabled.' "
+            "branch to DisabledRepoError"
+        )
+    pytest.fail("hf_raise_for_status returned cleanly on a 403 disabled response")
 
 
 def test_hf_error_response_sanitizes_header_values_for_http_transport():

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -45,6 +45,69 @@ def test_hf_shortcuts_cover_repo_revision_entry_and_server_errors():
     assert server_error.headers["x-error-code"] == "CustomError"
 
 
+def test_hf_disabled_repo_emits_hf_canonical_message_with_no_x_error_code():
+    """``DisabledRepoError`` dispatch in ``hf_raise_for_status`` is keyed
+    off the **exact** ``X-Error-Message`` string ``"Access to this resource
+    is disabled."`` — no ``X-Error-Code`` is involved. Drift that string
+    or add an ``X-Error-Code`` and HF clients fall back to a generic
+    ``HfHubHTTPError`` (verified live against ``huggingface_hub`` 1.11.0:
+    ``utils/_http.py`` matches the message verbatim before any code-based
+    branching). This regression-guards the canonical wire shape so the
+    helper is safe to wire up when a future moderation feature lands.
+    """
+    response = hf_utils.hf_disabled_repo("acme-labs/private-dataset")
+
+    assert response.status_code == 403
+    assert response.body == b""
+    # Exact HF message string — DisabledRepoError dispatches on it.
+    assert (
+        response.headers["x-error-message"]
+        == "Access to this resource is disabled."
+    )
+    # No X-Error-Code — HF doesn't set one for DisabledRepo, and adding
+    # ours would either be ignored or risk colliding with HF's contract.
+    assert "x-error-code" not in response.headers
+    # Operator debug aid is fine in our own namespace.
+    assert response.headers["x-khub-repo"] == "acme-labs/private-dataset"
+
+
+def test_hf_disabled_repo_works_without_repo_id():
+    """Reserved-for-future-use helper must not require a repo id —
+    moderation flows may need to disable a request before any specific
+    repo is known."""
+    response = hf_utils.hf_disabled_repo()
+    assert response.status_code == 403
+    assert (
+        response.headers["x-error-message"]
+        == "Access to this resource is disabled."
+    )
+    assert "x-khub-repo" not in response.headers
+
+
+def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub():
+    """End-to-end: a real ``hf_raise_for_status`` against our wire shape
+    must dispatch to ``DisabledRepoError``. This is what proves the
+    helper's contract — without this assertion, we're just guessing at
+    HF's parsing rules."""
+    import httpx
+    from huggingface_hub.errors import DisabledRepoError
+    from huggingface_hub.utils._http import hf_raise_for_status
+
+    response = hf_utils.hf_disabled_repo("acme-labs/private-dataset")
+
+    # Re-pack our FastAPI response into an httpx.Response so
+    # hf_raise_for_status can inspect it the way it would a real wire
+    # response from huggingface.co.
+    fake = httpx.Response(
+        status_code=response.status_code,
+        headers=dict(response.headers),
+        content=bytes(response.body),
+        request=httpx.Request("GET", "https://huggingface.co/api/models/acme-labs/private-dataset"),
+    )
+    with pytest.raises(DisabledRepoError):
+        hf_raise_for_status(fake)
+
+
 def test_hf_error_response_sanitizes_header_values_for_http_transport():
     response = hf_utils.hf_error_response(
         500,

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -114,7 +114,7 @@ def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub()
         # ``huggingface_hub.errors`` landed around v0.22; older versions
         # keep these exceptions under ``huggingface_hub.utils``. Try the
         # version-portable path, fall back to skip if unavailable.
-        from huggingface_hub.utils import DisabledRepoError
+        from huggingface_hub.utils import DisabledRepoError, HfHubHTTPError
     except ImportError:
         pytest.skip("DisabledRepoError not exported by this hf_hub version")
 
@@ -138,15 +138,21 @@ def test_hf_disabled_repo_dispatches_to_disabled_repo_error_in_huggingface_hub()
 
     # Probe whether this hf_hub version actually wires the
     # disabled-message dispatch. v0.30 / v0.36 export DisabledRepoError
-    # but the dispatch branch in hf_raise_for_status only landed ~v1.0,
-    # so older versions raise a non-DisabledRepoError on the same wire.
+    # but the dispatch branch in hf_raise_for_status only landed ~v1.0;
+    # those older versions raise either ``httpx.HTTPStatusError`` (the
+    # raw httpx 4xx default) or a generic ``HfHubHTTPError``. Catch
+    # exactly those two families so a future hf_hub version that
+    # dispatches the same wire shape to a *different* specific
+    # exception (an unlikely but possible API drift) surfaces as a
+    # genuine pytest failure instead of being swallowed by an
+    # over-broad ``except Exception``.
     try:
         hf_raise_for_status(_build_fake())
     except DisabledRepoError:
         # Already proved the round-trip works; the assertion below would
         # have raised on the next call if we let it.
         return
-    except Exception:
+    except (httpx.HTTPStatusError, HfHubHTTPError):
         pytest.skip(
             "hf_raise_for_status in this version does not dispatch the "
             "X-Error-Message=='Access to this resource is disabled.' "

--- a/test/kohakuhub/api/test_files_unit.py
+++ b/test/kohakuhub/api/test_files_unit.py
@@ -284,19 +284,29 @@ async def test_preupload_and_revision_cover_validation_quota_and_resolution_erro
 
     repo.private = True
 
-    def _raise_unauthorized(repo_row, user):
-        raise HTTPException(status_code=401, detail="auth required")
+    # Privacy translation now lives in the global handler in main.py
+    # (see #76). The unit's responsibility is to propagate
+    # ``RepoReadDeniedError`` unchanged; the handler converts it to
+    # ``404 + X-Error-Code: RepoNotFound`` at request time. Integration
+    # coverage for the on-the-wire shape lives in
+    # ``test_repo_read_denial_hf_alignment.py``.
+    from kohakuhub.auth.permissions import RepoReadDeniedError
 
-    monkeypatch.setattr(files_api, "check_repo_read_permission", _raise_unauthorized)
-    hidden_private_revision = await files_api.get_revision.__wrapped__(
-        files_api.RepoType.model,
-        "alice",
-        "demo",
-        "main",
-        request=None,
-        user=None,
-    )
-    assert hidden_private_revision.status_code == 404
+    def _raise_read_denied(repo_row, user):
+        raise RepoReadDeniedError(
+            SimpleNamespace(full_id="alice/demo", repo_type="model")
+        )
+
+    monkeypatch.setattr(files_api, "check_repo_read_permission", _raise_read_denied)
+    with pytest.raises(RepoReadDeniedError):
+        await files_api.get_revision.__wrapped__(
+            files_api.RepoType.model,
+            "alice",
+            "demo",
+            "main",
+            request=None,
+            user=None,
+        )
 
     def _raise_conflict(repo_row, user):
         raise HTTPException(status_code=409, detail="unexpected")
@@ -348,14 +358,20 @@ async def test_metadata_and_resolve_routes_cover_storage_backend_fallback_and_xe
     hidden_repo = SimpleNamespace(private=True)
     monkeypatch.setattr(files_api, "get_repository", lambda repo_type, namespace, name: hidden_repo)
 
-    def _raise_forbidden(repo_row, user):
-        raise HTTPException(status_code=403, detail="forbidden")
+    # Privacy translation lives in main.py's global handler post-#76;
+    # the unit just propagates ``RepoReadDeniedError`` from the helper.
+    # Integration coverage for the on-the-wire shape is in
+    # ``test_repo_read_denial_hf_alignment.py``.
+    from kohakuhub.auth.permissions import RepoReadDeniedError
 
-    monkeypatch.setattr(files_api, "check_repo_read_permission", _raise_forbidden)
-    with pytest.raises(HTTPException) as hidden_private_repo:
+    def _raise_read_denied(repo_row, user):
+        raise RepoReadDeniedError(
+            SimpleNamespace(full_id="alice/demo", repo_type="model")
+        )
+
+    monkeypatch.setattr(files_api, "check_repo_read_permission", _raise_read_denied)
+    with pytest.raises(RepoReadDeniedError):
         await files_api._get_file_metadata("model", "alice", "demo", "main", "file.txt", None)
-    assert hidden_private_repo.value.status_code == 404
-    assert hidden_private_repo.value.headers["X-Error-Code"] == files_api.HFErrorCode.REPO_NOT_FOUND
 
     def _raise_conflict(repo_row, user):
         raise HTTPException(status_code=409, detail="unexpected")

--- a/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
+++ b/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
@@ -113,6 +113,40 @@ async def test_info_anon_on_private_dataset_returns_repo_not_found(client):
     _assert_repo_not_found(response)
 
 
+async def test_info_anon_on_private_dataset_returns_repo_not_found_with_fallback_enabled(
+    client, monkeypatch
+):
+    """Production-shape regression guard for the fallback-decorator
+    interaction.
+
+    Other tests in this module pass ``?fallback=false`` to isolate the
+    *local* response shape from any chain-probe behavior. This test
+    deliberately does not — it pins the wire shape on the actual
+    production code path where ``cfg.fallback.enabled=True`` (the
+    production default) and the decorator wraps the endpoint with its
+    full try/except machinery.
+
+    The decorator catches generic ``Exception`` to route LakeFS / DB /
+    timeout failures to ``LOCAL_OTHER_ERROR`` + 500. A naive
+    ``RepoReadDeniedError`` design would be swallowed by that branch and
+    re-raised as a 500 — letting the global handler in ``main.py``
+    never run, and silently regressing this PR's wire-shape promise
+    for every fallback-enabled deployment. Pin the contract so a
+    future refactor of the decorator can't unwire the privacy
+    translation invisibly.
+    """
+    from kohakuhub.config import cfg
+
+    monkeypatch.setattr(cfg.fallback, "enabled", True)
+
+    response = await client.get(
+        "/api/datasets/acme-labs/private-dataset",
+        # NOTE: deliberately no ``?fallback=false`` — we want the
+        # wrapper's full code path.
+    )
+    _assert_repo_not_found(response)
+
+
 async def test_info_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
     response = await outsider_client.get(
         "/api/datasets/acme-labs/private-dataset",

--- a/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
+++ b/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
@@ -52,7 +52,12 @@ from typing import Optional
 
 import pytest
 from huggingface_hub import HfApi, hf_hub_download
-from huggingface_hub.errors import RepositoryNotFoundError
+
+# ``huggingface_hub.errors`` landed around v0.22; v0.20.3 (still in the CI
+# matrix) keeps these exceptions under ``huggingface_hub.utils``. The utils
+# path is the version-portable import that works against every client
+# version we target.
+from huggingface_hub.utils import RepositoryNotFoundError
 
 
 # ---------------------------------------------------------------------------

--- a/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
+++ b/test/kohakuhub/api/test_repo_read_denial_hf_alignment.py
@@ -1,0 +1,273 @@
+"""KohakuHub-as-fallback-source error contract for read-permission denials.
+
+Closes the gap audited in #76. The four standard HF X-Error-Code values
+already align with HuggingFace; the remaining gap is the
+permission-denial path. ``check_repo_read_permission`` historically raised
+``HTTPException(401)`` for anonymous-on-private and ``HTTPException(403)``
+for authed-no-access — both produce FastAPI's default ``{"detail": ...}``
+JSON envelope with no ``X-Error-Code``. A ``huggingface_hub`` client
+hitting a private hkub repo therefore got a generic ``HfHubHTTPError``
+instead of ``RepositoryNotFoundError``.
+
+Per the issue's recommended Option A (privacy-preserving / matches HF's
+authed branch), permission denials now emit ``404 + X-Error-Code:
+RepoNotFound`` regardless of whether the caller is anonymous or
+authenticated. This:
+
+- Makes hkub-as-fallback-source for another hkub instance speak the same
+  HF contract every other hkub upstream surface already speaks.
+- Maps cleanly through ``huggingface_hub.utils._http.hf_raise_for_status``
+  to ``RepositoryNotFoundError`` on the client.
+- Hides the private-repo enumeration leak (anon callers can no longer
+  distinguish "doesn't exist" from "private" by status code).
+
+Two test groups in this module:
+
+1. **Wire-shape tests** — drive the four read-side surfaces (info / tree
+   / paths-info / resolve HEAD/GET) for {anonymous, outsider} callers,
+   assert the response is ``404 + X-Error-Code: RepoNotFound`` with an
+   empty body. Owner regression guards confirm legitimate access still
+   resolves to 200.
+
+2. **huggingface_hub interop tests** — drive a real ``HfApi`` /
+   ``hf_hub_download`` client against the live test server and assert it
+   raises ``RepositoryNotFoundError`` (not generic ``HfHubHTTPError``).
+
+The empirical anchor for the wire shapes is the live HF probe captured
+2026-05-05 (and previously 2026-04-30 in the PR #77 design):
+
+| HF wire shape (probed)                              | hf_hub raises          |
+|-----------------------------------------------------|------------------------|
+| 401 bare + ``Invalid username or password.`` (anon) | RepositoryNotFoundError|
+| 404 + ``X-Error-Code: RepoNotFound`` (authed)       | RepositoryNotFoundError|
+
+We pick the authed shape (Option A) for hkub: same exception class on
+the client, no enumeration leak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import pytest
+from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub.errors import RepositoryNotFoundError
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape tests — assert the 404 + X-Error-Code: RepoNotFound contract
+# across every read-side surface that ``check_repo_read_permission`` gates.
+#
+# All requests carry ``?fallback=false`` so we test the *local* response
+# shape in isolation. Fallback chain interaction is covered separately by
+# the fallback test suite — that's a different concern from "what shape
+# does our local layer emit for a permission denial".
+# ---------------------------------------------------------------------------
+
+
+def _assert_repo_not_found(response, *, expected_message_contains: str = "private-dataset"):
+    """Assert a response matches HF's RepoNotFound contract on the wire.
+
+    Empty body, 404, ``X-Error-Code: RepoNotFound``, ``X-Error-Message``
+    present and non-trivial. Mirrors the helper checks in
+    ``test_error_contract.py`` for the EntryNotFound / RevisionNotFound
+    paths.
+    """
+    assert response.status_code == 404, (
+        f"expected 404 (HF authed-style RepoNotFound), got {response.status_code} "
+        f"body={response.content[:200]!r} headers={dict(response.headers)}"
+    )
+    assert response.headers.get("x-error-code") == "RepoNotFound", (
+        f"X-Error-Code missing or wrong; got {response.headers.get('x-error-code')!r}. "
+        "huggingface_hub.hf_raise_for_status keys off this header to dispatch "
+        "RepositoryNotFoundError; without it the client falls through to "
+        "generic HfHubHTTPError."
+    )
+    assert response.headers.get("x-error-message"), (
+        "X-Error-Message missing — becomes HfHubHTTPError.server_message; "
+        "leaving it blank degrades the user's traceback message."
+    )
+    assert expected_message_contains in response.headers["x-error-message"]
+    # HF's contract is empty body — error data lives in headers. The
+    # FastAPI default ``{"detail": ...}`` envelope is what we're moving away from.
+    assert response.content == b"", (
+        f"expected empty body (HF contract — error data in headers), "
+        f"got {response.content[:200]!r}"
+    )
+
+
+# ---- info surface ---------------------------------------------------------
+
+
+async def test_info_anon_on_private_dataset_returns_repo_not_found(client):
+    response = await client.get(
+        "/api/datasets/acme-labs/private-dataset",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_info_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
+    response = await outsider_client.get(
+        "/api/datasets/acme-labs/private-dataset",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_info_member_on_private_dataset_still_succeeds(member_client):
+    """Regression guard — legitimate access must still resolve to 200."""
+    response = await member_client.get(
+        "/api/datasets/acme-labs/private-dataset",
+        params={"fallback": "false"},
+    )
+    assert response.status_code == 200
+
+
+# ---- tree surface ---------------------------------------------------------
+
+
+async def test_tree_anon_on_private_dataset_returns_repo_not_found(client):
+    response = await client.get(
+        "/api/datasets/acme-labs/private-dataset/tree/main",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_tree_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
+    response = await outsider_client.get(
+        "/api/datasets/acme-labs/private-dataset/tree/main",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_tree_member_on_private_dataset_still_succeeds(member_client):
+    response = await member_client.get(
+        "/api/datasets/acme-labs/private-dataset/tree/main",
+        params={"fallback": "false"},
+    )
+    assert response.status_code == 200
+
+
+# ---- paths-info surface ---------------------------------------------------
+
+
+async def test_paths_info_anon_on_private_dataset_returns_repo_not_found(client):
+    response = await client.post(
+        "/api/datasets/acme-labs/private-dataset/paths-info/main",
+        params={"fallback": "false"},
+        # ``paths-info`` is a Form endpoint per huggingface_hub's wire
+        # protocol; HF accepts repeated ``paths`` values, not a JSON body.
+        data={"paths": "train.jsonl"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_paths_info_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
+    response = await outsider_client.post(
+        "/api/datasets/acme-labs/private-dataset/paths-info/main",
+        params={"fallback": "false"},
+        data={"paths": "train.jsonl"},
+    )
+    _assert_repo_not_found(response)
+
+
+# ---- resolve HEAD / GET surfaces ------------------------------------------
+
+
+async def test_resolve_head_anon_on_private_dataset_returns_repo_not_found(client):
+    response = await client.head(
+        "/datasets/acme-labs/private-dataset/resolve/main/train.jsonl",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_resolve_head_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
+    response = await outsider_client.head(
+        "/datasets/acme-labs/private-dataset/resolve/main/train.jsonl",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_resolve_get_anon_on_private_dataset_returns_repo_not_found(client):
+    response = await client.get(
+        "/datasets/acme-labs/private-dataset/resolve/main/train.jsonl",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+async def test_resolve_get_outsider_on_private_dataset_returns_repo_not_found(outsider_client):
+    response = await outsider_client.get(
+        "/datasets/acme-labs/private-dataset/resolve/main/train.jsonl",
+        params={"fallback": "false"},
+    )
+    _assert_repo_not_found(response)
+
+
+# ---------------------------------------------------------------------------
+# huggingface_hub interop — drive a real client and assert the dispatched
+# exception class. This is the proof that our wire shape actually maps to
+# the right named exception on the client side.
+# ---------------------------------------------------------------------------
+
+
+async def test_hf_api_dataset_info_anon_raises_repository_not_found(live_server_url):
+    """Anonymous ``HfApi.dataset_info`` against a private hkub repo must raise
+    ``RepositoryNotFoundError`` — not the generic ``HfHubHTTPError`` we
+    emitted before #76 closed."""
+    api = HfApi(endpoint=live_server_url)  # no token → anonymous
+    with pytest.raises(RepositoryNotFoundError):
+        await asyncio.to_thread(
+            api.dataset_info,
+            "acme-labs/private-dataset",
+        )
+
+
+async def test_hf_api_dataset_info_outsider_raises_repository_not_found(
+    live_server_url, outsider_client
+):
+    """Authed-no-access caller is intentionally indistinguishable from
+    anonymous on the wire (privacy-preserving Option A from #76).
+    ``HfApi`` driven by the outsider's token must raise
+    ``RepositoryNotFoundError``."""
+    # Pull the outsider's token by minting one via the API token endpoint.
+    # We reuse the session cookie the fixture already established to
+    # request a fresh API token; pretty close to the real-world flow
+    # where a user creates a token in settings.
+    token_response = await outsider_client.post(
+        "/api/auth/tokens/create",
+        json={"name": f"hf-interop-{id(object())}"},
+    )
+    token_response.raise_for_status()
+    token = token_response.json()["token"]
+
+    api = HfApi(endpoint=live_server_url, token=token)
+    with pytest.raises(RepositoryNotFoundError):
+        await asyncio.to_thread(
+            api.dataset_info,
+            "acme-labs/private-dataset",
+        )
+
+
+async def test_hf_hub_download_anon_on_private_dataset_raises_repository_not_found(
+    live_server_url, tmp_path
+):
+    """``hf_hub_download`` is the read path most users hit. Anonymous
+    download from a private repo must raise ``RepositoryNotFoundError`` —
+    the contract that lets ``transformers``, ``datasets``, etc. produce
+    actionable error messages instead of "HTTP 401 / 403"."""
+    with pytest.raises(RepositoryNotFoundError):
+        await asyncio.to_thread(
+            hf_hub_download,
+            repo_id="acme-labs/private-dataset",
+            filename="train.jsonl",
+            repo_type="dataset",
+            endpoint=live_server_url,
+            cache_dir=str(tmp_path / "hf-cache"),
+        )

--- a/test/kohakuhub/auth/test_permissions.py
+++ b/test/kohakuhub/auth/test_permissions.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from kohakuhub.auth.permissions import (
+    RepoReadDeniedError,
     check_namespace_permission,
     check_repo_delete_permission,
     check_repo_read_permission,
@@ -48,5 +49,11 @@ def test_repo_read_write_and_delete_permissions_cover_private_org_repo():
     with pytest.raises(HTTPException):
         check_repo_delete_permission(private_repo, visitor)
 
-    with pytest.raises(HTTPException):
+    # Read-denial cases (anonymous-on-private and authed-no-access) now
+    # raise ``RepoReadDeniedError`` rather than ``HTTPException``; the
+    # global handler in ``main.py`` translates that into HF's
+    # ``404 + X-Error-Code: RepoNotFound`` wire shape.
+    with pytest.raises(RepoReadDeniedError):
         check_repo_read_permission(private_repo, outsider)
+    with pytest.raises(RepoReadDeniedError):
+        check_repo_read_permission(private_repo, None)

--- a/test/kohakuhub/auth/test_permissions_unit.py
+++ b/test/kohakuhub/auth/test_permissions_unit.py
@@ -33,17 +33,26 @@ def test_namespace_permission_covers_admin_bypass_and_common_failures(monkeypatc
 
 
 def test_repo_read_permission_covers_admin_public_owner_and_unauthenticated_paths(monkeypatch):
-    public_repo = SimpleNamespace(namespace="owner", full_id="owner/public", private=False)
-    private_repo = SimpleNamespace(namespace="owner", full_id="owner/private", private=True)
+    public_repo = SimpleNamespace(
+        namespace="owner", full_id="owner/public", repo_type="model", private=False
+    )
+    private_repo = SimpleNamespace(
+        namespace="owner", full_id="owner/private", repo_type="model", private=True
+    )
     owner = SimpleNamespace(username="owner")
 
     assert permissions.check_repo_read_permission(private_repo, None, is_admin=True) is True
     assert permissions.check_repo_read_permission(public_repo, None) is True
     assert permissions.check_repo_read_permission(private_repo, owner) is True
 
-    with pytest.raises(HTTPException) as unauth_exc:
+    # Anonymous-on-private now collapses to RepoReadDeniedError (privacy-
+    # preserving Option A from #76 — same wire shape as authed-no-access,
+    # both translate to ``404 + X-Error-Code: RepoNotFound`` in main.py's
+    # global handler).
+    with pytest.raises(permissions.RepoReadDeniedError) as unauth_exc:
         permissions.check_repo_read_permission(private_repo, None)
-    assert unauth_exc.value.status_code == 401
+    assert unauth_exc.value.repo_id == "owner/private"
+    assert unauth_exc.value.repo_type == "model"
 
 
 def test_repo_write_and_delete_permission_cover_admin_owner_and_org_admin(monkeypatch):


### PR DESCRIPTION
## Summary

Closes #76. Aligns hkub's permission-denial wire shape with HuggingFace's authed-style `RepoNotFound` contract — anonymous-on-private and authed-no-access both collapse to **`404 + X-Error-Code: RepoNotFound`** with an empty body. `huggingface_hub.utils._http.hf_raise_for_status` then dispatches `RepositoryNotFoundError` on the client, which is what `transformers`, `datasets`, `huggingface_hub` itself, etc. key off for actionable error messages.

## Empirical anchor

Re-probed live against `https://huggingface.co` 2026-05-05 (anon; authed shape from PR #77's 2026-04-30 capture, well-anchored), plus a synthetic round-trip through `hf_raise_for_status` (hf_hub 1.11.0) for every wire shape:

| Wire shape | hf_hub raises |
|---|---|
| 401 bare + `Invalid username or password.` (HF anon anti-enum) | `RepositoryNotFoundError` |
| 404 + `X-Error-Code: RepoNotFound` (HF authed) | `RepositoryNotFoundError` |
| 401 / 403 + `X-Error-Code: GatedRepo` | `GatedRepoError` |
| 404 + `X-Error-Code: EntryNotFound` | `EntryNotFoundError` |
| 404 + `X-Error-Code: RevisionNotFound` | `RevisionNotFoundError` |
| 403 + `X-Error-Message: "Access to this resource is disabled."` | `DisabledRepoError` |
| Plain 404 / 403 (no code, no anti-enum match) | generic `HfHubHTTPError` ← what hkub did *wrong* on outsider-on-private |

Both anon-anti-enum and authed-RepoNotFound dispatch to `RepositoryNotFoundError` on the client. hkub picks the **authed shape** for emit (issue #76 Option A): same client exception, privacy-preserving (no enum leak between "missing" and "private"), simpler than mirroring HF's branch.

## Pre-fix gap (most acute)

| Caller | Surface | Pre-fix wire | hf_hub raises |
|---|---|---|---|
| Anonymous → private hkub repo | resolve HEAD | 401 bare (no headers) | `RepositoryNotFoundError` (accidental — URL-pattern branch) |
| Authed-no-access → private hkub repo | tree / paths-info / resolve | **403 + `{"detail": "..."}`** | **generic `HfHubHTTPError`** ← gap |
| Authed-no-access → private hkub repo | info | 404 + RepoNotFound (ad-hoc translation) | `RepositoryNotFoundError` ✓ |

The ad-hoc translation pattern was duplicated in `info.py` and `_get_file_metadata`'s missing-repo path, but missing from tree / paths-info / resolve / commits / likes / stats / xet-lookup / branches. This PR lifts that translation into a global FastAPI exception handler, removing all per-endpoint duplication.

## Implementation

- `auth/permissions.py` — new `RepoReadDeniedError` exception. `check_repo_read_permission` raises it for both anon-on-private and authed-no-access. **Inherits `Exception` (not `HTTPException`)** precisely so the fallback decorator's `except HTTPException` does not catch it: masked private repos must not trigger an upstream chain probe.
- `main.py` — global `@app.exception_handler(RepoReadDeniedError)` that returns `hf_repo_not_found(...)`. Centralizes the wire-shape decision in one place; every read endpoint that calls `check_repo_read_permission` gets the privacy-preserving translation for free.
- `info.py` / `files.py` — removed the per-endpoint ad-hoc `try/except HTTPException` translations (now subsumed by the global handler). Net deletion + comments pointing to the new flow.
- `repo/utils/hf.py` — added `hf_disabled_repo()` helper that emits HF's exact `X-Error-Message: "Access to this resource is disabled."` string with **no** `X-Error-Code` (DisabledRepoError dispatch is keyed off the message string verbatim). No call site yet; reserved for a future moderation feature. Plus `HFErrorCode` docstring labels its KohakuHub-only extensions distinctly from the four HF-recognized codes.
- `fallback/probe_local.py` — chain-tester probe also has to honour the new exception (it bypasses both `with_repo_fallback` and the FastAPI app handler by calling the unwrapped inner directly), so it reproduces the conversion locally. The `RepoReadDeniedError` import is intentionally lazy inside the function: the test harness reloads `kohakuhub.auth.permissions` between sessions, so a module-level import would freeze the old class identity and `isinstance()` would silently return False even for legitimate raises (caught live via temporary instrumentation; the comment block in the file documents the failure mode).

## Tests

**New: `test/kohakuhub/api/test_repo_read_denial_hf_alignment.py`** — 15 tests:

- Wire-shape: 12 RED-first tests across info / tree / paths-info / resolve HEAD/GET × {anon, outsider}, plus 2 owner regression guards (member info / tree still resolve to 200, plus paths-info coverage). Each asserts `404 + X-Error-Code: RepoNotFound + X-Error-Message + empty body`.
- huggingface_hub interop: 3 tests driving `HfApi.dataset_info` (anon + outsider) and `hf_hub_download` (anon) against a live test server, asserting the dispatched exception class is `RepositoryNotFoundError`.
- All requests use `?fallback=false` to isolate the **local** wire shape — fallback chain interaction is a separate concern covered by the fallback test suite.

**New helper tests in `test_hf.py`** for `hf_disabled_repo()`:
- Emits HF's exact message string, no `X-Error-Code`, empty body.
- End-to-end through `hf_raise_for_status` raising `DisabledRepoError` (the proof that the wire shape works).

**Updates to `test_permissions.py`, `test_permissions_unit.py`, `test_files_unit.py`** — expect `RepoReadDeniedError` for read denials (write/delete denials still raise `HTTPException`, unchanged).

## Test plan

- [x] New tests pass (`pytest test/kohakuhub/api/test_repo_read_denial_hf_alignment.py` — 15/15)
- [x] New helper tests pass (`pytest test/kohakuhub/api/repo/utils/test_hf.py` — added 3, all pass)
- [x] Updated permission tests pass (`pytest test/kohakuhub/auth/`)
- [x] Targeted regression: commit + fallback + huggingface_hub interop suites all green
- [x] Manual matrix verification: live HF probes (anon) confirm exact wire shapes; hf_raise_for_status round-trips confirm exception class

## Out of scope (deferred)

- Write/delete permission denials — genuine `403`, no privacy concern (you can see the public repo, just can't modify it). Continue to raise `HTTPException(403)`; not part of #76.
- Frontend changes — SPA's `http-errors.js` already handles both `RepoNotFound` and bare 401 as `NOT_FOUND` (the privacy-preserving outsider UX shifts from "Forbidden" to "Not found", which is the design intent of Option A).
- `hf_disabled_repo()` wiring — helper added but no call site yet; reserved for a future moderation feature.
