### PR TITLE
fix(repo/crud): accept huggingface_hub>=1.x visibility on create

### DIFF
--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -92,12 +92,23 @@ def _repo_exists_response(
 
 
 class CreateRepoPayload(BaseModel):
-    """Payload for repository creation."""
+    """Payload for repository creation.
+
+    Accepts the two on-the-wire shapes ``huggingface_hub`` clients use:
+
+    * ``huggingface_hub<1`` sends ``{"private": true}`` directly.
+    * ``huggingface_hub>=1.x`` resolves ``private=True`` into
+      ``{"visibility": "private"}`` and no longer sends the legacy
+      ``private`` field. The same dual-shape handling lives in the
+      ``update_repo_settings`` payload (commit 19c2a5c); this mirror
+      keeps the create endpoint compatible with both client versions.
+    """
 
     type: RepoType = "model"
     name: str
     organization: Optional[str] = None
-    private: bool = False
+    private: Optional[bool] = None
+    visibility: Optional[str] = None
     sdk: Optional[str] = None
 
 
@@ -202,6 +213,34 @@ async def _cleanup_orphan_namespace_if_safe(
     return deleted_count > 0
 
 
+def _resolve_create_repo_private(payload: CreateRepoPayload) -> bool:
+    """Collapse ``private`` and ``visibility`` into a single bool.
+
+    Mirrors the resolution used by ``update_repo_settings`` so the create
+    endpoint is compatible with both ``huggingface_hub<1`` (sends
+    ``private``) and ``huggingface_hub>=1.x`` (sends ``visibility``).
+    Explicit ``private`` takes precedence; ``visibility`` is only consulted
+    when ``private`` was not sent. Defaults to public when neither is set.
+    """
+    if payload.private is not None:
+        return bool(payload.private)
+    if payload.visibility is None:
+        return False
+    if payload.visibility == "private":
+        return True
+    if payload.visibility == "public":
+        return False
+    raise HTTPException(
+        400,
+        detail={
+            "error": (
+                "Unsupported repository visibility. "
+                "Only 'public' and 'private' are supported."
+            )
+        },
+    )
+
+
 @router.post("/repos/create")
 async def create_repo(
     payload: CreateRepoPayload, user: User = Depends(get_current_user)
@@ -218,6 +257,7 @@ async def create_repo(
     logger.info(
         f"Creating repository: {payload.organization or user.username}/{payload.name}"
     )
+    resolved_private = _resolve_create_repo_private(payload)
     namespace = payload.organization or user.username
 
     # Check if user has permission to use this namespace
@@ -305,7 +345,7 @@ async def create_repo(
         namespace=namespace,
         name=payload.name,
         full_id=full_id,
-        defaults={"private": payload.private, "owner": user},
+        defaults={"private": resolved_private, "owner": user},
     )
 
     # Strict-freshness invalidation (#79): a fallback ghost binding for

--- a/test/kohakuhub/api/repo/routers/test_crud.py
+++ b/test/kohakuhub/api/repo/routers/test_crud.py
@@ -24,41 +24,6 @@ async def test_create_repository_and_reject_normalized_duplicate(owner_client):
     assert body["repo_id"] == "owner/sandbox-repo"
 
 
-async def test_create_repo_visibility_public_creates_public_repo(owner_client):
-    """``visibility="public"`` (huggingface_hub>=1.x shape with
-    ``private=False``) must round-trip as a public repo. Pairs with the
-    ``visibility="private"`` path covered through the live hf-client e2e
-    test in ``test_huggingface_hub_deep.py`` — together they exercise
-    both branches of the visibility resolver in ``crud.py`` so the
-    patch-coverage gate stays clean."""
-    response = await owner_client.post(
-        "/api/repos/create",
-        json={"type": "model", "name": "visibility-public-repo", "visibility": "public"},
-    )
-    assert response.status_code == 200
-    assert response.json()["repo_id"] == "owner/visibility-public-repo"
-
-    info = await owner_client.get("/api/models/owner/visibility-public-repo")
-    assert info.status_code == 200
-    assert info.json()["private"] is False
-
-
-async def test_create_repo_unknown_visibility_returns_400(owner_client):
-    """The resolver must reject visibility values it cannot map to a
-    private bool. Without this guard a typo like ``"hidden"`` would be
-    silently treated as public — masking client-side bugs and breaking
-    HF API symmetry with ``update_repo_settings``."""
-    response = await owner_client.post(
-        "/api/repos/create",
-        json={"type": "model", "name": "visibility-bogus-repo", "visibility": "hidden"},
-    )
-    assert response.status_code == 400
-    body = response.json()
-    error_text = body.get("detail", {}).get("error", "") if isinstance(body.get("detail"), dict) else str(body)
-    assert "visibility" in error_text.lower()
-    assert "public" in error_text and "private" in error_text
-
-
 async def test_admin_can_delete_empty_org_repository(admin_client, owner_client):
     create_response = await owner_client.post(
         "/api/repos/create",

--- a/test/kohakuhub/api/repo/routers/test_crud.py
+++ b/test/kohakuhub/api/repo/routers/test_crud.py
@@ -24,6 +24,41 @@ async def test_create_repository_and_reject_normalized_duplicate(owner_client):
     assert body["repo_id"] == "owner/sandbox-repo"
 
 
+async def test_create_repo_visibility_public_creates_public_repo(owner_client):
+    """``visibility="public"`` (huggingface_hub>=1.x shape with
+    ``private=False``) must round-trip as a public repo. Pairs with the
+    ``visibility="private"`` path covered through the live hf-client e2e
+    test in ``test_huggingface_hub_deep.py`` — together they exercise
+    both branches of the visibility resolver in ``crud.py`` so the
+    patch-coverage gate stays clean."""
+    response = await owner_client.post(
+        "/api/repos/create",
+        json={"type": "model", "name": "visibility-public-repo", "visibility": "public"},
+    )
+    assert response.status_code == 200
+    assert response.json()["repo_id"] == "owner/visibility-public-repo"
+
+    info = await owner_client.get("/api/models/owner/visibility-public-repo")
+    assert info.status_code == 200
+    assert info.json()["private"] is False
+
+
+async def test_create_repo_unknown_visibility_returns_400(owner_client):
+    """The resolver must reject visibility values it cannot map to a
+    private bool. Without this guard a typo like ``"hidden"`` would be
+    silently treated as public — masking client-side bugs and breaking
+    HF API symmetry with ``update_repo_settings``."""
+    response = await owner_client.post(
+        "/api/repos/create",
+        json={"type": "model", "name": "visibility-bogus-repo", "visibility": "hidden"},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    error_text = body.get("detail", {}).get("error", "") if isinstance(body.get("detail"), dict) else str(body)
+    assert "visibility" in error_text.lower()
+    assert "public" in error_text and "private" in error_text
+
+
 async def test_admin_can_delete_empty_org_repository(admin_client, owner_client):
     create_response = await owner_client.post(
         "/api/repos/create",

--- a/test/kohakuhub/api/test_huggingface_hub_deep.py
+++ b/test/kohakuhub/api/test_huggingface_hub_deep.py
@@ -836,6 +836,72 @@ async def test_create_repo_private_flag_is_honored_across_hf_versions(
         await _run(outsider_api.repo_info, repo_id)
 
 
+async def test_create_repo_private_false_round_trips_as_public(
+    live_server_url, hf_api_token
+):
+    """``HfApi.create_repo(repo_id, private=False)`` must produce a
+    public repo on every client version.
+
+    The two on-the-wire shapes are also asymmetric on the public side:
+
+    * ``huggingface_hub<1`` sends ``{"private": false}`` directly,
+      hitting the explicit-``private`` branch of the backend resolver.
+    * ``huggingface_hub>=1.x`` resolves ``private=False`` into
+      ``{"visibility": "public"}`` (see ``_resolve_repo_visibility`` in
+      ``hf_api.py``), hitting the ``visibility=="public"`` branch
+      instead.
+
+    Routing through the real client on the matrix exercises *both*
+    branches across the CI matrix — v0 cells cover ``private``
+    resolution and v1 cells cover ``visibility`` resolution — so a
+    regression in either branch surfaces here.
+    """
+    api = _api(live_server_url, hf_api_token)
+    repo_id = "owner/hf-deep-create-public"
+    await _run(api.create_repo, repo_id, private=False)
+
+    info = await _run(api.repo_info, repo_id)
+    assert info.private is False, (
+        "create_repo(private=False) produced a private repo — the "
+        "backend mis-resolved the public path. v0 sends 'private=False' "
+        "and v1 sends 'visibility=public'; both must collapse to public."
+    )
+
+
+async def test_create_repo_rejects_unknown_visibility_value(
+    live_server_url, hf_api_token
+):
+    """The visibility resolver must reject values it cannot map to a
+    private bool with a 400 (and a stable error message).
+
+    The real ``huggingface_hub`` client validates ``visibility``
+    client-side (``RepoVisibility_T = Literal["public", "private",
+    "protected"]`` in ``hf_api.py``) and refuses to send a typo like
+    ``"hidden"`` over the wire — so the only way to drive this
+    server-side branch is a direct HTTP request alongside the
+    hf-client e2e flow. Without this guard a typo would silently
+    produce a public repo, masking client-side bugs and breaking
+    symmetry with the same guard in ``update_repo_settings``.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.post(
+            f"{live_server_url}/api/repos/create",
+            json={
+                "type": "model",
+                "name": "hf-deep-create-bogus-visibility",
+                "visibility": "hidden",
+            },
+            headers={"Authorization": f"Bearer {hf_api_token}"},
+        )
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail") if isinstance(body, dict) else None
+    error_text = detail.get("error", "") if isinstance(detail, dict) else str(body)
+    assert "visibility" in error_text.lower()
+    assert "public" in error_text and "private" in error_text
+
+
 async def test_update_repo_settings_visibility_field_is_honored(
     live_server_url, hf_api_token
 ):

--- a/test/kohakuhub/api/test_huggingface_hub_deep.py
+++ b/test/kohakuhub/api/test_huggingface_hub_deep.py
@@ -776,6 +776,66 @@ async def test_entry_not_found_raises_named_error_on_download(
         )
 
 
+async def test_create_repo_private_flag_is_honored_across_hf_versions(
+    live_server_url, hf_api_token, outsider_hf_api_token
+):
+    """``HfApi.create_repo(repo_id, private=True)`` must produce a real
+    private repo regardless of which on-the-wire shape the installed
+    client uses.
+
+    Two shapes exist in the wild and the backend must accept both:
+
+    * ``huggingface_hub<1`` — the client sends ``{"private": true}`` in
+      the create_repo body.
+    * ``huggingface_hub>=1.x`` — the client resolves ``private=True`` via
+      ``_resolve_repo_visibility`` into ``payload["visibility"] = "private"``
+      and *no longer sends* the legacy ``private`` field.
+
+    The end-to-end shape of "private" matters here, not just a single
+    metadata field. This test drives the whole loop through the real
+    ``huggingface_hub`` client (no raw HTTP) so a regression in any link
+    of the chain — wire parsing, DB column write, owner read-back,
+    outsider hidden-private semantics — surfaces as a single failure:
+
+    1. owner ``create_repo(private=True)`` succeeds;
+    2. owner ``repo_info`` reports ``private=True``;
+    3. owner ``repo_exists`` is ``True``;
+    4. outsider ``repo_exists`` is ``False`` (hidden-private);
+    5. outsider ``repo_info`` raises ``RepositoryNotFoundError``
+       (no 401/403 existence leak — same contract as
+       ``test_hidden_private_repo_is_invisible_to_outsider``).
+
+    The same dual-shape handling already lives in
+    ``update_repo_settings`` (commit 19c2a5c); this extends it to
+    ``create_repo``.
+    """
+    owner_api = _api(live_server_url, hf_api_token)
+    outsider_api = _api(live_server_url, outsider_hf_api_token)
+    repo_id = "owner/hf-deep-create-private"
+
+    await _run(owner_api.create_repo, repo_id, private=True)
+
+    # 1. Owner sees the repo as private through repo_info.
+    info = await _run(owner_api.repo_info, repo_id)
+    assert info.private is True, (
+        "create_repo(private=True) produced a public repo — the backend "
+        "likely dropped the visibility/private field sent by this client "
+        "version. v0 sends 'private', v1 sends 'visibility'; the create "
+        "endpoint must accept both."
+    )
+
+    # 2. Owner can confirm existence.
+    assert await _run(owner_api.repo_exists, repo_id) is True
+
+    # 3. Outsider must get the hidden-private response shape: existence
+    # check returns False and direct info raises 404 — proving the
+    # ``private=True`` flag is enforced by the access-control layer, not
+    # just stamped onto a metadata field.
+    assert await _run(outsider_api.repo_exists, repo_id) is False
+    with pytest.raises(RepositoryNotFoundError):
+        await _run(outsider_api.repo_info, repo_id)
+
+
 async def test_update_repo_settings_visibility_field_is_honored(
     live_server_url, hf_api_token
 ):


### PR DESCRIPTION
## Summary

- `huggingface_hub>=1.x` resolves `create_repo(private=True)` client-side into `{"visibility": "private"}` and **stops sending** the legacy `private` field (see `_resolve_repo_visibility` in `huggingface_hub/hf_api.py:4436-4440`). KohakuHub's `CreateRepoPayload` only accepted `private`, so v1 clients **silently produced public repos** when asking for private.
- Mirrors the dual-shape resolution `update_repo_settings` already does (commit 19c2a5c) — `private` takes precedence, `visibility` is consulted only when `private` is omitted, unknown values return 400. Behavior for `huggingface_hub<1` (which sends `private` directly) is unchanged.
- TDD: new e2e test exercises the full privacy loop through the real `huggingface_hub` Python client — `create_repo(private=True)` → owner `repo_info` reports `private=True` → owner `repo_exists=True` → outsider `repo_exists=False` → outsider `repo_info` raises `RepositoryNotFoundError`. Failed RED on `hf 1.11.0` against `main` (`info.private` came back `False`); passes GREEN after the fix on the same version. The CI matrix already runs `0.20.3 / 0.30.2 / 0.36.2 / 1.0.1 / 1.6.0 / latest`, so both wire shapes are covered.

## Test plan

- [x] New test fails RED on `main` (proves bug reproduction)
- [x] New test passes GREEN with the fix on `huggingface_hub==1.11.0`
- [x] Full `test_huggingface_hub_deep.py` (28) + `test_huggingface_hub_compat.py` (6) + `test_huggingface_hub_concurrency.py` (4) + `test_huggingface_hub_surface.py` (9) green locally
- [x] `test/kohakuhub/api/repo/routers/` + `test/kohakuhub/api/commit/routers/` (no regressions on `private: bool = False` → `Optional[bool] = None` schema change)
- [ ] CI matrix green across `hf 0.20.3 / 0.30.2 / 0.36.2 / 1.0.1 / 1.6.0 / latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)