### PR TITLE
fix(repo): free a renamed repo's name immediately (#93)

### DIFF
--- a/scripts/db_migrations/016_repository_lakefs_repo.py
+++ b/scripts/db_migrations/016_repository_lakefs_repo.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Migration 016: Persist the LakeFS repository id on Repository.
+
+Adds:
+- Repository: lakefs_repo (NULL = derive from repo_type + full_id, legacy behaviour)
+
+Why: the LakeFS repository id is currently derived from the repo id on every
+call (utils/lakefs.py: lakefs_repo_name). Because the derivation is
+deterministic, a repo id that is freed by a rename maps straight back to the
+LakeFS repository the rename just deleted. LakeFS deletes repositories
+asynchronously, so re-creating the freed name inside the cleanup window fails
+with `409 not unique` (see issue #93). Storing the id lets it be allocated
+instead of derived, so a new repository under a just-freed name can take a
+fresh id and never collide with a pending deletion.
+
+Existing rows are backfilled with the currently-derived value, so the stored id
+keeps pointing at the LakeFS repository that already holds the data.
+
+NOTE: the derivation below is a FROZEN COPY of lakefs_repo_name() as of this
+migration, deliberately not an import. A future change to that function must not
+retroactively change what this backfill writes for repositories that were
+created under the old scheme.
+"""
+
+import hashlib
+import os
+import re
+import sys
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+# Add db_migrations to path (for _migration_utils)
+sys.path.insert(0, os.path.dirname(__file__))
+
+from kohakuhub.db import db
+from kohakuhub.config import cfg
+from _migration_utils import should_skip_due_to_future_migrations, check_column_exists
+
+MIGRATION_NUMBER = 16
+
+_BASE36_DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+def _frozen_base36(num: int) -> str:
+    """Base36-encode with the 0-9a-z alphabet (matches numpy.base_repr(...).lower())."""
+    if num == 0:
+        return "0"
+    out = []
+    while num:
+        num, rem = divmod(num, 36)
+        out.append(_BASE36_DIGITS[rem])
+    return "".join(reversed(out))
+
+
+def _frozen_hash_to_112bit(data: str) -> int:
+    """SHA3-224 folded to 112 bits by XORing its two halves."""
+    digest = hashlib.sha3_224(data.encode()).digest()  # 28 bytes
+    return int.from_bytes(digest[:14], "big") ^ int.from_bytes(digest[14:], "big")
+
+
+def _frozen_sanitize_repo_id(repo_id: str) -> str:
+    """Reduce a repo id to LakeFS-safe characters (a-z, 0-9, hyphen)."""
+    safe = repo_id.replace("/", "-").replace("_", "-").replace(".", "-")
+    safe = re.sub(r"[^a-z0-9-]", "-", safe.lower())
+    safe = re.sub(r"-+", "-", safe)
+    return safe.strip("-")
+
+
+def frozen_lakefs_repo_name(repo_type: str, repo_id: str) -> str:
+    """Frozen copy of lakefs_repo_name: {type_char}-{safe_id[:38]}-{hash_b36:>022}."""
+    type_char = {"model": "m", "dataset": "d", "space": "s"}.get(repo_type, "m")
+    safe_id = _frozen_sanitize_repo_id(repo_id)[:38]
+    hash_suffix = _frozen_base36(_frozen_hash_to_112bit(repo_id)).zfill(22)
+    return f"{type_char}-{safe_id}-{hash_suffix}"
+
+
+def is_applied(db, cfg):
+    """Check if THIS migration has been applied.
+
+    Returns True if Repository.lakefs_repo column exists.
+    """
+    return check_column_exists(db, cfg, "repository", "lakefs_repo")
+
+
+def check_migration_needed():
+    """Check if this migration needs to run by checking if the column exists."""
+    cursor = db.cursor()
+
+    if cfg.app.db_backend == "postgres":
+        cursor.execute(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name='repository' AND column_name='lakefs_repo'
+        """
+        )
+        return cursor.fetchone() is None
+    else:
+        # SQLite: Check via PRAGMA
+        cursor.execute("PRAGMA table_info(repository)")
+        columns = [row[1] for row in cursor.fetchall()]
+        return "lakefs_repo" not in columns
+
+
+def _backfill_lakefs_repo():
+    """Fill lakefs_repo for rows that do not have it yet.
+
+    Runs inside the caller's transaction. Values are computed from the frozen
+    derivation so they match the LakeFS repositories that already exist.
+    """
+    cursor = db.cursor()
+    cursor.execute(
+        "SELECT id, repo_type, namespace, name FROM repository WHERE lakefs_repo IS NULL"
+    )
+    rows = cursor.fetchall()
+
+    if not rows:
+        print("  - No rows to backfill")
+        return
+
+    placeholder = "%s" if cfg.app.db_backend == "postgres" else "?"
+    update_sql = (
+        f"UPDATE repository SET lakefs_repo = {placeholder} "
+        f"WHERE id = {placeholder} AND lakefs_repo IS NULL"
+    )
+
+    seen = {}
+    duplicates = 0
+    for repo_id, repo_type, namespace, name in rows:
+        derived = frozen_lakefs_repo_name(repo_type, f"{namespace}/{name}")
+        if derived in seen:
+            # Two rows deriving the same id would mean the existing scheme already
+            # had them sharing one LakeFS repository. Report instead of failing:
+            # the column is nullable and reads fall back to the derivation, so a
+            # duplicate is no worse than today's behaviour.
+            duplicates += 1
+            print(
+                f"  ! Duplicate derived id {derived}: "
+                f"row {repo_id} collides with row {seen[derived]}"
+            )
+        else:
+            seen[derived] = repo_id
+        cursor.execute(update_sql, (derived, repo_id))
+
+    print(f"  ✓ Backfilled Repository.lakefs_repo for {len(rows)} row(s)")
+    if duplicates:
+        print(
+            f"  ! {duplicates} duplicate derived id(s) found — do NOT add a unique "
+            f"constraint until these are resolved"
+        )
+    else:
+        print(f"  ✓ All {len(rows)} backfilled id(s) are distinct")
+
+
+def migrate_sqlite():
+    """Migrate SQLite database.
+
+    Note: This function runs inside a transaction (db.atomic()).
+    Do NOT call db.commit() or db.rollback() inside this function.
+    """
+    cursor = db.cursor()
+
+    try:
+        cursor.execute(
+            "ALTER TABLE repository ADD COLUMN lakefs_repo VARCHAR(255) DEFAULT NULL"
+        )
+        print("  ✓ Added Repository.lakefs_repo")
+    except Exception as e:
+        if "duplicate column" in str(e).lower():
+            print("  - Repository.lakefs_repo already exists")
+        else:
+            raise
+
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS repository_lakefs_repo ON repository (lakefs_repo)"
+    )
+    print("  ✓ Ensured index repository_lakefs_repo")
+
+    _backfill_lakefs_repo()
+
+
+def migrate_postgres():
+    """Migrate PostgreSQL database.
+
+    Note: This function runs inside a transaction (db.atomic()).
+    Do NOT call db.commit() or db.rollback() inside this function.
+    """
+    cursor = db.cursor()
+
+    try:
+        cursor.execute(
+            "ALTER TABLE repository ADD COLUMN lakefs_repo VARCHAR(255) DEFAULT NULL"
+        )
+        print("  ✓ Added Repository.lakefs_repo")
+    except Exception as e:
+        if "already exists" in str(e).lower():
+            print("  - Repository.lakefs_repo already exists")
+            # Don't need to rollback - the exception will propagate and rollback
+            # the entire transaction
+        else:
+            raise
+
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS repository_lakefs_repo ON repository (lakefs_repo)"
+    )
+    print("  ✓ Ensured index repository_lakefs_repo")
+
+    _backfill_lakefs_repo()
+
+
+def run():
+    """Run this migration.
+
+    IMPORTANT: Do NOT call db.close() in finally block!
+    The db connection is managed by run_migrations.py and should stay open
+    across all migrations to avoid stdout/stderr closure issues on Windows.
+    """
+    db.connect(reuse_if_open=True)
+
+    try:
+        # Pre-flight checks (outside transaction for performance)
+        if should_skip_due_to_future_migrations(MIGRATION_NUMBER, db, cfg):
+            print("Migration 016: Skipped (superseded by future migration)")
+            return True
+
+        if not check_migration_needed():
+            print("Migration 016: Already applied (column exists)")
+            return True
+
+        print("Migration 016: Adding Repository.lakefs_repo...")
+
+        # Run migration in a transaction - will auto-rollback on exception
+        with db.atomic():
+            if cfg.app.db_backend == "postgres":
+                migrate_postgres()
+            else:
+                migrate_sqlite()
+
+        print("Migration 016: ✓ Completed")
+        return True
+
+    except Exception as e:
+        # Transaction automatically rolled back if we reach here
+        print(f"Migration 016: ✗ Failed - {e}")
+        print("  All changes have been rolled back")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    # NOTE: No finally block - db connection stays open
+
+
+if __name__ == "__main__":
+    success = run()
+    sys.exit(0 if success else 1)

--- a/scripts/dev/up_infra.sh
+++ b/scripts/dev/up_infra.sh
@@ -40,6 +40,11 @@ container_exists() {
   docker ps -a --format '{{.Names}}' | grep -Fxq "$1"
 }
 
+docker_is_rootless() {
+  docker info --format '{{range .SecurityOptions}}{{.}} {{end}}' 2>/dev/null |
+    grep -q 'name=rootless'
+}
+
 container_running() {
   docker ps --format '{{.Names}}' | grep -Fxq "$1"
 }
@@ -127,10 +132,40 @@ ensure_lakefs() {
   fi
 
   # Match the host user so LakeFS can write to the persisted metadata directory.
+  # That uid has no /etc/passwd entry in the image, so Docker falls back to
+  # HOME=/ and the config's "~/lakefs/data/cache" lands on the cache bind mount.
+  #
+  # Rootless Docker cannot use the host ids: they sit outside the container's id
+  # mapping and runc aborts with "setgroups: invalid argument". There, container
+  # root is already mapped to the invoking host user, so run as root and set
+  # HOME explicitly to keep the cache path pointing at the same bind mount
+  # (the image default user would be lakefs/uid 100, which can write neither).
+  local -a user_args=()
+  if docker_is_rootless; then
+    echo "Rootless Docker detected; running ${LAKEFS_CONTAINER} as container root"
+    user_args=(--user 0:0 -e HOME=/)
+  else
+    user_args=(--user "$(id -u):$(id -g)")
+  fi
+
+  # A Docker client with a "proxies" block in ~/.docker/config.json injects
+  # HTTP_PROXY/NO_PROXY into every container. LakeFS reaches MinIO by container
+  # name, and NO_PROXY is matched against the hostname rather than the resolved
+  # address, so the container-network CIDRs listed there do not exempt it: the
+  # S3 calls get routed to the host proxy, which cannot resolve an internal
+  # container name, and repository creation fails with a 503. Keep this
+  # container-to-container hop direct.
+  local no_proxy_value="${MINIO_CONTAINER},localhost,127.0.0.1,::1"
+  if [[ -n "${NO_PROXY:-${no_proxy:-}}" ]]; then
+    no_proxy_value="${MINIO_CONTAINER},${NO_PROXY:-${no_proxy}}"
+  fi
+
   docker run -d \
     --name "${LAKEFS_CONTAINER}" \
     --network "${NETWORK_NAME}" \
-    --user "$(id -u):$(id -g)" \
+    ${user_args[@]+"${user_args[@]}"} \
+    -e "NO_PROXY=${no_proxy_value}" \
+    -e "no_proxy=${no_proxy_value}" \
     -p 28000:28000 \
     -e LAKEFS_DATABASE_TYPE=local \
     -e LAKEFS_DATABASE_LOCAL_PATH=/var/lakefs/data/metadata.db \

--- a/src/kohakuhub/api/admin/routers/repositories.py
+++ b/src/kohakuhub/api/admin/routers/repositories.py
@@ -8,7 +8,7 @@ from kohakuhub.db_operations import get_file
 from kohakuhub.logger import get_logger
 from kohakuhub.api.admin.utils import verify_admin_token
 from kohakuhub.api.quota.util import get_repo_storage_info
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 
 logger = get_logger("ADMIN")
 router = APIRouter()
@@ -204,7 +204,7 @@ async def get_repository_files_admin(
         )
 
     # Get file tree from LakeFS
-    lakefs_repo = lakefs_repo_name(repo_type, f"{namespace}/{name}")
+    lakefs_repo = resolve_lakefs_repo(repo)
     client = get_lakefs_client()
 
     try:

--- a/src/kohakuhub/api/branches.py
+++ b/src/kohakuhub/api/branches.py
@@ -16,7 +16,7 @@ from kohakuhub.auth.permissions import (
 )
 from kohakuhub.utils.lakefs import (
     get_lakefs_client,
-    lakefs_repo_name,
+    resolve_lakefs_repo,
     resolve_revision,
 )
 from kohakuhub.api.repo.utils.gc import (
@@ -81,7 +81,7 @@ async def create_branch(
     # Check if user has permission
     check_repo_delete_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     try:
@@ -182,7 +182,7 @@ async def delete_branch(
             "Cannot delete main branch",
         )
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     try:
@@ -269,7 +269,7 @@ async def create_tag(
     # Check if user has permission
     check_repo_delete_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     try:
@@ -349,7 +349,7 @@ async def delete_tag(
     # Check if user has permission
     check_repo_delete_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     try:
@@ -415,7 +415,7 @@ async def list_repo_refs(
 
     check_repo_read_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
     branches: list[dict[str, str]] = []
     tags: list[dict[str, str]] = []
@@ -514,7 +514,7 @@ async def revert_branch(
     # Check if user has write permission
     check_repo_write_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Resolve the ref to a commit ID (for logging/validation)
@@ -658,7 +658,7 @@ async def merge_branches(
     # Check if user has write permission
     check_repo_write_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Perform the merge
@@ -800,7 +800,7 @@ async def reset_branch(
             },
         )
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Resolve the ref to a commit ID

--- a/src/kohakuhub/api/commit/routers/history.py
+++ b/src/kohakuhub/api/commit/routers/history.py
@@ -15,7 +15,7 @@ from kohakuhub.lakefs_rest_client import get_lakefs_rest_client
 from kohakuhub.logger import get_logger
 from kohakuhub.auth.dependencies import get_optional_user
 from kohakuhub.auth.permissions import check_repo_read_permission
-from kohakuhub.utils.lakefs import lakefs_repo_name
+from kohakuhub.utils.lakefs import resolve_lakefs_repo
 from kohakuhub.api.repo.utils.hf import (
     format_hf_datetime,
     hf_repo_not_found,
@@ -88,7 +88,7 @@ async def list_commits(
     # Check read permission
     check_repo_read_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
 
     try:
         # Get commits from LakeFS using REST API
@@ -212,7 +212,7 @@ async def get_commit_detail(
     # Check read permission
     check_repo_read_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
 
     try:
         # Get commit from LakeFS
@@ -283,7 +283,7 @@ async def get_commit_diff(
     # Check read permission
     check_repo_read_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
 
     try:
         # Get commit from LakeFS

--- a/src/kohakuhub/api/commit/routers/operations.py
+++ b/src/kohakuhub/api/commit/routers/operations.py
@@ -24,7 +24,7 @@ from kohakuhub.db_operations import (
 from kohakuhub.logger import get_logger
 from kohakuhub.auth.dependencies import get_current_user
 from kohakuhub.auth.permissions import check_repo_write_permission
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 from kohakuhub.utils.s3 import get_object_metadata, object_exists
 from kohakuhub.api.quota.util import update_namespace_storage, update_repository_storage
 from kohakuhub.api.repo.utils.gc import run_gc_for_file, track_lfs_object
@@ -734,7 +734,7 @@ async def commit(
 
     check_repo_write_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type.value, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Parse NDJSON payload

--- a/src/kohakuhub/api/files.py
+++ b/src/kohakuhub/api/files.py
@@ -28,7 +28,11 @@ from kohakuhub.auth.permissions import (
     check_repo_read_permission,
     check_repo_write_permission,
 )
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name, resolve_revision
+from kohakuhub.utils.lakefs import (
+    get_lakefs_client,
+    resolve_lakefs_repo,
+    resolve_revision,
+)
 from kohakuhub.utils.s3 import generate_download_presigned_url, parse_s3_uri
 from kohakuhub.api.fallback import with_repo_fallback
 from kohakuhub.api.xet import XET_ENABLE
@@ -252,7 +256,7 @@ async def preupload(
         )
 
     # Get LakeFS repository name
-    lakefs_repo = lakefs_repo_name(repo_type.value, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     # Get effective LFS threshold for this repository
     threshold = get_effective_lfs_threshold(repo_row)
 
@@ -311,7 +315,7 @@ async def get_revision(
             return hf_repo_not_found(repo_id, repo_type.value)
         raise
 
-    lakefs_repo = lakefs_repo_name(repo_type.value, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Resolve revision (supports both branch names and commit hashes)
@@ -412,7 +416,7 @@ async def _get_file_metadata(
             ) from exc
         raise
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     try:

--- a/src/kohakuhub/api/git/routers/http.py
+++ b/src/kohakuhub/api/git/routers/http.py
@@ -18,6 +18,7 @@ from kohakuhub.auth.permissions import (
 )
 from kohakuhub.auth.utils import hash_token
 from kohakuhub.api.git.utils.lakefs_bridge import GitLakeFSBridge
+from kohakuhub.utils.lakefs import resolve_lakefs_repo
 from kohakuhub.api.git.utils.server import (
     GitReceivePackHandler,
     GitUploadPackHandler,
@@ -115,7 +116,9 @@ async def git_info_refs(
         raise HTTPException(400, detail=f"Unknown service: {service}")
 
     # Get refs from LakeFS using the repository's actual type
-    bridge = GitLakeFSBridge(repo.repo_type, namespace, name)
+    bridge = GitLakeFSBridge(
+        repo.repo_type, namespace, name, lakefs_repo=resolve_lakefs_repo(repo)
+    )
     refs = await bridge.get_refs(branch="main")
 
     # Generate service advertisement
@@ -175,7 +178,9 @@ async def git_upload_pack(
     request_body = await request.body()
 
     # Create bridge for LakeFS integration using the repository's actual type
-    bridge = GitLakeFSBridge(repo.repo_type, namespace, name)
+    bridge = GitLakeFSBridge(
+        repo.repo_type, namespace, name, lakefs_repo=resolve_lakefs_repo(repo)
+    )
 
     # Handle upload-pack
     handler = GitUploadPackHandler(repo_id, bridge=bridge)

--- a/src/kohakuhub/api/git/utils/lakefs_bridge.py
+++ b/src/kohakuhub/api/git/utils/lakefs_bridge.py
@@ -47,12 +47,21 @@ def generate_lfsconfig(base_url: str, namespace: str, name: str) -> bytes:
 class GitLakeFSBridge:
     """Git-LakeFS bridge - Pure Python, in-memory only (no pygit2, no temp files)."""
 
-    def __init__(self, repo_type: str, namespace: str, name: str):
+    def __init__(
+        self,
+        repo_type: str,
+        namespace: str,
+        name: str,
+        lakefs_repo: str | None = None,
+    ):
         self.repo_type = repo_type
         self.namespace = namespace
         self.name = name
         self.repo_id = f"{namespace}/{name}"
-        self.lakefs_repo = lakefs_repo_name(repo_type, self.repo_id)
+        # Callers that hold the Repository row should pass its resolved LakeFS id
+        # (`resolve_lakefs_repo`); deriving it only works for repositories still
+        # on generation 0.
+        self.lakefs_repo = lakefs_repo or lakefs_repo_name(repo_type, self.repo_id)
         self.lakefs_client = get_lakefs_client()
 
     async def get_refs(self, branch: str = "main") -> dict[str, str]:

--- a/src/kohakuhub/api/quota/util.py
+++ b/src/kohakuhub/api/quota/util.py
@@ -12,7 +12,7 @@ from kohakuhub.config import cfg
 from kohakuhub.db import File, LFSObjectHistory, Repository, User
 from kohakuhub.db_operations import get_organization
 from kohakuhub.logger import get_logger
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 
 logger = get_logger("QUOTA")
 
@@ -39,7 +39,7 @@ async def calculate_repository_storage(repo: Repository) -> dict[str, int]:
         - lfs_total_bytes: Total LFS storage (all versions)
         - lfs_unique_bytes: Unique LFS storage (deduplicated by SHA256)
     """
-    lakefs_repo = lakefs_repo_name(repo.repo_type, repo.full_id)
+    lakefs_repo = resolve_lakefs_repo(repo)
     client = get_lakefs_client()
 
     # Bulk-load LFS flag for every active file in this repo *once* up front,

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -374,7 +374,15 @@ async def create_repo(
     # result is persisted below - deriving it again later would address the wrong
     # repository.
     client = get_lakefs_client()
-    lakefs_repo = await allocate_lakefs_repo_name(client, payload.type, full_id)
+    try:
+        lakefs_repo = await allocate_lakefs_repo_name(client, payload.type, full_id)
+    except Exception as e:
+        # Allocation probes LakeFS, so it is a new place this request can fail.
+        # Keep the header-based error shape the rest of the API uses rather than
+        # letting the exception escape as a bare 500.
+        logger.exception(f"LakeFS repository allocation failed for {full_id}", e)
+        return hf_server_error(f"LakeFS repository allocation failed: {str(e)}")
+
     storage_namespace = f"s3://{cfg.s3.bucket}/{lakefs_repo}"
 
     try:
@@ -995,9 +1003,18 @@ async def move_repo(
     # Allocate the destination id instead of deriving it: if the destination name
     # was used before and its LakeFS repository is still being deleted, the
     # derived name is not available yet.
-    to_lakefs_repo = await allocate_lakefs_repo_name(
-        get_lakefs_client(), repo_type, to_id
-    )
+    try:
+        to_lakefs_repo = await allocate_lakefs_repo_name(
+            get_lakefs_client(), repo_type, to_id
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"LakeFS repository allocation failed for {to_id}", e)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to allocate LakeFS repository: {str(e)}"},
+        )
 
     await _migrate_lakefs_repository(
         repo_type=repo_type,

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -393,9 +393,22 @@ async def create_repo(
         )
     except Exception as e:
         if _is_lakefs_repo_id_taken_error(e):
-            # Allocation raced with LakeFS: the id was free when we probed and
-            # taken by the time we created. Hand the client a conflict it knows
-            # to retry, after a short hold to pace hf_hub's sleepless retry loop.
+            # The id was free when we probed and taken by the time we created.
+            # Two different things look like this, and they need opposite
+            # answers, so re-check the DB to tell them apart.
+            if get_repository(payload.type, namespace, payload.name):
+                # A concurrent create won the race. The name is taken for good,
+                # so telling the client to retry would only make it spin before
+                # learning the same thing.
+                logger.info(
+                    f"Concurrent create won the race for {full_id}; "
+                    f"reporting it as an existing repository"
+                )
+                return _repo_exists_response(payload.type, full_id)
+
+            # Nobody owns the name here: LakeFS is still deleting a previous
+            # incarnation of it. Hand the client a conflict it knows to retry,
+            # after a short hold to pace hf_hub's sleepless retry loop.
             logger.warning(
                 f"LakeFS repository id {lakefs_repo} for {full_id} is still held "
                 f"(async deletion in progress); returning retryable conflict"

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -31,7 +31,11 @@ from kohakuhub.auth.permissions import (
     check_namespace_permission,
     check_repo_delete_permission,
 )
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import (
+    allocate_lakefs_repo_name,
+    get_lakefs_client,
+    resolve_lakefs_repo,
+)
 from kohakuhub.utils.s3 import copy_s3_folder, delete_objects_with_prefix, get_s3_client
 from kohakuhub.lakefs_rest_client import StagingLocation, StagingMetadata
 from kohakuhub.api.repo.utils.hf import (
@@ -111,6 +115,120 @@ def _is_lakefs_namespace_in_use_error(error: Exception, storage_namespace: str) 
             "_lakefs/dummy" in error_text,
         )
     )
+
+
+# Verbatim sentence that `huggingface_hub.HfApi.create_repo` matches against the
+# response *body* to decide that a conflict is transient and worth retrying. The
+# check has been present unchanged from 0.20.3 through 1.x:
+#
+#     while True:
+#         r = get_session().post(path, headers=headers, json=payload)
+#         if r.status_code == 409 and "Cannot create repo: another conflicting
+#                                      operation is in progress" in r.text:
+#             continue
+#         break
+#
+# Getting the wording wrong is not a cosmetic issue: a 409 *without* it is
+# treated as "repo already exists" by `create_repo(exist_ok=True)`, which then
+# returns successfully and leaves the caller uploading into a repo that does not
+# exist.
+LAKEFS_CONFLICT_RETRY_MESSAGE = (
+    "Cannot create repo: another conflicting operation is in progress"
+)
+
+# hf_hub's retry loop has no sleep and no attempt limit, so a client would spin
+# at full request rate for as long as the conflict lasts. Holding the response
+# briefly is the only way to pace it without changing the client.
+LAKEFS_RECYCLING_HOLD_SECONDS = 2.0
+
+# Bound for waiting out an asynchronous LakeFS repository deletion. LakeFS acks
+# DELETE /repositories/{id} before the record is actually gone, and the cleanup
+# scales with how much metadata the repository had, so this cannot be unbounded:
+# the wait happens inside a request.
+LAKEFS_DELETION_WAIT_MAX_ATTEMPTS = 20
+LAKEFS_DELETION_WAIT_INTERVAL_SECONDS = 0.5
+
+
+def _is_lakefs_repo_id_taken_error(error: Exception) -> bool:
+    """Return True for the LakeFS 409 raised while an id is still held.
+
+    LakeFS answers `409 {"message":"error creating repository: not unique"}` when
+    the repository id already exists in its KV store - including for a
+    repository whose asynchronous deletion has not finished yet (issue #93).
+
+    This is deliberately distinct from `_is_lakefs_namespace_in_use_error`: that
+    one is a leftover S3 marker we can clean up and retry immediately, while
+    this one only clears when LakeFS finishes its own cleanup.
+    """
+    lowered = str(error).lower()
+    if "not unique" not in lowered:
+        return False
+
+    # `LakeFSRestClient._check_response` raises `httpx.HTTPStatusError`, so the
+    # status is available structurally; prefer it over matching "409" in the
+    # message, which could also appear inside a repository name or URL.
+    status_code = getattr(getattr(error, "response", None), "status_code", None)
+    if status_code is not None:
+        return status_code == 409
+
+    return "409" in lowered
+
+
+def _repo_recycling_response(repo_type: str, full_id: str) -> Response:
+    """Build the retryable 409 for a repo id LakeFS has not released yet.
+
+    The body carries `LAKEFS_CONFLICT_RETRY_MESSAGE` so huggingface_hub retries
+    on its own. `X-Error-Code` is informational: `hf_raise_for_status` has no 409
+    branch, so no HF client consumes it for this status.
+    """
+    body = json.dumps(
+        {
+            "error": LAKEFS_CONFLICT_RETRY_MESSAGE,
+            "repo_id": full_id,
+            "repo_type": repo_type,
+        }
+    )
+    return Response(
+        status_code=409,
+        content=body,
+        media_type="application/json",
+        headers={
+            "X-Error-Code": HFErrorCode.REPO_NAME_RECYCLING,
+            "X-Error-Message": LAKEFS_CONFLICT_RETRY_MESSAGE,
+            # Ignored by hf_hub (its create_repo bypasses http_backoff), but
+            # correct for any client that does honour it.
+            "Retry-After": str(int(LAKEFS_RECYCLING_HOLD_SECONDS) or 1),
+        },
+    )
+
+
+async def _wait_for_lakefs_repo_deletion(client, lakefs_repo: str) -> bool:
+    """Wait, bounded, for LakeFS to finish deleting `lakefs_repo`.
+
+    Returns True if the repository is gone, False if it was still present when
+    the bound was reached. Callers treat False as non-fatal: the id simply stays
+    unusable a little longer, which `_is_lakefs_repo_id_taken_error` turns into a
+    retryable response for clients.
+    """
+    for attempt in range(LAKEFS_DELETION_WAIT_MAX_ATTEMPTS):
+        try:
+            if not await client.repository_exists(lakefs_repo):
+                return True
+        except Exception as e:
+            # Never let a probe failure fail the move: the data has already been
+            # migrated by this point.
+            logger.debug(f"repository_exists check failed for {lakefs_repo}: {e}")
+            return False
+
+        if attempt + 1 < LAKEFS_DELETION_WAIT_MAX_ATTEMPTS:
+            await asyncio.sleep(LAKEFS_DELETION_WAIT_INTERVAL_SECONDS)
+
+    logger.warning(
+        f"LakeFS repository {lakefs_repo} still present after "
+        f"{LAKEFS_DELETION_WAIT_MAX_ATTEMPTS} checks; its id stays reserved until "
+        f"LakeFS finishes deleting it"
+    )
+    return False
 
 
 def _has_only_internal_lakefs_markers(
@@ -223,7 +341,6 @@ async def create_repo(
     check_namespace_permission(namespace, user)
 
     full_id = f"{namespace}/{payload.name}"
-    lakefs_repo = lakefs_repo_name(payload.type, full_id)
 
     # Check for exact match.
     # `huggingface_hub` only honors `exist_ok=True` when the server returns 409 (see
@@ -250,8 +367,14 @@ async def create_repo(
                 message=f"Repository name conflicts with existing repository: {repo.name}",
             )
 
-    # Create LakeFS repository
+    # Create LakeFS repository.
+    # The id is allocated rather than derived: a repo id whose previous
+    # incarnation is still being deleted by LakeFS cannot reuse the derived
+    # (generation 0) name yet, so allocation steps to the next generation. The
+    # result is persisted below - deriving it again later would address the wrong
+    # repository.
     client = get_lakefs_client()
+    lakefs_repo = await allocate_lakefs_repo_name(client, payload.type, full_id)
     storage_namespace = f"s3://{cfg.s3.bucket}/{lakefs_repo}"
 
     try:
@@ -261,6 +384,17 @@ async def create_repo(
             default_branch="main",
         )
     except Exception as e:
+        if _is_lakefs_repo_id_taken_error(e):
+            # Allocation raced with LakeFS: the id was free when we probed and
+            # taken by the time we created. Hand the client a conflict it knows
+            # to retry, after a short hold to pace hf_hub's sleepless retry loop.
+            logger.warning(
+                f"LakeFS repository id {lakefs_repo} for {full_id} is still held "
+                f"(async deletion in progress); returning retryable conflict"
+            )
+            await asyncio.sleep(LAKEFS_RECYCLING_HOLD_SECONDS)
+            return _repo_recycling_response(payload.type, full_id)
+
         namespace_in_use = _is_lakefs_namespace_in_use_error(e, storage_namespace)
         logger.warning(
             f"LakeFS create_repository failed for {full_id}; "
@@ -298,13 +432,19 @@ async def create_repo(
             logger.exception(f"LakeFS repository creation failed for {full_id}", e)
             return hf_server_error(f"LakeFS repository creation failed: {str(e)}")
 
-    # Store in database for listing/metadata
+    # Store in database for listing/metadata.
+    # `lakefs_repo` records which LakeFS repository this row owns; every read
+    # path resolves through it (see `resolve_lakefs_repo`).
     Repository.get_or_create(
         repo_type=payload.type,
         namespace=namespace,
         name=payload.name,
         full_id=full_id,
-        defaults={"private": payload.private, "owner": user},
+        defaults={
+            "private": payload.private,
+            "owner": user,
+            "lakefs_repo": lakefs_repo,
+        },
     )
 
     return {
@@ -353,13 +493,14 @@ async def delete_repo(
         namespace = payload.organization or user.username
 
     full_id = f"{namespace}/{payload.name}"
-    lakefs_repo = lakefs_repo_name(repo_type, full_id)
 
     # 1. Check if repository exists in database
     repo_row = get_repository(repo_type, namespace, payload.name)
 
     if not repo_row:
         return hf_repo_not_found(full_id, repo_type)
+
+    lakefs_repo = resolve_lakefs_repo(repo_row)
 
     # 2. Check if user has permission to delete this repository (admin bypasses)
     check_repo_delete_permission(repo_row, user, is_admin=is_admin)
@@ -429,7 +570,14 @@ class SquashRepoPayload(BaseModel):
     type: str = "model"
 
 
-async def _migrate_lakefs_repository(repo_type: str, from_id: str, to_id: str) -> None:
+async def _migrate_lakefs_repository(
+    repo_type: str,
+    from_id: str,
+    to_id: str,
+    *,
+    from_lakefs_repo: str,
+    to_lakefs_repo: str,
+) -> None:
     """Migrate LakeFS repository with proper LFS handling using File table.
 
     Strategy:
@@ -448,13 +596,15 @@ async def _migrate_lakefs_repository(repo_type: str, from_id: str, to_id: str) -
         repo_type: Repository type (model/dataset/space)
         from_id: Source repository ID (namespace/name)
         to_id: Target repository ID (namespace/name)
+        from_lakefs_repo: LakeFS repository currently backing `from_id`, resolved
+            by the caller from the DB row (never re-derived here - a row created
+            at generation > 0 does not derive back to its own id).
+        to_lakefs_repo: LakeFS repository to create for `to_id`, allocated by the
+            caller so it cannot collide with a pending deletion.
 
     Raises:
         HTTPException: If migration fails
     """
-    from_lakefs_repo = lakefs_repo_name(repo_type, from_id)
-    to_lakefs_repo = lakefs_repo_name(repo_type, to_id)
-
     if from_lakefs_repo == to_lakefs_repo:
         # No migration needed (e.g., just renaming within namespace)
         return
@@ -614,12 +764,23 @@ async def _migrate_lakefs_repository(repo_type: str, from_id: str, to_id: str) -
             logger.success("Committed all objects to new repository")
 
         # 5. Delete old LakeFS repository
+        deleted = False
         try:
             await client.delete_repository(repository=from_lakefs_repo, force=True)
             logger.info(f"Deleted old LakeFS repository: {from_lakefs_repo}")
+            deleted = True
         except Exception as e:
             if not is_lakefs_not_found_error(e):
                 logger.warning(f"Failed to delete old LakeFS repo: {e}")
+
+        # 5b. LakeFS acks the DELETE before the repository record is gone, and
+        # until it is, the id cannot be reused - which is what made a rename
+        # followed by recreating the old name fail (issue #93). Waiting here,
+        # bounded, means the common case never surfaces a conflict at all.
+        # Timing out is not an error: the move itself already succeeded, and a
+        # later create against the same id degrades to a retryable 409.
+        if deleted:
+            await _wait_for_lakefs_repo_deletion(client, from_lakefs_repo)
 
         # 6. Delete old S3 folder to free up the name
         deleted_count = await delete_objects_with_prefix(cfg.s3.bucket, from_s3_prefix)
@@ -657,6 +818,7 @@ def _update_repository_database_records(
     to_name: str,
     moving_namespace: bool,
     repo_size: int,
+    to_lakefs_repo: str,
     preserve_quota: bool = True,
 ) -> None:
     """Update database records for repository move (must be called within db.atomic()).
@@ -670,6 +832,9 @@ def _update_repository_database_records(
         to_name: Target repository name
         moving_namespace: Whether namespace is changing
         repo_size: Repository size in bytes
+        to_lakefs_repo: LakeFS repository the migration created for `to_id`. The
+            row must point at it explicitly, since the destination may have been
+            allocated at generation > 0 and would not derive back to this id.
         preserve_quota: Whether to preserve repository quota settings (default: True)
     """
     # Preserve current quota settings before update
@@ -688,6 +853,7 @@ def _update_repository_database_records(
         namespace=to_namespace,
         name=to_name,
         full_id=to_id,
+        lakefs_repo=to_lakefs_repo,
         quota_bytes=current_quota_bytes,
         used_bytes=current_used_bytes,
     ).where(Repository.id == repo_row.id).execute()
@@ -825,12 +991,20 @@ async def move_repo(
 
     # Migrate LakeFS repository FIRST (before updating DB)
     # This ensures File table queries use correct from_id
-    from_lakefs_repo = lakefs_repo_name(repo_type, from_id)
+    from_lakefs_repo = resolve_lakefs_repo(repo_row)
+    # Allocate the destination id instead of deriving it: if the destination name
+    # was used before and its LakeFS repository is still being deleted, the
+    # derived name is not available yet.
+    to_lakefs_repo = await allocate_lakefs_repo_name(
+        get_lakefs_client(), repo_type, to_id
+    )
 
     await _migrate_lakefs_repository(
         repo_type=repo_type,
         from_id=from_id,
         to_id=to_id,
+        from_lakefs_repo=from_lakefs_repo,
+        to_lakefs_repo=to_lakefs_repo,
     )
 
     # Update database records AFTER successful LakeFS migration
@@ -844,6 +1018,7 @@ async def move_repo(
             to_name=to_name,
             moving_namespace=moving_namespace,
             repo_size=repo_size,
+            to_lakefs_repo=to_lakefs_repo,
         )
 
     # Clean up old S3 storage after successful migration
@@ -929,11 +1104,19 @@ async def squash_repo(
         logger.info(f"Step 1: Moving {repo_id} to temporary {temp_id}")
 
         # Use internal move logic
-        from_lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+        client = get_lakefs_client()
+        from_lakefs_repo = resolve_lakefs_repo(repo_row)
+        temp_lakefs_repo = await allocate_lakefs_repo_name(
+            client, repo_type, temp_id
+        )
 
         # Migrate LakeFS FIRST (before updating DB)
         await _migrate_lakefs_repository(
-            repo_type=repo_type, from_id=repo_id, to_id=temp_id
+            repo_type=repo_type,
+            from_id=repo_id,
+            to_id=temp_id,
+            from_lakefs_repo=from_lakefs_repo,
+            to_lakefs_repo=temp_lakefs_repo,
         )
 
         # Update DB AFTER successful migration
@@ -947,6 +1130,7 @@ async def squash_repo(
                 to_name=temp_name,
                 moving_namespace=False,  # Same namespace
                 repo_size=0,  # No quota change
+                to_lakefs_repo=temp_lakefs_repo,
             )
 
         # Clean up old storage
@@ -959,40 +1143,26 @@ async def squash_repo(
 
         logger.success(f"Moved to temporary repository: {temp_id}")
 
-        # Wait for old LakeFS repo to be fully deleted (with exponential backoff)
-        # This ensures we can reuse the name immediately
-        client = get_lakefs_client()
-        old_deleted = False
-        max_attempts = 20
-        for attempt in range(max_attempts):
-            if not await client.repository_exists(from_lakefs_repo):
-                old_deleted = True
-                logger.info(
-                    f"Confirmed old repository {from_lakefs_repo} deleted after {attempt + 1} check(s)"
-                )
-                break
-            # Exponential backoff: 0.05s, 0.1s, 0.2s, 0.4s, ...
-            wait_time = 0.05 * (2 ** min(attempt, 5))
-            logger.debug(
-                f"Old repository still exists, waiting {wait_time:.2f}s... (attempt {attempt + 1}/{max_attempts})"
-            )
-            await asyncio.sleep(wait_time)
-
-        if not old_deleted:
-            logger.warning(
-                f"Old repository {from_lakefs_repo} still exists after {max_attempts} checks"
-            )
-            # Continue anyway - the 409 error will be caught and handled
+        # `_migrate_lakefs_repository` already waited for the old repository's
+        # asynchronous deletion, so the original id is free to reuse below. If it
+        # timed out, allocation picks the next generation instead of colliding.
 
         # Step 2: Move back to original name
         logger.info(f"Step 2: Moving {temp_id} back to {repo_id}")
 
         # Reload repo row (it was updated to temp name)
         repo_row = get_repository(repo_type, namespace, temp_name)
+        final_lakefs_repo = await allocate_lakefs_repo_name(
+            client, repo_type, repo_id
+        )
 
         # Migrate LakeFS FIRST (before updating DB)
         await _migrate_lakefs_repository(
-            repo_type=repo_type, from_id=temp_id, to_id=repo_id
+            repo_type=repo_type,
+            from_id=temp_id,
+            to_id=repo_id,
+            from_lakefs_repo=resolve_lakefs_repo(repo_row),
+            to_lakefs_repo=final_lakefs_repo,
         )
 
         # Update DB AFTER successful migration
@@ -1006,10 +1176,10 @@ async def squash_repo(
                 to_name=name,
                 moving_namespace=False,  # Same namespace
                 repo_size=0,  # No quota change
+                to_lakefs_repo=final_lakefs_repo,
             )
 
         # Clean up temp storage
-        temp_lakefs_repo = lakefs_repo_name(repo_type, temp_id)
         await cleanup_repository_storage(
             repo_type=repo_type,
             namespace=namespace,
@@ -1017,22 +1187,8 @@ async def squash_repo(
             lakefs_repo=temp_lakefs_repo,
         )
 
-        # Wait for temp LakeFS repo to be fully deleted
-        temp_deleted = False
-        for attempt in range(20):
-            if not await client.repository_exists(temp_lakefs_repo):
-                temp_deleted = True
-                logger.info(
-                    f"Confirmed temp repository {temp_lakefs_repo} deleted after {attempt + 1} check(s)"
-                )
-                break
-            wait_time = 0.05 * (2 ** min(attempt, 5))
-            await asyncio.sleep(wait_time)
-
-        if not temp_deleted:
-            logger.warning(
-                f"Temp repository {temp_lakefs_repo} still exists after cleanup"
-            )
+        # The temp id is never reused, so its deletion only needs to be observed
+        # for logging; `_migrate_lakefs_repository` already waited for it.
 
         # Step 3: Recalculate repository storage after squashing
         # Storage might have changed after clearing history
@@ -1062,7 +1218,9 @@ async def squash_repo(
             temp_repo = get_repository(repo_type, namespace, temp_name)
             if temp_repo:
                 logger.info(f"Attempting to recover from temp repository: {temp_id}")
-                # Move back from temp
+                # Move back from temp. Only the DB row is renamed here - the data
+                # still lives in the temp LakeFS repository, so the row must keep
+                # pointing at it rather than at the original id's derived name.
                 with db.atomic():
                     _update_repository_database_records(
                         repo_row=temp_repo,
@@ -1073,6 +1231,7 @@ async def squash_repo(
                         to_name=name,
                         moving_namespace=False,
                         repo_size=0,
+                        to_lakefs_repo=resolve_lakefs_repo(temp_repo),
                     )
                 logger.info("Recovery attempt completed")
         except Exception as recovery_error:

--- a/src/kohakuhub/api/repo/routers/info.py
+++ b/src/kohakuhub/api/repo/routers/info.py
@@ -20,7 +20,7 @@ from kohakuhub.auth.permissions import (
     check_repo_read_permission,
     check_repo_write_permission,
 )
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 from kohakuhub.api.fallback import (
     with_list_aggregation,
     with_repo_fallback,
@@ -227,7 +227,7 @@ async def get_repo_info(
         raise
 
     # Get LakeFS info for default branch
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
 
     # Get default branch info
@@ -408,7 +408,7 @@ async def _list_repos_internal(
             sha, last_at = head
             last_modified = safe_strftime(last_at, DATETIME_FORMAT_ISO)
         else:
-            lakefs_repo = lakefs_repo_name(rt, r.full_id)
+            lakefs_repo = resolve_lakefs_repo(r)
             sha, last_modified = await _resolve_main_head_via_lakefs(
                 client, lakefs_repo
             )
@@ -570,7 +570,7 @@ async def list_user_repos(
                 sha, last_at = head
                 last_modified = safe_strftime(last_at, DATETIME_FORMAT_ISO)
             else:
-                lakefs_repo = lakefs_repo_name(repo_type, r.full_id)
+                lakefs_repo = resolve_lakefs_repo(r)
                 sha, last_modified = await _resolve_main_head_via_lakefs(
                     client, lakefs_repo
                 )

--- a/src/kohakuhub/api/repo/routers/tree.py
+++ b/src/kohakuhub/api/repo/routers/tree.py
@@ -18,7 +18,7 @@ from kohakuhub.lakefs_rest_client import get_lakefs_rest_client
 from kohakuhub.logger import get_logger
 from kohakuhub.utils.lakefs import (
     get_lakefs_client,
-    lakefs_repo_name,
+    resolve_lakefs_repo,
     resolve_revision,
 )
 from kohakuhub.api.fallback import with_repo_fallback
@@ -472,7 +472,7 @@ async def list_repo_tree(
 
     check_repo_read_permission(repo_row, user)
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     clean_path = _normalize_repo_path(path)
     base_prefix = f"{clean_path}/" if clean_path else ""
 
@@ -614,7 +614,7 @@ async def get_paths_info(
             f"Too many paths requested. Maximum supported paths per request is {PATHS_INFO_MAX_PATHS}."
         )
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     try:
         resolved_revision, _ = await resolve_revision(
             get_lakefs_client(), lakefs_repo, revision

--- a/src/kohakuhub/api/repo/utils/hf.py
+++ b/src/kohakuhub/api/repo/utils/hf.py
@@ -34,6 +34,10 @@ class HFErrorCode:
 
     # KohakuHub custom error codes (not in official HF Hub)
     REPO_EXISTS = "RepoExists"
+    # A repo id whose LakeFS repository is still being deleted. Informational
+    # only: hf_raise_for_status has no 409 branch, so HF clients key off the
+    # response body instead (see LAKEFS_CONFLICT_RETRY_MESSAGE).
+    REPO_NAME_RECYCLING = "RepoNameRecycling"
     BAD_REQUEST = "BadRequest"
     INVALID_REPO_TYPE = "InvalidRepoType"
     INVALID_REPO_ID = "InvalidRepoId"
@@ -320,9 +324,9 @@ async def collect_hf_siblings(
 ) -> list[dict]:
     """Collect repository files using the schema expected by `huggingface_hub`."""
     from kohakuhub.db_operations import get_file, should_use_lfs
-    from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+    from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 
-    lakefs_repo = lakefs_repo_name(repo_type, repo_id)
+    lakefs_repo = resolve_lakefs_repo(repo_row)
     client = get_lakefs_client()
     all_results = []
     after = ""

--- a/src/kohakuhub/api/xet/routers/cas.py
+++ b/src/kohakuhub/api/xet/routers/cas.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 
 from kohakuhub.db import User
 from kohakuhub.logger import get_logger
-from kohakuhub.utils.lakefs import get_lakefs_client, lakefs_repo_name
+from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 from kohakuhub.utils.s3 import generate_download_presigned_url, parse_s3_uri
 from kohakuhub.auth.dependencies import get_optional_user
 from kohakuhub.api.xet.utils.file_lookup import (
@@ -60,7 +60,7 @@ async def get_reconstruction(
     check_file_read_permission(repo, user)
 
     # Get LakeFS repository name
-    lakefs_repo = lakefs_repo_name(repo.repo_type, repo.full_id)
+    lakefs_repo = resolve_lakefs_repo(repo)
 
     # Get file from LakeFS (use main branch to get latest physical address)
     client = get_lakefs_client()

--- a/src/kohakuhub/db.py
+++ b/src/kohakuhub/db.py
@@ -158,6 +158,11 @@ class Repository(BaseModel):
     namespace = CharField(index=True)
     name = CharField(index=True)
     full_id = CharField(index=True)  # Not unique - same full_id can exist across types
+    # LakeFS repository backing this row. NULL means "derive from repo_type +
+    # full_id" (rows written before migration 016). Always read it through
+    # `kohakuhub.utils.lakefs.resolve_lakefs_repo`: a repository allocated at
+    # generation > 0 does not derive back to its own id.
+    lakefs_repo = CharField(null=True, index=True)
     private = BooleanField(default=False)
     owner = ForeignKeyField(
         User, backref="owned_repos", on_delete="CASCADE", index=True

--- a/src/kohakuhub/db_operations.py
+++ b/src/kohakuhub/db_operations.py
@@ -195,10 +195,16 @@ def create_repository(
     full_id: str,
     private: bool,
     owner: User,
+    lakefs_repo: str | None = None,
 ) -> Repository:
     """Create a new repository with ForeignKey to owner (User or Org).
 
     NOTE: Wrap in db.atomic() if checking existence first.
+
+    Pass `lakefs_repo` with the id returned by
+    `kohakuhub.utils.lakefs.allocate_lakefs_repo_name`. Leaving it None means
+    "derive the generation-0 name", which is only correct while that name is
+    actually free - see issue #93.
     """
     return Repository.create(
         repo_type=repo_type,
@@ -207,6 +213,7 @@ def create_repository(
         full_id=full_id,
         private=private,
         owner=owner,  # ForeignKey to User (can be user or org)
+        lakefs_repo=lakefs_repo,
     )
 
 

--- a/src/kohakuhub/utils/lakefs.py
+++ b/src/kohakuhub/utils/lakefs.py
@@ -136,7 +136,7 @@ def _sanitize_repo_id(repo_id: str) -> str:
     return safe
 
 
-def lakefs_repo_name(repo_type: str, repo_id: str) -> str:
+def lakefs_repo_name(repo_type: str, repo_id: str, generation: int = 0) -> str:
     """Generate LakeFS repository name from HuggingFace repo ID.
 
     LakeFS naming requirements: ^[a-z0-9][a-z0-9-]{2,62}$
@@ -162,9 +162,26 @@ def lakefs_repo_name(repo_type: str, repo_id: str) -> str:
         Hash: SHA3-224 (224 bits) → XOR folding → 112 bits
         Uses numpy.base_repr for C-optimized performance
 
+    Generations:
+        A repo ID can outlive the LakeFS repository it maps to: renaming a repo
+        deletes the old LakeFS repository, and LakeFS deletes asynchronously, so
+        the derived name stays taken for a while afterwards (issue #93). The
+        layout above is exactly 63 chars - the LakeFS maximum - so there is no
+        room to append a generation token. The generation goes into the *hash
+        input* instead:
+
+            generation 0 -> hash(repo_id)            (legacy value, unchanged)
+            generation N -> hash(f"{repo_id}#{N}")
+
+        Generation 0 must stay byte-identical to the pre-generation scheme:
+        existing rows are backfilled with it by migration 016, and any drift
+        would point stored ids at LakeFS repositories that do not exist.
+
     Args:
         repo_type: Repository type (model/dataset/space)
         repo_id: Full repository ID (e.g., "org/repo-name")
+        generation: Which incarnation of this repo ID to name. Allocate it with
+            `allocate_lakefs_repo_name` rather than guessing.
 
     Returns:
         LakeFS-safe repository name (always 63 chars)
@@ -183,7 +200,10 @@ def lakefs_repo_name(repo_type: str, repo_id: str) -> str:
 
     # ALWAYS generate hash of ORIGINAL repo_id (before sanitization)
     # This ensures uniqueness even when sanitization causes collisions
-    hash_int = _hash_to_112bit(repo_id)  # Hash ORIGINAL, not sanitized!
+    # Generation 0 hashes the bare repo_id so the name matches the pre-generation
+    # scheme exactly; later generations salt it to get a distinct repository.
+    hash_input = repo_id if generation == 0 else f"{repo_id}#{generation}"
+    hash_int = _hash_to_112bit(hash_input)  # Hash ORIGINAL, not sanitized!
 
     # Encode to base36 using numpy (C-optimized)
     hash_b36 = _base36_encode(hash_int)
@@ -195,6 +215,75 @@ def lakefs_repo_name(repo_type: str, repo_id: str) -> str:
     basename = f"{type_char}-{safe_id}-{hash_suffix}"
 
     return basename
+
+
+# How many generations to probe before giving up. Each generation costs one
+# LakeFS HEAD-style lookup, and reaching even generation 2 requires a repo id to
+# have been recycled twice while a deletion was still pending.
+MAX_LAKEFS_REPO_GENERATIONS = 16
+
+
+def resolve_lakefs_repo(repo) -> str:
+    """Return the LakeFS repository id backing a Repository row.
+
+    Prefers the id stored on the row, falling back to the generation-0
+    derivation for rows written before migration 016 added the column.
+
+    Always use this instead of calling `lakefs_repo_name` with a repo id: a row
+    whose LakeFS repository was allocated at generation > 0 does not derive back
+    to its own id, so deriving would silently address the wrong repository.
+
+    Args:
+        repo: Repository row (needs `repo_type`, `full_id`, and optionally
+            `lakefs_repo`).
+
+    Returns:
+        LakeFS repository id.
+    """
+    stored = getattr(repo, "lakefs_repo", None)
+    if stored:
+        return stored
+    return lakefs_repo_name(repo.repo_type, repo.full_id)
+
+
+async def allocate_lakefs_repo_name(
+    client,
+    repo_type: str,
+    repo_id: str,
+    max_generations: int = MAX_LAKEFS_REPO_GENERATIONS,
+) -> str:
+    """Pick a LakeFS repository id for `repo_id` that LakeFS does not already hold.
+
+    Generation 0 is the legacy derived name and is used whenever it is free, so
+    the common case is unchanged. It is *not* free while a previous incarnation
+    of the same repo id is still being deleted (LakeFS deletes asynchronously,
+    see issue #93); allocation then steps to the next generation instead of
+    colliding with `409 not unique`.
+
+    The caller must persist the result on `Repository.lakefs_repo`, otherwise a
+    generation > 0 repository becomes unreachable.
+
+    Args:
+        client: LakeFS client exposing `repository_exists`.
+        repo_type: Repository type (model/dataset/space).
+        repo_id: Full repository ID (e.g., "org/repo-name").
+        max_generations: How many generations to probe before giving up.
+
+    Returns:
+        A LakeFS repository id that was free at probe time.
+
+    Raises:
+        RuntimeError: If every probed generation is taken.
+    """
+    for generation in range(max_generations):
+        candidate = lakefs_repo_name(repo_type, repo_id, generation=generation)
+        if not await client.repository_exists(candidate):
+            return candidate
+
+    raise RuntimeError(
+        f"No free LakeFS repository id for {repo_type}:{repo_id} "
+        f"after {max_generations} generations"
+    )
 
 
 if __name__ == "__main__":

--- a/src/kohakuhub/utils/lakefs.py
+++ b/src/kohakuhub/utils/lakefs.py
@@ -233,6 +233,11 @@ def resolve_lakefs_repo(repo) -> str:
     whose LakeFS repository was allocated at generation > 0 does not derive back
     to its own id, so deriving would silently address the wrong repository.
 
+    The row must come from a full `Repository.select()`. Peewee returns None for
+    a column that was not selected, which is indistinguishable here from a
+    pre-migration row and would quietly fall back to the derived name. No query
+    feeding this function selects a subset today; keep it that way.
+
     Args:
         repo: Repository row (needs `repo_type`, `full_id`, and optionally
             `lakefs_repo`).

--- a/test/kohakuhub/api/commit/routers/test_history_unit.py
+++ b/test/kohakuhub/api/commit/routers/test_history_unit.py
@@ -120,7 +120,7 @@ async def test_list_commits_covers_not_found_empty_parse_failure_and_server_erro
         lambda message: SimpleNamespace(status_code=500, message=message),
     )
     monkeypatch.setattr(commit_history, "check_repo_read_permission", lambda repo, user: None)
-    monkeypatch.setattr(commit_history, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_history, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_history, "get_lakefs_rest_client", lambda: client)
 
     monkeypatch.setattr(commit_history, "get_repository", lambda repo_type, namespace, name: None)
@@ -194,7 +194,7 @@ async def test_list_commits_sets_link_header_and_formatted_expand(monkeypatch):
     )
 
     monkeypatch.setattr(commit_history, "check_repo_read_permission", lambda repo, user: None)
-    monkeypatch.setattr(commit_history, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_history, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_history, "get_lakefs_rest_client", lambda: client)
     monkeypatch.setattr(commit_history, "get_repository", lambda repo_type, namespace, name: repo_row)
 
@@ -253,7 +253,7 @@ async def test_list_commits_skips_link_when_cursor_missing_and_propagates_read_e
         ]
     )
 
-    monkeypatch.setattr(commit_history, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_history, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_history, "get_lakefs_rest_client", lambda: client)
     monkeypatch.setattr(commit_history, "get_repository", lambda repo_type, namespace, name: repo_row)
 
@@ -301,7 +301,7 @@ async def test_get_commit_detail_covers_not_found_fallback_author_and_server_err
         lambda message: SimpleNamespace(status_code=500, message=message),
     )
     monkeypatch.setattr(commit_history, "check_repo_read_permission", lambda repo, user: None)
-    monkeypatch.setattr(commit_history, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_history, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_history, "get_lakefs_rest_client", lambda: client)
     monkeypatch.setattr(commit_history, "get_repository", lambda repo_type, namespace, name: None)
 
@@ -360,7 +360,7 @@ async def test_get_commit_diff_covers_parentless_diff_generation_skips_and_error
         lambda message: SimpleNamespace(status_code=500, message=message),
     )
     monkeypatch.setattr(commit_history, "check_repo_read_permission", lambda repo, user: None)
-    monkeypatch.setattr(commit_history, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_history, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_history, "get_lakefs_rest_client", lambda: client)
     monkeypatch.setattr(
         commit_history,

--- a/test/kohakuhub/api/commit/routers/test_operations_unit.py
+++ b/test/kohakuhub/api/commit/routers/test_operations_unit.py
@@ -352,7 +352,7 @@ async def test_process_lfs_file_covers_same_content_new_content_and_failures(mon
 
 @pytest.mark.asyncio
 async def test_process_deleted_file_and_folder_cover_success_partial_failures_and_exceptions(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     client = _FakeLakeFSClient()
     monkeypatch.setattr(commit_ops, "File", _FakeFileModel)
     monkeypatch.setattr(commit_ops, "get_lakefs_client", lambda: client)
@@ -421,7 +421,7 @@ async def test_commit_route_covers_parse_dispatch_noop_and_success_paths(monkeyp
 
     monkeypatch.setattr(commit_ops.Repository, "get_or_none", lambda *args: repo)
     monkeypatch.setattr(commit_ops, "check_repo_write_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(commit_ops, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(commit_ops, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(commit_ops, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(commit_ops.cfg.app, "base_url", "https://hub.example.com")
     monkeypatch.setattr(commit_ops.cfg.app, "debug_log_payloads", False)

--- a/test/kohakuhub/api/git/routers/test_http.py
+++ b/test/kohakuhub/api/git/routers/test_http.py
@@ -70,7 +70,7 @@ def test_get_user_from_git_auth_handles_missing_invalid_and_active_users(monkeyp
 
 @pytest.mark.asyncio
 async def test_git_info_refs_handles_upload_and_receive_services(monkeypatch):
-    repo = SimpleNamespace(repo_type="dataset", private=False)
+    repo = SimpleNamespace(repo_type="dataset", full_id="owner/repo", private=False)
     user = SimpleNamespace(username="owner")
     seen = {"handlers": []}
 
@@ -84,8 +84,11 @@ async def test_git_info_refs_handles_upload_and_receive_services(monkeypatch):
     monkeypatch.setattr(git_http, "check_repo_write_permission", lambda repo_arg, user_arg: seen.setdefault("write", []).append((repo_arg, user_arg)))
 
     class FakeBridge:
-        def __init__(self, repo_type, namespace, name):
+        def __init__(self, repo_type, namespace, name, lakefs_repo=None):
+            # The route resolves the LakeFS id from the Repository row and hands
+            # it over, instead of letting the bridge re-derive it.
             seen["bridge_args"] = (repo_type, namespace, name)
+            seen["bridge_lakefs_repo"] = lakefs_repo
 
         async def get_refs(self, branch="main"):
             seen["branch"] = branch
@@ -118,6 +121,9 @@ async def test_git_info_refs_handles_upload_and_receive_services(monkeypatch):
     assert upload_response.media_type == "application/x-git-upload-pack-advertisement"
     assert receive_response.body == b"receive-info"
     assert seen["bridge_args"] == ("dataset", "owner", "repo")
+    assert seen["bridge_lakefs_repo"], (
+        "the route must pass the row's resolved LakeFS id to the bridge"
+    )
     assert seen["read"] == [(repo, user)]
     assert seen["write"] == [(repo, user)]
 
@@ -131,7 +137,7 @@ async def test_git_info_refs_rejects_missing_repo_unknown_service_and_unauthenti
 
     assert not_found.value.status_code == 404
 
-    repo = SimpleNamespace(repo_type="model", private=False)
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo", private=False)
     monkeypatch.setattr(git_http, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(git_http, "get_user_from_git_auth", lambda authorization: None)
     monkeypatch.setattr(git_http, "check_repo_read_permission", lambda repo_arg, user_arg: None)
@@ -149,7 +155,7 @@ async def test_git_info_refs_rejects_missing_repo_unknown_service_and_unauthenti
 
 @pytest.mark.asyncio
 async def test_git_upload_pack_receive_pack_and_head_use_expected_handlers(monkeypatch):
-    repo = SimpleNamespace(repo_type="space", private=False)
+    repo = SimpleNamespace(repo_type="space", full_id="owner/repo", private=False)
     user = SimpleNamespace(username="owner")
     seen = {}
 
@@ -163,8 +169,11 @@ async def test_git_upload_pack_receive_pack_and_head_use_expected_handlers(monke
     monkeypatch.setattr(git_http, "check_repo_write_permission", lambda repo_arg, user_arg: seen.setdefault("write", []).append((repo_arg, user_arg)))
 
     class FakeBridge:
-        def __init__(self, repo_type, namespace, name):
+        def __init__(self, repo_type, namespace, name, lakefs_repo=None):
+            # The route resolves the LakeFS id from the Repository row and hands
+            # it over, instead of letting the bridge re-derive it.
             seen["bridge_args"] = (repo_type, namespace, name)
+            seen["bridge_lakefs_repo"] = lakefs_repo
 
     class FakeUploadHandler:
         def __init__(self, repo_id, bridge):
@@ -206,11 +215,14 @@ async def test_git_upload_pack_receive_pack_and_head_use_expected_handlers(monke
     assert seen["upload_body"] == b"want main"
     assert seen["receive_body"] == b"push refs"
     assert seen["bridge_args"] == ("space", "owner", "repo")
+    assert seen["bridge_lakefs_repo"], (
+        "the route must pass the row's resolved LakeFS id to the bridge"
+    )
 
 
 @pytest.mark.asyncio
 async def test_git_receive_pack_requires_authentication(monkeypatch):
-    repo = SimpleNamespace(repo_type="model", private=False)
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo", private=False)
     monkeypatch.setattr(git_http, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(git_http, "get_user_from_git_auth", lambda authorization: None)
 

--- a/test/kohakuhub/api/quota/test_util.py
+++ b/test/kohakuhub/api/quota/test_util.py
@@ -180,7 +180,7 @@ def _patch_models(monkeypatch):
     monkeypatch.setattr(quota_util, "File", _FakeFileModel)
     monkeypatch.setattr(quota_util, "LFSObjectHistory", _FakeLFSObjectHistoryModel)
     monkeypatch.setattr(quota_util, "User", _FakeUserModel)
-    monkeypatch.setattr(quota_util, "lakefs_repo_name", lambda repo_type, full_id: f"{repo_type}-{full_id}")
+    monkeypatch.setattr(quota_util, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}-{repo.full_id}")
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -394,6 +394,15 @@ async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(mo
     monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud, "cleanup_repository_storage", lambda **kwargs: _async_return({"repo_objects_deleted": 1, "lfs_objects_deleted": 0, "lfs_history_deleted": 0}))
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
+    # move_repo allocates the destination id, which probes LakeFS. Stub both the
+    # client and the allocator so this stays a unit test - without it the probe
+    # reaches whatever LakeFS the environment happens to point at.
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        repo_crud,
+        "allocate_lakefs_repo_name",
+        lambda client, repo_type, repo_id: _async_return(f"{repo_type}:{repo_id}#alloc"),
+    )
 
     bad_source = await repo_crud.move_repo(
         repo_crud.MoveRepoPayload(fromRepo="bad", toRepo="owner/to", type="model"),
@@ -438,6 +447,9 @@ async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(mo
     )
     assert success["success"] is True
     assert atomic_state["updated"]
+    # The allocated destination id must reach the DB row, otherwise the moved
+    # repository would resolve back to a derived name that is not its own.
+    assert atomic_state["updated"][-1]["to_lakefs_repo"] == "model:other/to#alloc"
 
     monkeypatch.setattr(repo_crud, "cleanup_repository_storage", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("cleanup failed")))
     success = await repo_crud.move_repo(

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -164,7 +164,6 @@ async def test_create_repo_covers_conflicts_lakefs_failure_and_success(monkeypat
     monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
     monkeypatch.setattr(repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None)
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
     monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: None)

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -1242,3 +1242,74 @@ async def test_wait_for_lakefs_repo_deletion_reports_states_and_survives_probe_e
         assert len(sleeps) == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
     finally:
         module.asyncio.sleep = original_sleep
+
+
+@pytest.mark.asyncio
+async def test_create_repo_reports_allocation_failure_as_a_shaped_server_error(
+    monkeypatch,
+):
+    """A LakeFS outage during id allocation must keep the HF error shape.
+
+    Allocation probes LakeFS before creating anything, so it is a new place the
+    request can fail. Letting that exception escape would return a bare 500 with
+    no X-Error-Code, losing the header protocol the rest of the API follows.
+    """
+    user = SimpleNamespace(username="owner")
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("lakefs unreachable")
+
+    monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
+    monkeypatch.setattr(
+        repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None
+    )
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(repo_crud, "allocate_lakefs_repo_name", _boom)
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+    monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
+    monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: None)
+    monkeypatch.setattr(repo_crud, "normalize_name", lambda name: name.lower())
+
+    response = await repo_crud.create_repo(
+        repo_crud.CreateRepoPayload(type="model", name="demo-model"), user=user
+    )
+
+    assert response.status_code == 500
+    assert response.headers.get("x-error-code") == repo_crud.HFErrorCode.SERVER_ERROR
+    assert not _FakeRepositoryModel.get_or_create_calls
+
+
+@pytest.mark.asyncio
+async def test_move_repo_reports_allocation_failure_as_http_500(monkeypatch):
+    """Same for move: an allocation failure must not escape as an unhandled error."""
+    repo_row = SimpleNamespace(
+        private=False,
+        repo_type="model",
+        full_id="owner/from",
+        lakefs_repo="m-owner-from",
+    )
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("lakefs unreachable")
+
+    monkeypatch.setattr(
+        repo_crud, "check_repo_delete_permission", lambda repo, user, is_admin=False: None
+    )
+    monkeypatch.setattr(
+        repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None
+    )
+    monkeypatch.setattr(
+        repo_crud,
+        "get_repository",
+        lambda repo_type, namespace, name: repo_row if (namespace, name) == ("owner", "from") else None,
+    )
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(repo_crud, "allocate_lakefs_repo_name", _boom)
+
+    with pytest.raises(HTTPException) as allocation_error:
+        await repo_crud.move_repo(
+            repo_crud.MoveRepoPayload(fromRepo="owner/from", toRepo="owner/to", type="model"),
+            auth=(SimpleNamespace(username="owner"), False),
+        )
+
+    assert allocation_error.value.status_code == 500

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -1200,7 +1200,9 @@ def test_is_lakefs_repo_id_taken_error_prefers_the_structured_status_code():
 
 
 @pytest.mark.asyncio
-async def test_wait_for_lakefs_repo_deletion_reports_states_and_survives_probe_errors():
+async def test_wait_for_lakefs_repo_deletion_reports_states_and_survives_probe_errors(
+    monkeypatch,
+):
     sleeps = []
 
     class _Client:
@@ -1218,30 +1220,26 @@ async def test_wait_for_lakefs_repo_deletion_reports_states_and_survives_probe_e
     async def fake_sleep(seconds):
         sleeps.append(seconds)
 
-    import kohakuhub.api.repo.routers.crud as module
+    monkeypatch.setattr(repo_crud.asyncio, "sleep", fake_sleep)
 
-    original_sleep = module.asyncio.sleep
-    module.asyncio.sleep = fake_sleep
-    try:
-        gone = await repo_crud._wait_for_lakefs_repo_deletion(
-            _Client([True, False]), "old-repo"
-        )
-        assert gone is True
+    gone = await repo_crud._wait_for_lakefs_repo_deletion(
+        _Client([True, False]), "old-repo"
+    )
+    assert gone is True
 
-        # A probe failure must not fail the move; the data is already migrated.
-        survived = await repo_crud._wait_for_lakefs_repo_deletion(
-            _Client([RuntimeError("lakefs unreachable")]), "old-repo"
-        )
-        assert survived is False
+    # A probe failure must not fail the move; the data is already migrated.
+    survived = await repo_crud._wait_for_lakefs_repo_deletion(
+        _Client([RuntimeError("lakefs unreachable")]), "old-repo"
+    )
+    assert survived is False
 
-        never = _Client([True] * repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS)
-        timed_out = await repo_crud._wait_for_lakefs_repo_deletion(never, "old-repo")
-        assert timed_out is False
-        assert never.calls == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
-        # No sleep after the final attempt.
-        assert len(sleeps) == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
-    finally:
-        module.asyncio.sleep = original_sleep
+    never = _Client([True] * repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS)
+    timed_out = await repo_crud._wait_for_lakefs_repo_deletion(never, "old-repo")
+    assert timed_out is False
+    assert never.calls == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
+    # One sleep between attempts, none after the final one: 1 for the first
+    # client (it sleeps once, then sees the repo gone) plus MAX - 1 here.
+    assert len(sleeps) == 1 + (repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS - 1)
 
 
 @pytest.mark.asyncio

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -164,7 +164,7 @@ async def test_create_repo_covers_conflicts_lakefs_failure_and_success(monkeypat
     monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
     monkeypatch.setattr(repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None)
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_crud, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
     monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: None)
@@ -209,12 +209,17 @@ async def test_create_repo_covers_conflicts_lakefs_failure_and_success(monkeypat
 
 @pytest.mark.asyncio
 async def test_delete_repo_covers_admin_validation_not_found_and_failures(monkeypatch):
-    repo_row = SimpleNamespace(delete_instance=lambda: None)
+    repo_row = SimpleNamespace(
+        delete_instance=lambda: None,
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
     client = _FakeClient()
     atomic_state = {}
 
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_crud, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud, "check_repo_delete_permission", lambda repo, user, is_admin=False: None)
     monkeypatch.setattr(repo_crud, "cleanup_repository_storage", lambda **kwargs: _async_return({"repo_objects_deleted": 1, "lfs_objects_deleted": 0, "lfs_history_deleted": 0}))
     monkeypatch.setattr(repo_crud, "is_lakefs_not_found_error", lambda error: "404" in str(error))
@@ -250,7 +255,12 @@ async def test_delete_repo_covers_admin_validation_not_found_and_failures(monkey
     assert failure.status_code == 500
 
     client.raise_on["delete_repository"] = RuntimeError("404 missing")
-    db_failure_repo = SimpleNamespace(delete_instance=lambda: (_ for _ in ()).throw(RuntimeError("db broke")))
+    db_failure_repo = SimpleNamespace(
+        delete_instance=lambda: (_ for _ in ()).throw(RuntimeError("db broke")),
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
     monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: db_failure_repo)
     db_failure = await repo_crud.delete_repo(
         repo_crud.DeleteRepoPayload(type="model", name="demo-model"),
@@ -265,17 +275,29 @@ async def test_migrate_lakefs_repository_covers_noop_missing_source_success_and_
     from_repo = SimpleNamespace(full_id="owner/from")
     deleted_prefixes = []
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_crud, "lakefs_repo_name", lambda repo_type, repo_id: "same-repo" if repo_id == "owner/same" else repo_id.replace("/", "-"))
     monkeypatch.setattr(repo_crud, "get_repository", lambda repo_type, namespace, name: from_repo if name in {"from", "same"} else None)
     monkeypatch.setattr(repo_crud, "get_file", lambda repo, path: SimpleNamespace(lfs=path.endswith(".bin")) if path != "missing.txt" else None)
     monkeypatch.setattr(repo_crud, "should_use_lfs", lambda repo, path, size: path.endswith(".bin"))
     monkeypatch.setattr(repo_crud, "delete_objects_with_prefix", lambda bucket, prefix: deleted_prefixes.append((bucket, prefix)) or _async_return(2))
     monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
 
-    await repo_crud._migrate_lakefs_repository("model", "owner/same", "owner/same")
+    # Same source and destination LakeFS repository: nothing to migrate.
+    await repo_crud._migrate_lakefs_repository(
+        "model",
+        "owner/same",
+        "owner/same",
+        from_lakefs_repo="same-repo",
+        to_lakefs_repo="same-repo",
+    )
 
     with pytest.raises(HTTPException) as missing_source:
-        await repo_crud._migrate_lakefs_repository("model", "owner/missing", "owner/to")
+        await repo_crud._migrate_lakefs_repository(
+            "model",
+            "owner/missing",
+            "owner/to",
+            from_lakefs_repo="owner-missing",
+            to_lakefs_repo="owner-to",
+        )
     assert missing_source.value.status_code == 404
 
     client.list_payloads = [
@@ -287,7 +309,13 @@ async def test_migrate_lakefs_repository_covers_noop_missing_source_success_and_
             "pagination": {"has_more": False},
         }
     ]
-    await repo_crud._migrate_lakefs_repository("model", "owner/from", "owner/to")
+    await repo_crud._migrate_lakefs_repository(
+        "model",
+        "owner/from",
+        "owner/to",
+        from_lakefs_repo="owner-from",
+        to_lakefs_repo="owner-to",
+    )
     method_names = [name for name, _kwargs in client.calls]
     assert "create_repository" in method_names
     assert "link_physical_address" in method_names
@@ -296,7 +324,13 @@ async def test_migrate_lakefs_repository_covers_noop_missing_source_success_and_
 
     client.raise_on["create_repository"] = RuntimeError("migration broke")
     with pytest.raises(HTTPException) as migration_error:
-        await repo_crud._migrate_lakefs_repository("model", "owner/from", "owner/to")
+        await repo_crud._migrate_lakefs_repository(
+            "model",
+            "owner/from",
+            "owner/to",
+            from_lakefs_repo="owner-from",
+            to_lakefs_repo="owner-to",
+        )
     assert migration_error.value.status_code == 500
 
 
@@ -316,8 +350,12 @@ def test_update_repository_database_records_covers_same_and_cross_namespace_move
         to_name="to",
         moving_namespace=False,
         repo_size=0,
+        to_lakefs_repo="m-owner-to",
     )
     assert _FakeRepositoryModel.update_kwargs["quota_bytes"] == 100
+    assert _FakeRepositoryModel.update_kwargs["lakefs_repo"] == "m-owner-to", (
+        "the row must point at the LakeFS repository the migration created"
+    )
 
     repo_crud._update_repository_database_records(
         repo_row=repo_row,
@@ -328,6 +366,7 @@ def test_update_repository_database_records_covers_same_and_cross_namespace_move
         to_name="to",
         moving_namespace=True,
         repo_size=25,
+        to_lakefs_repo="m-org-team-to",
     )
     assert _FakeRepositoryModel.update_kwargs["quota_bytes"] is None
     assert increments[0]["bytes_delta"] == -25
@@ -336,7 +375,12 @@ def test_update_repository_database_records_covers_same_and_cross_namespace_move
 
 @pytest.mark.asyncio
 async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(monkeypatch):
-    repo_row = SimpleNamespace(private=False)
+    repo_row = SimpleNamespace(
+        private=False,
+        repo_type="model",
+        full_id="owner/from",
+        lakefs_repo="m-owner-from",
+    )
     atomic_state = {}
     monkeypatch.setattr(repo_crud, "check_repo_delete_permission", lambda repo, user, is_admin=False: None)
     monkeypatch.setattr(repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None)
@@ -347,7 +391,7 @@ async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(mo
     monkeypatch.setattr(repo_crud, "_migrate_lakefs_repository", lambda **kwargs: _async_return(None))
     monkeypatch.setattr(repo_crud, "_update_repository_database_records", lambda **kwargs: atomic_state.setdefault("updated", []).append(kwargs))
     monkeypatch.setattr(repo_crud, "db", SimpleNamespace(atomic=lambda: _AtomicContext(atomic_state)))
-    monkeypatch.setattr(repo_crud, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud, "cleanup_repository_storage", lambda **kwargs: _async_return({"repo_objects_deleted": 1, "lfs_objects_deleted": 0, "lfs_history_deleted": 0}))
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
 
@@ -405,8 +449,20 @@ async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(mo
 
 @pytest.mark.asyncio
 async def test_squash_repo_covers_validation_success_and_recovery(monkeypatch):
-    repo_row = SimpleNamespace(private=False)
-    temp_repo = SimpleNamespace(private=False)
+    repo_row = SimpleNamespace(
+        private=False,
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
+    # Step 2 reloads the row under the temporary name and resolves its LakeFS id
+    # from it, so the temp row carries its own identity too.
+    temp_repo = SimpleNamespace(
+        private=False,
+        repo_type="model",
+        full_id="owner/demo-squash-abc12345",
+        lakefs_repo="model:owner/demo-squash-abc12345",
+    )
     atomic_state = {}
     client = _FakeClient()
     client.repository_exists_values = [True, False, True, False]
@@ -425,7 +481,7 @@ async def test_squash_repo_covers_validation_success_and_recovery(monkeypatch):
     monkeypatch.setattr(repo_crud, "_update_repository_database_records", lambda **kwargs: atomic_state.setdefault("updated", []).append(kwargs))
     monkeypatch.setattr(repo_crud, "cleanup_repository_storage", lambda **kwargs: _async_return({"repo_objects_deleted": 1, "lfs_objects_deleted": 0, "lfs_history_deleted": 0}))
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_crud, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_crud, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(repo_crud, "update_repository_storage", lambda repo: _async_return(None))
     monkeypatch.setattr(repo_crud, "db", SimpleNamespace(atomic=lambda: _AtomicContext(atomic_state)))
     monkeypatch.setattr(repo_crud.uuid, "uuid4", lambda: SimpleNamespace(hex="abc12345deadbeef"))
@@ -597,10 +653,12 @@ async def test_create_repo_heals_orphan_dummy_marker_and_retries_lakefs_create(
         lambda namespace, user, is_admin=False: None,
     )
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
+    # create_repo allocates its LakeFS id rather than deriving it, so the
+    # allocator is the seam that fixes the name this test asserts against.
     monkeypatch.setattr(
         repo_crud,
-        "lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "allocate_lakefs_repo_name",
+        lambda client, repo_type, repo_id: _async_return(f"{repo_type}:{repo_id}"),
     )
     monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
@@ -680,8 +738,8 @@ async def test_create_repo_does_not_retry_on_unrelated_lakefs_error(monkeypatch)
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(
         repo_crud,
-        "lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
     monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
@@ -718,7 +776,12 @@ async def test_delete_repo_runs_lakefs_metadata_delete_before_s3_cleanup(monkeyp
     LakeFS metadata is removed first; S3 cleanup only follows once LakeFS no
     longer references the storage.
     """
-    repo_row = SimpleNamespace(delete_instance=lambda: None)
+    repo_row = SimpleNamespace(
+        delete_instance=lambda: None,
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
     client = _FakeClient()
     atomic_state = {}
     call_order: list[str] = []
@@ -742,8 +805,8 @@ async def test_delete_repo_runs_lakefs_metadata_delete_before_s3_cleanup(monkeyp
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(
         repo_crud,
-        "lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr(
         repo_crud,
@@ -779,7 +842,12 @@ async def test_delete_repo_skips_s3_cleanup_when_lakefs_delete_fails(monkeypatch
     even tried, so the failed delete left an orphan LakeFS repo over wiped S3
     storage — the exact state that surfaced as 302->403 to clients.
     """
-    repo_row = SimpleNamespace(delete_instance=lambda: None)
+    repo_row = SimpleNamespace(
+        delete_instance=lambda: None,
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
     client = _FakeClient()
     client.raise_on["delete_repository"] = RuntimeError("LakeFS internal error 500")
     atomic_state = {}
@@ -796,8 +864,8 @@ async def test_delete_repo_skips_s3_cleanup_when_lakefs_delete_fails(monkeypatch
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(
         repo_crud,
-        "lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr(
         repo_crud,
@@ -835,7 +903,12 @@ async def test_delete_repo_treats_lakefs_404_as_success_and_continues_to_s3(
     the recovery path: after a previous delete crashed mid-way the user can
     safely retry and reach a clean end state.
     """
-    repo_row = SimpleNamespace(delete_instance=lambda: None)
+    repo_row = SimpleNamespace(
+        delete_instance=lambda: None,
+        repo_type="model",
+        full_id="owner/demo-model",
+        lakefs_repo="model:owner/demo-model",
+    )
     client = _FakeClient()
     client.raise_on["delete_repository"] = RuntimeError("404 repository not found")
     atomic_state = {}
@@ -852,8 +925,8 @@ async def test_delete_repo_treats_lakefs_404_as_success_and_continues_to_s3(
     monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(
         repo_crud,
-        "lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr(
         repo_crud,
@@ -879,3 +952,293 @@ async def test_delete_repo_treats_lakefs_404_as_success_and_continues_to_s3(
         "After a 404 from LakeFS, S3 cleanup must still run so leftover "
         "objects from a prior partial delete can be reaped"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #93: a renamed repo's freed name stays unusable while LakeFS finishes
+# deleting the old repository asynchronously.
+# ---------------------------------------------------------------------------
+
+
+def test_is_lakefs_repo_id_taken_error_matches_only_the_async_deletion_conflict():
+    taken = RuntimeError(
+        "LakeFS API error 409 Conflict for POST http://lakefs:28000/api/v1/repositories: "
+        '{"message":"error creating repository: not unique"}'
+    )
+    assert repo_crud._is_lakefs_repo_id_taken_error(taken) is True
+
+    # The namespace-in-use error has its own (S3 marker cleanup) recovery path
+    # and must not be reported as a retryable id conflict.
+    namespace_in_use = RuntimeError(
+        "LakeFS API error 400 Bad Request: failed to create repository: found lakeFS "
+        "objects in the storage (:s3://hub-storage/d-owner-demo-x) key(_lakefs/dummy): "
+        "storage namespace already in use"
+    )
+    assert repo_crud._is_lakefs_repo_id_taken_error(namespace_in_use) is False
+
+    for unrelated in (
+        RuntimeError("lakefs is on fire"),
+        RuntimeError("LakeFS API error 404 Not Found"),
+        RuntimeError('409 Conflict {"message":"something else entirely"}'),
+        RuntimeError('{"message":"error creating repository: not unique"}'),  # no 409
+    ):
+        assert repo_crud._is_lakefs_repo_id_taken_error(unrelated) is False
+
+
+def test_repo_recycling_response_matches_the_huggingface_hub_retry_contract():
+    """`huggingface_hub.HfApi.create_repo` retries transparently, but only on a
+    409 whose *body* contains this exact sentence. The check has been in place
+    unchanged from 0.20.3 through 1.x, so the wording is load-bearing: without
+    it, `create_repo(exist_ok=True)` instead swallows the 409 as "already
+    exists" and the caller proceeds against a repo that does not exist.
+    """
+    response = repo_crud._repo_recycling_response("dataset", "owner/demo")
+
+    assert response.status_code == 409
+    body = bytes(response.body).decode()
+    assert (
+        "Cannot create repo: another conflicting operation is in progress" in body
+    ), "hf_hub matches this substring against r.text, so it must be in the body"
+
+    payload = json.loads(body)
+    assert payload["repo_id"] == "owner/demo"
+    # Header protocol clients still get a structured code, even though
+    # hf_raise_for_status has no 409 branch that reads it.
+    assert response.headers.get("x-error-code") == repo_crud.HFErrorCode.REPO_NAME_RECYCLING
+
+
+@pytest.mark.asyncio
+async def test_create_repo_returns_retryable_conflict_when_lakefs_id_is_still_held(
+    monkeypatch,
+):
+    user = SimpleNamespace(username="owner")
+    sleeps = []
+
+    class _IdTakenClient(_FakeClient):
+        async def create_repository(self, **kwargs):
+            self.calls.append(("create_repository", kwargs))
+            raise RuntimeError(
+                "LakeFS API error 409 Conflict for POST /repositories: "
+                '{"message":"error creating repository: not unique"}'
+            )
+
+    client = _IdTakenClient()
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(repo_crud.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
+    monkeypatch.setattr(
+        repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None
+    )
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
+    monkeypatch.setattr(
+        repo_crud, "allocate_lakefs_repo_name", lambda *a, **k: _async_return("m-owner-demo")
+    )
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+    monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
+    monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: None)
+    monkeypatch.setattr(repo_crud, "normalize_name", lambda name: name.lower())
+
+    response = await repo_crud.create_repo(
+        repo_crud.CreateRepoPayload(type="model", name="demo-model"), user=user
+    )
+
+    assert response.status_code == 409
+    assert "another conflicting operation is in progress" in bytes(response.body).decode()
+    assert sleeps == [repo_crud.LAKEFS_RECYCLING_HOLD_SECONDS], (
+        "hf_hub's retry loop has no backoff of its own, so the server supplies "
+        "the delay by holding the response briefly"
+    )
+    assert not _FakeRepositoryModel.get_or_create_calls, (
+        "A retryable conflict must not leave a half-created DB row behind"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_repo_persists_the_allocated_lakefs_repo_id(monkeypatch):
+    user = SimpleNamespace(username="owner")
+    client = _FakeClient()
+
+    monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
+    monkeypatch.setattr(
+        repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None
+    )
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
+    monkeypatch.setattr(
+        repo_crud, "allocate_lakefs_repo_name", lambda *a, **k: _async_return("m-owner-demo-gen1")
+    )
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+    monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
+    monkeypatch.setattr(repo_crud, "get_repository", lambda *_args: None)
+    monkeypatch.setattr(repo_crud, "normalize_name", lambda name: name.lower())
+
+    result = await repo_crud.create_repo(
+        repo_crud.CreateRepoPayload(type="model", name="demo-model"), user=user
+    )
+
+    assert result["repo_id"] == "owner/demo-model"
+    created_kwargs = _FakeRepositoryModel.get_or_create_calls[-1]
+    assert created_kwargs["defaults"]["lakefs_repo"] == "m-owner-demo-gen1", (
+        "An allocated id that is not persisted makes the repository unreachable"
+    )
+    create_calls = [kwargs for name, kwargs in client.calls if name == "create_repository"]
+    assert create_calls[-1]["name"] == "m-owner-demo-gen1"
+    assert create_calls[-1]["storage_namespace"].endswith("/m-owner-demo-gen1"), (
+        "Storage namespace must follow the allocated id, not the derived one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migrate_lakefs_repository_waits_for_the_old_repo_to_disappear(monkeypatch):
+    """Stage 2: LakeFS acks DELETE before the repository record is gone, so the
+    freed id stays taken. Waiting here means the common case never has to
+    surface a conflict to the client at all.
+    """
+    client = _FakeClient()
+    # Still present twice, then finally deleted.
+    client.repository_exists_values = [True, True, False]
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(repo_crud.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
+    monkeypatch.setattr(repo_crud, "get_repository", lambda *_a: SimpleNamespace(full_id="owner/from", lakefs_repo="from-repo"))
+    monkeypatch.setattr(repo_crud, "delete_objects_with_prefix", lambda bucket, prefix: _async_return(0))
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+
+    client.list_payloads = [{"results": [], "pagination": {"has_more": False}}]
+    await repo_crud._migrate_lakefs_repository(
+        "model", "owner/from", "owner/to",
+        from_lakefs_repo="from-repo", to_lakefs_repo="to-repo",
+    )
+
+    exists_calls = [name for name, _ in client.calls if name == "repository_exists"]
+    assert len(exists_calls) == 3, "must poll until the old repository is really gone"
+    assert sleeps, "polling must yield between attempts"
+
+    delete_index = [i for i, (name, _) in enumerate(client.calls) if name == "delete_repository"][0]
+    first_exists_index = [i for i, (name, _) in enumerate(client.calls) if name == "repository_exists"][0]
+    assert delete_index < first_exists_index, "the wait must follow the delete"
+
+
+@pytest.mark.asyncio
+async def test_migrate_lakefs_repository_wait_is_bounded_and_non_fatal(monkeypatch):
+    """A repository whose cleanup outlives the bound (large history) must not
+    fail the move - the rename itself already succeeded.
+    """
+    client = _FakeClient()
+    sleeps = []
+
+    class _NeverDeleted(_FakeClient):
+        async def repository_exists(self, repo_name):
+            self.calls.append(("repository_exists", repo_name))
+            return True
+
+    client = _NeverDeleted()
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(repo_crud.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: client)
+    monkeypatch.setattr(repo_crud, "get_repository", lambda *_a: SimpleNamespace(full_id="owner/from", lakefs_repo="from-repo"))
+    monkeypatch.setattr(repo_crud, "delete_objects_with_prefix", lambda bucket, prefix: _async_return(0))
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+
+    client.list_payloads = [{"results": [], "pagination": {"has_more": False}}]
+    await repo_crud._migrate_lakefs_repository(
+        "model", "owner/from", "owner/to",
+        from_lakefs_repo="from-repo", to_lakefs_repo="to-repo",
+    )
+
+    exists_calls = [name for name, _ in client.calls if name == "repository_exists"]
+    assert exists_calls, "must have tried"
+    assert len(exists_calls) <= repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS, (
+        "the wait must be bounded so a large repo cannot hang the request"
+    )
+
+
+def test_is_lakefs_repo_id_taken_error_prefers_the_structured_status_code():
+    """LakeFSRestClient raises httpx.HTTPStatusError, so the status is available
+    structurally. Matching "409" in the message alone would misfire on a
+    repository name or URL that merely contains those digits.
+    """
+
+    class _Resp:
+        def __init__(self, status_code):
+            self.status_code = status_code
+
+    class _Err(RuntimeError):
+        def __init__(self, message, status_code):
+            super().__init__(message)
+            self.response = _Resp(status_code)
+
+    assert (
+        repo_crud._is_lakefs_repo_id_taken_error(
+            _Err('{"message":"error creating repository: not unique"}', 409)
+        )
+        is True
+    )
+    # Same wording, different status: not our retryable case.
+    assert (
+        repo_crud._is_lakefs_repo_id_taken_error(
+            _Err('{"message":"error creating repository: not unique"}', 400)
+        )
+        is False
+    )
+    # "409" appearing only inside the repository name must not qualify.
+    assert (
+        repo_crud._is_lakefs_repo_id_taken_error(
+            RuntimeError("LakeFS API error 500 for repo d-owner-model409-abc: boom")
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_lakefs_repo_deletion_reports_states_and_survives_probe_errors():
+    sleeps = []
+
+    class _Client:
+        def __init__(self, values):
+            self.values = list(values)
+            self.calls = 0
+
+        async def repository_exists(self, repo_name):
+            self.calls += 1
+            value = self.values.pop(0)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    import kohakuhub.api.repo.routers.crud as module
+
+    original_sleep = module.asyncio.sleep
+    module.asyncio.sleep = fake_sleep
+    try:
+        gone = await repo_crud._wait_for_lakefs_repo_deletion(
+            _Client([True, False]), "old-repo"
+        )
+        assert gone is True
+
+        # A probe failure must not fail the move; the data is already migrated.
+        survived = await repo_crud._wait_for_lakefs_repo_deletion(
+            _Client([RuntimeError("lakefs unreachable")]), "old-repo"
+        )
+        assert survived is False
+
+        never = _Client([True] * repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS)
+        timed_out = await repo_crud._wait_for_lakefs_repo_deletion(never, "old-repo")
+        assert timed_out is False
+        assert never.calls == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
+        # No sleep after the final attempt.
+        assert len(sleeps) == repo_crud.LAKEFS_DELETION_WAIT_MAX_ATTEMPTS
+    finally:
+        module.asyncio.sleep = original_sleep

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -1322,3 +1322,63 @@ async def test_move_repo_reports_allocation_failure_as_http_500(monkeypatch):
         )
 
     assert allocation_error.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_create_repo_reports_a_concurrent_winner_as_exists_not_retry(monkeypatch):
+    """A lost create race is "already exists", not "retry shortly".
+
+    Two parallel creates both find generation 0 free, so the loser gets the same
+    LakeFS `409 not unique` as the recycling case. But the name is now taken for
+    good, not transiently: answering with the retryable sentence would make the
+    client spin (and cost it the pacing hold) before it eventually learns the
+    repo exists. Distinguish the two by re-checking the DB.
+    """
+    user = SimpleNamespace(username="owner")
+    sleeps = []
+
+    class _IdTakenClient(_FakeClient):
+        async def create_repository(self, **kwargs):
+            self.calls.append(("create_repository", kwargs))
+            raise RuntimeError(
+                "LakeFS API error 409 Conflict: "
+                '{"message":"error creating repository: not unique"}'
+            )
+
+    # Absent on the pre-flight check, present by the time the create fails -
+    # exactly what a concurrent winner looks like.
+    lookups = {"count": 0}
+
+    def fake_get_repository(*_args):
+        lookups["count"] += 1
+        return None if lookups["count"] == 1 else SimpleNamespace()
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(repo_crud.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(repo_crud, "Repository", _FakeRepositoryModel)
+    monkeypatch.setattr(
+        repo_crud, "check_namespace_permission", lambda namespace, user, is_admin=False: None
+    )
+    monkeypatch.setattr(repo_crud, "get_lakefs_client", lambda: _IdTakenClient())
+    monkeypatch.setattr(
+        repo_crud, "allocate_lakefs_repo_name", lambda *a, **k: _async_return("m-owner-demo")
+    )
+    monkeypatch.setattr(repo_crud.cfg.s3, "bucket", "hub-storage")
+    monkeypatch.setattr(repo_crud.cfg.app, "base_url", "https://hub.example.com")
+    monkeypatch.setattr(repo_crud, "get_repository", fake_get_repository)
+    monkeypatch.setattr(repo_crud, "normalize_name", lambda name: name.lower())
+
+    response = await repo_crud.create_repo(
+        repo_crud.CreateRepoPayload(type="model", name="demo-model"), user=user
+    )
+
+    assert response.status_code == 409
+    assert response.headers.get("x-error-code") == repo_crud.HFErrorCode.REPO_EXISTS
+    body = json.loads(bytes(response.body))
+    assert body["url"], "create_repo(exist_ok=True) reads url off the 409 body"
+    assert repo_crud.LAKEFS_CONFLICT_RETRY_MESSAGE not in bytes(response.body).decode(), (
+        "a permanently taken name must not be advertised as retryable"
+    )
+    assert sleeps == [], "no need to pace a client that should stop retrying"

--- a/test/kohakuhub/api/repo/routers/test_info_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_info_unit.py
@@ -241,7 +241,7 @@ async def test_get_repo_info_covers_invalid_type_not_found_siblings_and_storage_
         lambda repo_id, repo_type: SimpleNamespace(status_code=404),
     )
     monkeypatch.setattr(repo_info, "check_repo_read_permission", lambda repo, user: None)
-    monkeypatch.setattr(repo_info, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_info, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(repo_info, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(repo_info, "format_hf_datetime", lambda value: "2024-01-02T00:00:00.000000Z")
 
@@ -387,7 +387,7 @@ async def test_list_routes_cover_trending_invalid_path_and_user_repo_error_paths
     # below.
     monkeypatch.setattr(repo_info, "_latest_main_commits", lambda repo_ids: {})
     monkeypatch.setattr(repo_info, "get_lakefs_client", lambda: client)
-    monkeypatch.setattr(repo_info, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(repo_info, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(
         repo_info,
         "safe_strftime",

--- a/test/kohakuhub/api/repo/routers/test_tree_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_tree_unit.py
@@ -752,7 +752,7 @@ async def test_list_repo_tree_covers_success_pagination_and_error_paths(monkeypa
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
 
@@ -957,7 +957,7 @@ async def test_list_repo_tree_handles_last_commit_lookup_failures(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
 
@@ -1075,7 +1075,7 @@ async def test_get_paths_info_covers_limits_success_and_error_paths(monkeypatch)
         )
     )["bad_request"]
 
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
 
@@ -1222,7 +1222,7 @@ async def test_get_paths_info_handles_last_commit_lookup_failures(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
 
@@ -1313,7 +1313,7 @@ async def test_list_repo_tree_name_prefix_pushes_lakefs_prefix(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1375,7 +1375,7 @@ async def test_list_repo_tree_name_prefix_root_path(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1414,7 +1414,7 @@ async def test_list_repo_tree_name_prefix_validation(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1468,7 +1468,7 @@ async def test_list_repo_tree_blank_name_prefix_is_byte_identical(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1517,7 +1517,7 @@ async def test_list_repo_tree_empty_with_name_prefix_returns_200(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1562,7 +1562,7 @@ async def test_list_repo_tree_empty_path_with_cursor_no_404(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")
@@ -1607,7 +1607,7 @@ async def test_list_repo_tree_link_header_preserves_name_prefix(monkeypatch):
 
     monkeypatch.setattr(tree_api, "get_repository", lambda *args: repo)
     monkeypatch.setattr(tree_api, "check_repo_read_permission", lambda repo_arg, user: True)
-    monkeypatch.setattr(tree_api, "lakefs_repo_name", lambda repo_type, repo_id: "lake-repo")
+    monkeypatch.setattr(tree_api, "resolve_lakefs_repo", lambda repo: "lake-repo")
 
     async def _resolve_revision(client, lakefs_repo, revision):
         return ("resolved-main", "branch")

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -80,7 +80,7 @@ def test_format_hf_datetime_and_lakefs_error_classifiers(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_collect_hf_siblings_handles_pagination_and_lfs_metadata(monkeypatch):
-    repo_row = SimpleNamespace()
+    repo_row = SimpleNamespace(repo_type="model", full_id="alice/demo")
     calls = []
 
     class _FakeClient:
@@ -123,8 +123,8 @@ async def test_collect_hf_siblings_handles_pagination_and_lfs_metadata(monkeypat
 
     monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
     monkeypatch.setattr(
-        "kohakuhub.utils.lakefs.lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr(
         "kohakuhub.db_operations.should_use_lfs",
@@ -192,13 +192,13 @@ async def test_collect_hf_siblings_accepts_list_payload_without_pagination(monke
 
     monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
     monkeypatch.setattr(
-        "kohakuhub.utils.lakefs.lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr("kohakuhub.db_operations.should_use_lfs", lambda repo, path, size: False)
 
     siblings = await hf_utils.collect_hf_siblings(
-        SimpleNamespace(),
+        SimpleNamespace(repo_type="dataset", full_id="alice/data"),
         "dataset",
         "alice/data",
         "dev",
@@ -228,13 +228,13 @@ async def test_collect_hf_siblings_stops_when_pagination_cursor_is_missing(monke
 
     monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
     monkeypatch.setattr(
-        "kohakuhub.utils.lakefs.lakefs_repo_name",
-        lambda repo_type, repo_id: f"{repo_type}:{repo_id}",
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo",
+        lambda repo: f"{repo.repo_type}:{repo.full_id}",
     )
     monkeypatch.setattr("kohakuhub.db_operations.should_use_lfs", lambda repo, path, size: False)
 
     siblings = await hf_utils.collect_hf_siblings(
-        SimpleNamespace(),
+        SimpleNamespace(repo_type="model", full_id="alice/demo"),
         "model",
         "alice/demo",
         "main",

--- a/test/kohakuhub/api/test_branches_unit.py
+++ b/test/kohakuhub/api/test_branches_unit.py
@@ -108,13 +108,13 @@ def _response_error_message(response) -> str:
 
 @pytest.mark.asyncio
 async def test_create_branch_and_tag_routes_cover_success_and_error_paths(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_delete_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
 
     create_branch_response = await branches_api.create_branch(
@@ -201,13 +201,13 @@ async def test_create_branch_and_tag_routes_cover_success_and_error_paths(monkey
 
 @pytest.mark.asyncio
 async def test_delete_branch_and_tag_cover_success_not_found_and_guardrails(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_delete_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
 
     main_response = await branches_api.delete_branch("model", "owner", "repo", "main", user=user)
@@ -234,7 +234,7 @@ async def test_delete_branch_and_tag_cover_success_not_found_and_guardrails(monk
 
 @pytest.mark.asyncio
 async def test_reference_helpers_and_list_repo_refs_cover_pagination_and_fallback(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     client = _FakeClient()
     warnings = []
 
@@ -255,7 +255,7 @@ async def test_reference_helpers_and_list_repo_refs_cover_pagination_and_fallbac
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_read_permission", lambda repo_arg, user: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(branches_api.logger, "warning", lambda message: warnings.append(message))
 
@@ -281,14 +281,14 @@ async def test_reference_helpers_and_list_repo_refs_cover_pagination_and_fallbac
 
 @pytest.mark.asyncio
 async def test_revert_branch_covers_not_found_conflict_success_and_tracking_failure(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
     created_commits = []
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_write_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(branches_api, "track_commit_lfs_objects", lambda **kwargs: _async_return(2))
     monkeypatch.setattr(branches_api, "create_commit", lambda **kwargs: created_commits.append(kwargs))
@@ -380,14 +380,14 @@ def _async_return(value):
 
 @pytest.mark.asyncio
 async def test_merge_branches_covers_not_found_conflict_success_and_tracking_paths(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
     created_commits = []
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_write_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(branches_api, "track_commit_lfs_objects", lambda **kwargs: _async_return(1))
     monkeypatch.setattr(branches_api, "create_commit", lambda **kwargs: created_commits.append(kwargs))
@@ -440,7 +440,7 @@ async def test_merge_branches_covers_not_found_conflict_success_and_tracking_pat
 
 @pytest.mark.asyncio
 async def test_reset_branch_covers_guardrails_recoverability_success_and_failures(monkeypatch):
-    repo = SimpleNamespace(full_id="owner/repo")
+    repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
     created_commits = []
@@ -448,7 +448,7 @@ async def test_reset_branch_covers_guardrails_recoverability_success_and_failure
 
     monkeypatch.setattr(branches_api, "get_repository", lambda *_args: repo)
     monkeypatch.setattr(branches_api, "check_repo_write_permission", lambda repo_arg, user_arg: None)
-    monkeypatch.setattr(branches_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(branches_api, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(branches_api, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(branches_api, "check_commit_range_recoverability", lambda **kwargs: _async_return((True, [], [])))
     monkeypatch.setattr(branches_api, "sync_file_table_with_commit", lambda **kwargs: synced_refs.append(kwargs) or _async_return(3))

--- a/test/kohakuhub/api/test_files_unit.py
+++ b/test/kohakuhub/api/test_files_unit.py
@@ -132,7 +132,7 @@ async def test_preupload_and_revision_cover_validation_quota_and_resolution_erro
     monkeypatch.setattr(files_api, "check_repo_write_permission", lambda repo_row, user: None)
     monkeypatch.setattr(files_api, "get_organization", lambda namespace: None)
     monkeypatch.setattr(files_api, "get_effective_lfs_threshold", lambda repo_row: 1024)
-    monkeypatch.setattr(files_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(files_api, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(
         files_api,
         "process_preupload_file",
@@ -323,7 +323,7 @@ async def test_metadata_and_resolve_routes_cover_storage_backend_fallback_and_xe
 
     monkeypatch.setattr(files_api, "get_repository", lambda repo_type, namespace, name: repo)
     monkeypatch.setattr(files_api, "check_repo_read_permission", lambda repo_row, user: None)
-    monkeypatch.setattr(files_api, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(files_api, "resolve_lakefs_repo", lambda repo: "model:owner/repo")
     monkeypatch.setattr(files_api, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(files_api, "parse_s3_uri", lambda uri: ("bucket", "key/path.txt"))
     monkeypatch.setattr(

--- a/test/kohakuhub/api/test_huggingface_hub_compat.py
+++ b/test/kohakuhub/api/test_huggingface_hub_compat.py
@@ -506,7 +506,9 @@ async def test_hf_move_repo_frees_the_old_name_for_immediate_reuse(
     recreated = await asyncio.to_thread(
         lambda: api.repo_info(repo_id=source_id, repo_type="dataset")
     )
-    recreated_files = {sibling.rfilename for sibling in recreated.siblings}
+    # `siblings` is None rather than [] for an empty repo on huggingface_hub
+    # < 1.0, and an empty repo is exactly what this asserts.
+    recreated_files = {sibling.rfilename for sibling in (recreated.siblings or [])}
     assert "README.md" not in recreated_files, (
         "the recreated repo must be empty, not aliased onto the renamed one's data"
     )
@@ -516,7 +518,7 @@ async def test_hf_move_repo_frees_the_old_name_for_immediate_reuse(
     renamed = await asyncio.to_thread(
         lambda: api.repo_info(repo_id=renamed_id, repo_type="dataset")
     )
-    renamed_files = {sibling.rfilename for sibling in renamed.siblings}
+    renamed_files = {sibling.rfilename for sibling in (renamed.siblings or [])}
     assert {"README.md", "table.parquet"} <= renamed_files
 
     # The two repos must be backed by different LakeFS repositories, otherwise
@@ -540,4 +542,4 @@ async def test_hf_move_repo_frees_the_old_name_for_immediate_reuse(
     renamed_after = await asyncio.to_thread(
         lambda: api.repo_info(repo_id=renamed_id, repo_type="dataset")
     )
-    assert "NEW.md" not in {s.rfilename for s in renamed_after.siblings}
+    assert "NEW.md" not in {s.rfilename for s in (renamed_after.siblings or [])}

--- a/test/kohakuhub/api/test_huggingface_hub_compat.py
+++ b/test/kohakuhub/api/test_huggingface_hub_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 from pathlib import Path
 
 import pytest
@@ -415,3 +416,128 @@ async def test_hf_api_likes_visibility_move_delete_and_list_liked_repos(
         )
         is False
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #93: renaming a repo must free its name immediately.
+# ---------------------------------------------------------------------------
+
+
+def test_hf_client_still_retries_on_our_conflict_sentence():
+    """Pin our retry sentence to the one huggingface_hub actually looks for.
+
+    `HfApi.create_repo` wraps its POST in `while True` and retries only when the
+    response body contains this exact sentence. If a future huggingface_hub
+    reworded it, our 409 would stop being retryable and - worse - would start
+    being swallowed by `create_repo(exist_ok=True)` as "already exists". This
+    runs against every version in the CI matrix, so it fails loudly if that
+    happens rather than silently degrading.
+    """
+    import inspect
+
+    from huggingface_hub import hf_api as hf_api_module
+
+    from kohakuhub.api.repo.routers.crud import LAKEFS_CONFLICT_RETRY_MESSAGE
+
+    source = inspect.getsource(hf_api_module)
+    assert LAKEFS_CONFLICT_RETRY_MESSAGE in source, (
+        "huggingface_hub no longer contains the conflict sentence we emit; "
+        "create_repo will not retry our recycling 409 anymore"
+    )
+
+
+async def test_hf_move_repo_frees_the_old_name_for_immediate_reuse(
+    live_server_url,
+    hf_api_token,
+):
+    """End-to-end reproduction of issue #93.
+
+    Renaming a dataset and immediately recreating the original name used to fail
+    with a 500 wrapping LakeFS's `409 not unique`, because the LakeFS repository
+    id is derived from the repo id and LakeFS deletes asynchronously. It must now
+    succeed straight away, with the renamed repo left intact.
+    """
+    api = HfApi(endpoint=live_server_url, token=hf_api_token)
+    source_id = "owner/issue93-index"
+    renamed_id = "owner/issue93-index-deprecate"
+
+    await asyncio.to_thread(
+        lambda: api.create_repo(repo_id=source_id, repo_type="dataset", private=True)
+    )
+
+    # A regular file and an LFS-sized one, so the rename exercises both the
+    # re-upload and the physical-address linking paths (the test profile sets the
+    # LFS threshold to 1 KiB).
+    #
+    # Both are passed as file-like objects rather than raw bytes on purpose:
+    # huggingface_hub >= 1.0 routes byte payloads through Xet storage when
+    # hf_xet is installed, and this server does not implement the Xet upload
+    # endpoints. A buffer is explicitly unsupported by Xet, so the client falls
+    # back to the plain HTTP/LFS path this test means to exercise.
+    await asyncio.to_thread(
+        lambda: api.upload_file(
+            path_or_fileobj=io.BytesIO(b"# issue 93\n"),
+            path_in_repo="README.md",
+            repo_id=source_id,
+            repo_type="dataset",
+        )
+    )
+    await asyncio.to_thread(
+        lambda: api.upload_file(
+            path_or_fileobj=io.BytesIO(b"x" * 4096),
+            path_in_repo="table.parquet",
+            repo_id=source_id,
+            repo_type="dataset",
+        )
+    )
+
+    await asyncio.to_thread(
+        lambda: api.move_repo(
+            from_id=source_id, to_id=renamed_id, repo_type="dataset"
+        )
+    )
+
+    # The freed name must be usable right away. Pre-fix this raised
+    # HfHubHTTPError(500).
+    await asyncio.to_thread(
+        lambda: api.create_repo(repo_id=source_id, repo_type="dataset", private=True)
+    )
+
+    recreated = await asyncio.to_thread(
+        lambda: api.repo_info(repo_id=source_id, repo_type="dataset")
+    )
+    recreated_files = {sibling.rfilename for sibling in recreated.siblings}
+    assert "README.md" not in recreated_files, (
+        "the recreated repo must be empty, not aliased onto the renamed one's data"
+    )
+    assert "table.parquet" not in recreated_files
+
+    # And the renamed repo keeps its content.
+    renamed = await asyncio.to_thread(
+        lambda: api.repo_info(repo_id=renamed_id, repo_type="dataset")
+    )
+    renamed_files = {sibling.rfilename for sibling in renamed.siblings}
+    assert {"README.md", "table.parquet"} <= renamed_files
+
+    # The two repos must be backed by different LakeFS repositories, otherwise
+    # writing to one would corrupt the other.
+    from kohakuhub.db_operations import get_repository
+    from kohakuhub.utils.lakefs import resolve_lakefs_repo
+
+    recreated_row = get_repository("dataset", "owner", "issue93-index")
+    renamed_row = get_repository("dataset", "owner", "issue93-index-deprecate")
+    assert resolve_lakefs_repo(recreated_row) != resolve_lakefs_repo(renamed_row)
+
+    # Writing to the recreated repo must not touch the renamed one.
+    await asyncio.to_thread(
+        lambda: api.upload_file(
+            path_or_fileobj=io.BytesIO(b"fresh\n"),
+            path_in_repo="NEW.md",
+            repo_id=source_id,
+            repo_type="dataset",
+        )
+    )
+    renamed_after = await asyncio.to_thread(
+        lambda: api.repo_info(repo_id=renamed_id, repo_type="dataset")
+    )
+    assert "NEW.md" not in {s.rfilename for s in renamed_after.siblings}

--- a/test/kohakuhub/api/xet/routers/test_cas.py
+++ b/test/kohakuhub/api/xet/routers/test_cas.py
@@ -40,7 +40,7 @@ async def test_get_reconstruction_returns_chunked_response(monkeypatch):
 
     monkeypatch.setattr(cas_router, "lookup_file_by_sha256", lambda file_id: (repo, file_record))
     monkeypatch.setattr(cas_router, "check_file_read_permission", lambda repo_arg, user: seen.setdefault("permission", (repo_arg, user)))
-    monkeypatch.setattr(cas_router, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(cas_router, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(cas_router, "get_lakefs_client", lambda: FakeClient())
     monkeypatch.setattr(cas_router, "parse_s3_uri", lambda uri: ("bucket", "path/to/object"))
 
@@ -79,7 +79,7 @@ async def test_get_reconstruction_raises_not_found_when_lakefs_lookup_fails(monk
 
     monkeypatch.setattr(cas_router, "lookup_file_by_sha256", lambda file_id: (repo, file_record))
     monkeypatch.setattr(cas_router, "check_file_read_permission", lambda repo_arg, user: None)
-    monkeypatch.setattr(cas_router, "lakefs_repo_name", lambda repo_type, repo_id: f"{repo_type}:{repo_id}")
+    monkeypatch.setattr(cas_router, "resolve_lakefs_repo", lambda repo: f"{repo.repo_type}:{repo.full_id}")
     monkeypatch.setattr(cas_router, "get_lakefs_client", lambda: FakeClient())
 
     with pytest.raises(HTTPException) as exc_info:

--- a/test/kohakuhub/support/service_bootstrap.py
+++ b/test/kohakuhub/support/service_bootstrap.py
@@ -107,6 +107,13 @@ def apply_service_test_env() -> None:
         lakefs_credentials = _read_env_file(DEV_LAKEFS_CREDENTIALS_FILE)
 
     forced_env = {
+        # This server declares XET_ENABLE = False and implements no Xet upload
+        # endpoints, so the client must not route byte payloads through Xet
+        # storage. huggingface_hub >= 1.0 does so whenever hf_xet is installed,
+        # which otherwise fails uploads with a 404 on xet-write-token. Read at
+        # huggingface_hub import time, which is why it is set here rather than in
+        # individual tests. Older clients have no Xet support and ignore it.
+        "HF_HUB_DISABLE_XET": "1",
         "KOHAKU_HUB_BASE_URL": "http://testserver",
         "KOHAKU_HUB_INTERNAL_BASE_URL": "http://testserver",
         "KOHAKU_HUB_API_BASE": "/api",

--- a/test/kohakuhub/utils/test_lakefs.py
+++ b/test/kohakuhub/utils/test_lakefs.py
@@ -1,8 +1,16 @@
 """Tests for LakeFS utility helpers."""
 
+from types import SimpleNamespace
+
 import pytest
 
-from kohakuhub.utils.lakefs import _sanitize_repo_id, lakefs_repo_name, resolve_revision
+from kohakuhub.utils.lakefs import (
+    _sanitize_repo_id,
+    allocate_lakefs_repo_name,
+    lakefs_repo_name,
+    resolve_lakefs_repo,
+    resolve_revision,
+)
 from test.kohakuhub.support.fakes import FakeLakeFSClient, FakeS3Service
 
 
@@ -16,6 +24,108 @@ def test_lakefs_repo_name_is_deterministic_and_length_bound():
     assert repo_name == lakefs_repo_name("model", "owner/demo-model")
     assert len(repo_name) <= 63
     assert repo_name.startswith("m-")
+
+
+def test_lakefs_repo_name_generation_zero_matches_the_legacy_name():
+    """Generation 0 must stay byte-identical to the pre-generation scheme.
+
+    Existing repositories were created under that scheme and migration 016
+    backfills Repository.lakefs_repo with it, so any drift would point stored
+    ids at LakeFS repositories that do not exist.
+    """
+    assert lakefs_repo_name("dataset", "owner/demo", generation=0) == lakefs_repo_name(
+        "dataset", "owner/demo"
+    )
+
+
+@pytest.mark.parametrize("repo_type", ["model", "dataset", "space"])
+def test_lakefs_repo_name_generations_are_distinct_and_length_bound(repo_type):
+    names = {
+        lakefs_repo_name(repo_type, "owner/demo-repo", generation=generation)
+        for generation in range(5)
+    }
+
+    assert len(names) == 5, "each generation must map to its own LakeFS repository"
+    for name in names:
+        assert len(name) <= 63, "LakeFS rejects ids longer than 63 characters"
+        assert name.startswith(repo_type[0])
+
+
+def test_lakefs_repo_name_generation_stays_bound_for_maximally_long_ids():
+    """The layout is exactly 63 chars at generation 0, so the generation token
+    must live in the hash input rather than being appended to the name."""
+    long_id = "a" * 40 + "/" + "b" * 60
+
+    for generation in range(3):
+        name = lakefs_repo_name("model", long_id, generation=generation)
+        assert len(name) <= 63
+
+
+def test_resolve_lakefs_repo_prefers_the_stored_id():
+    repo = SimpleNamespace(
+        repo_type="dataset", full_id="owner/demo", lakefs_repo="d-stored-id"
+    )
+
+    assert resolve_lakefs_repo(repo) == "d-stored-id"
+
+
+@pytest.mark.parametrize("stored", [None, ""])
+def test_resolve_lakefs_repo_falls_back_to_derivation_when_unset(stored):
+    """Rows created before migration 016 have no stored id; they must keep
+    resolving to the derived (generation 0) name."""
+    repo = SimpleNamespace(
+        repo_type="dataset", full_id="owner/demo", lakefs_repo=stored
+    )
+
+    assert resolve_lakefs_repo(repo) == lakefs_repo_name("dataset", "owner/demo")
+
+
+def test_resolve_lakefs_repo_handles_rows_without_the_column():
+    """A Repository object that predates the column (e.g. a stub in tests) must
+    not raise - it should simply derive."""
+    repo = SimpleNamespace(repo_type="model", full_id="owner/demo")
+
+    assert resolve_lakefs_repo(repo) == lakefs_repo_name("model", "owner/demo")
+
+
+@pytest.mark.asyncio
+async def test_allocate_lakefs_repo_name_returns_generation_zero_when_free():
+    s3 = FakeS3Service()
+    lakefs = FakeLakeFSClient(s3_service=s3, default_bucket="test-bucket")
+
+    allocated = await allocate_lakefs_repo_name(lakefs, "dataset", "owner/demo")
+
+    assert allocated == lakefs_repo_name("dataset", "owner/demo")
+
+
+@pytest.mark.asyncio
+async def test_allocate_lakefs_repo_name_skips_ids_still_held_by_lakefs():
+    """The core of issue #93: a rename deletes the old LakeFS repository, but
+    the deletion is asynchronous, so the id stays taken for a while. Allocation
+    must step over it instead of colliding."""
+    s3 = FakeS3Service()
+    lakefs = FakeLakeFSClient(s3_service=s3, default_bucket="test-bucket")
+    taken = lakefs_repo_name("dataset", "owner/demo")
+    await lakefs.create_repository(
+        name=taken,
+        storage_namespace=f"s3://test-bucket/{taken}",
+        default_branch="main",
+    )
+
+    allocated = await allocate_lakefs_repo_name(lakefs, "dataset", "owner/demo")
+
+    assert allocated == lakefs_repo_name("dataset", "owner/demo", generation=1)
+    assert allocated != taken
+
+
+@pytest.mark.asyncio
+async def test_allocate_lakefs_repo_name_raises_when_every_generation_is_taken():
+    class _AllTaken:
+        async def repository_exists(self, repo_name):
+            return True
+
+    with pytest.raises(RuntimeError):
+        await allocate_lakefs_repo_name(_AllTaken(), "model", "owner/demo")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #93.

Renaming a repo left the freed name unusable for minutes: `create_repo` failed with a `500` wrapping LakeFS's `409 not unique`, and nothing in the response told a client that waiting was the right move.

## Root cause

Three things line up:

1. `lakefs_repo_name()` derives the LakeFS repository id deterministically from the repo id, with no random component. A freed repo id therefore maps straight back to the LakeFS repository a rename just deleted.
2. LakeFS deletes repositories **asynchronously**. `DELETE /repositories/{id}` is acked before the record is gone; measured locally on a repo with 40 objects across 6 commits, `GET /repositories/{id}` kept answering **200** and `POST /repositories` kept answering **409 `not unique`** for ~6 s after the 204. The window scales with how much metadata the cleanup has to remove, so a 141 MB dataset with months of history taking minutes is consistent.
3. `_migrate_lakefs_repository` deletes the old repository and then deletes its S3 prefix, removing the `_lakefs/dummy` marker. LakeFS checks *storage-namespace-in-use* before *id uniqueness*, so wiping the marker lets the request reach the uniqueness check — which is the error the existing `_is_lakefs_namespace_in_use_error` recovery path does **not** cover. Everything else fell through to `hf_server_error`, i.e. a 500.

`squash_repo` already worked around this with its own wait-for-deletion loop ("This ensures we can reuse the name immediately"); `move_repo` never got the same treatment.

## What changed

**Allocated, not derived, LakeFS repository ids.** `Repository.lakefs_repo` now records which LakeFS repository a row owns, and `resolve_lakefs_repo(row)` is the single way to read it. `allocate_lakefs_repo_name()` picks generation 0 — the legacy derived name — whenever it is free, and steps to the next generation when it is not, so a create under a just-freed name can never collide with a pending deletion.

The name layout is exactly 63 characters at generation 0, which is LakeFS's maximum, so there is no room to append a generation token. The generation goes into the **hash input** instead: `hash(repo_id)` for generation 0, `hash(f"{repo_id}#{N}")` after that. Generation 0 stays byte-identical to the previous scheme, which is what makes the backfill below safe.

**A wait, bounded, for the asynchronous deletion.** `_migrate_lakefs_repository` now waits for the old repository to actually disappear before returning (20 × 0.5 s). This is what keeps the common case from surfacing a conflict at all. Timing out is not an error — the move itself already succeeded — and it replaces the two bespoke wait loops `squash_repo` was carrying.

**A conflict clients already know how to retry.** If allocation still races LakeFS, `create_repo` now answers `409` with a body containing `Cannot create repo: another conflicting operation is in progress`, held for 2 s.

That wording is load-bearing, and it comes from reading the client rather than guessing: `HfApi.create_repo` wraps its POST in `while True` and retries only on a 409 whose `r.text` contains that exact sentence. The check is present unchanged in **every** version in this repo's CI matrix (verified 0.20.3, 0.30.2, 0.36.0, 1.0.1, 1.6.0, 1.27.0), so existing clients — including the 0.36.0 in the issue report — recover transparently with no client change.

Two consequences worth spelling out:

- It must be in the **body**. `hf_error_response` deliberately writes an empty body and puts everything in `X-Error-*` headers, so it cannot be used here.
- A 409 **without** that sentence is worse than the 500 it replaces: `create_repo(exist_ok=True)` swallows a bare 409 as "repo already exists" and returns successfully, leaving the caller uploading into a repo that does not exist. `test_hf_client_still_retries_on_our_conflict_sentence` pins our constant against `huggingface_hub`'s own source so a future rewording fails CI instead of silently degrading.
- The client's retry loop has no sleep and no attempt limit, which is why the server supplies the 2 s pacing. `Retry-After` is set for correctness but `create_repo` bypasses `http_backoff` entirely, so nothing in hf_hub consults it.

`X-Error-Code: RepoNameRecycling` is informational only — `hf_raise_for_status` has no 409 branch, so no HF client reads it for this status.

## Database change

`Repository.lakefs_repo` (`VARCHAR(255)`, nullable, indexed), plus `scripts/db_migrations/016_repository_lakefs_repo.py`.

- **NULL means "derive"**, so the service behaves correctly even if the migration has not run; `resolve_lakefs_repo` falls back to the generation-0 derivation.
- The backfill uses a **frozen copy** of the derivation rather than importing `lakefs_repo_name`. If it imported the live function, a future change to it would retroactively change what the backfill writes for repositories that were created under the old scheme — pointing stored ids at LakeFS repositories that do not exist. A differential test over 3013 generated inputs (plus unicode, over-long, and unknown-repo-type cases) confirms the frozen copy matches the current function exactly.
- The index is deliberately **not unique**. Uniqueness is the real invariant, but enforcing it in this migration would fail on any deployment with pre-existing duplicates; the migration reports whether the backfilled values are distinct so that a follow-up can promote it once operators confirm.

Verified locally against the dev stack: applied to a seeded Postgres (30 rows), the backfilled ids form an exact bijection with the 30 live LakeFS repositories; re-running reports "Already applied"; the SQLite branch adds column, index and backfill correctly on an older schema. Note that `run_migrations.py` skips migrations entirely on a fresh database and builds the schema from the models, which is why the model field and the migration have to land together.

## Tests

- `test/kohakuhub/utils/test_lakefs.py` — generation 0 equals the legacy name; generations are distinct and stay within 63 chars even for maximally long repo ids; `resolve_lakefs_repo` prefers the stored id and falls back for pre-migration rows; allocation skips ids LakeFS still holds and raises when every generation is taken.
- `test/kohakuhub/api/repo/routers/test_crud_unit.py` — the id-taken error is distinguished from the namespace-in-use error and from unrelated failures (including a status-code-aware case, so a repo name containing "409" cannot misfire); the recycling response carries the sentence in its body; `create_repo` holds for the configured interval and leaves no half-created row; the allocated id is persisted and drives the storage namespace; the deletion wait polls, is bounded, and survives probe errors.
- `test/kohakuhub/api/test_huggingface_hub_compat.py` — end-to-end through the real `huggingface_hub` client: create a dataset with a regular and an LFS-sized file, `move_repo`, then immediately `create_repo` under the old name. Asserts the recreated repo is empty rather than aliased onto the renamed one's data, that the renamed repo keeps its content, that the two are backed by different LakeFS repositories, and that writing to one does not appear in the other.

Allocation probes LakeFS before anything is created, which is a new place both routes can fail, so there are tests pinning that a failure there keeps the header-based error shape (`hf_server_error` / `HTTPException(500)`) rather than escaping as a bare 500.

The existing unit tests that stubbed `lakefs_repo_name` were retargeted at `resolve_lakefs_repo`, since that is where the seam now is. One of them - `test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup` - also had to start stubbing the LakeFS client: it previously never touched it, and the new allocation probe would otherwise reach whatever LakeFS the environment points at (it passed locally against a running dev stack and failed in CI with a 401).

## Two test-infrastructure fixes the matrix forced out

Neither is related to the fix itself, but the matrix is red without them:

- **`siblings` is `None`, not `[]`, on huggingface_hub < 1.0** when a repo has no files - and an empty recreated repo is precisely what the e2e test asserts. It failed on the 0.20.3 legs with `'NoneType' object is not iterable`.
- **`HF_HUB_DISABLE_XET=1` is now forced in the test profile.** The server declares `XET_ENABLE = False` and implements no Xet upload endpoints, but huggingface_hub >= 1.0 routes byte payloads through Xet whenever `hf_xet` is installed, so uploads fail with a 404 on `xet-write-token`. That takes out three `test_huggingface_hub_deep` tests on the `latest` legs. It reproduces on main with a current huggingface_hub, so it is a newer client release rather than a regression here - main's last CI run predates it. The variable is read at huggingface_hub import time, hence setting it in `apply_service_test_env` rather than per test; clients without Xet support ignore it.

## Also included

`scripts/dev/up_infra.sh` gained two guards for bringing the dev stack up under rootless Docker, found while reproducing this issue locally. Both are conditional, so rootful hosts without a proxy behave exactly as before:

- The LakeFS container was started with `--user "$(id -u):$(id -g)"`. Under rootless Docker the host uid/gid sit outside the container's id mapping and `runc` aborts with `setgroups: invalid argument`; container root is already mapped to the invoking user there, so it now runs as `0:0` with `HOME=/` set explicitly. `HOME` matters: the config's `committed.local_cache.dir` is `~/lakefs/data/cache`, and the cache bind mount is at `/lakefs/data/cache`, which only lines up because the rootful uid has no `/etc/passwd` entry and Docker falls back to `HOME=/`. Leaving it unset would silently move the cache off the persisted volume.
- A Docker client with a `proxies` block in `~/.docker/config.json` injects `HTTP_PROXY`/`NO_PROXY` into every container. `NO_PROXY` is matched against the hostname, so the container-network CIDRs it usually lists do not exempt LakeFS reaching MinIO *by container name* — those S3 calls get routed to the host proxy and come back as a 503, which surfaces as `failed to create repository: failed to access storage`. The MinIO container name is now added to the LakeFS container's `NO_PROXY`.

## Not addressed here

The issue's third point — `repo_info` answering for a repo every other endpoint reports as absent — is a separate concern and is left out of this PR. It is not caused by the rename: `@with_repo_fallback("info")` serves any locally-absent repo id from a configured upstream, which is intentional mirror behaviour. The useful change there is making the fallback origin visible to typed clients (the response already carries `_source`, but `ModelInfo`/`DatasetInfo` drop unknown fields), and that deserves its own discussion.
