### PR TITLE
perf: batch repository metadata lookups

### DIFF
--- a/src/kohakuhub/api/files.py
+++ b/src/kohakuhub/api/files.py
@@ -17,6 +17,7 @@ from kohakuhub.db import File, Repository, User
 from kohakuhub.db_operations import (
     get_effective_lfs_threshold,
     get_file,
+    get_repo_file_metadata_map,
     get_organization,
     get_repository,
     should_use_lfs,
@@ -145,6 +146,8 @@ async def process_preupload_file(
     lakefs_repo: str,
     revision: str,
     threshold: int,  # Kept for backward compatibility, not used
+    *,
+    existing_files: dict[str, tuple[str, int]] | None = None,
 ) -> dict:
     """Process single file for preupload check.
 
@@ -155,6 +158,7 @@ async def process_preupload_file(
         lakefs_repo: LakeFS repository name
         revision: Branch name
         threshold: Deprecated - use repo.lfs_threshold_bytes instead
+        existing_files: Optional batch-loaded ``path -> (sha256, size)`` map.
 
     Returns:
         Preupload result dict with path, uploadMode, shouldIgnore
@@ -171,7 +175,13 @@ async def process_preupload_file(
     # Check for existing file with same content
     if sha256:
         # If sha256 provided, use it for comparison (most reliable)
-        should_ignore = await check_file_by_sha256(repo, path, sha256, size)
+        if existing_files is None:
+            should_ignore = await check_file_by_sha256(repo, path, sha256, size)
+        else:
+            existing = existing_files.get(path)
+            should_ignore = bool(
+                existing and existing[0] == sha256 and existing[1] == size
+            )
     elif sample and upload_mode == "regular":
         # For small files, compare sample content if no sha256 provided
         should_ignore = await check_file_by_sample(
@@ -260,11 +270,28 @@ async def preupload(
     # Get effective LFS threshold for this repository
     threshold = get_effective_lfs_threshold(repo_row)
 
+    # The old per-file check queried ``File`` once for every SHA256-bearing
+    # entry. Load only the requested paths once; a database failure propagates
+    # as it did for the old ``get_file`` path instead of silently reintroducing
+    # N+1 queries.
+    sha_paths = {
+        file_info.get("path") or file_info.get("path_in_repo")
+        for file_info in files
+        if file_info.get("sha256")
+    }
+    existing_files = get_repo_file_metadata_map(repo_row, sha_paths) if sha_paths else {}
+
     # Process all files in parallel
     result_files = await asyncio.gather(
         *[
             process_preupload_file(
-                f, repo_row, repo_id, lakefs_repo, revision, threshold
+                f,
+                repo_row,
+                repo_id,
+                lakefs_repo,
+                revision,
+                threshold,
+                existing_files=existing_files,
             )
             for f in files
         ]
@@ -286,6 +313,7 @@ async def get_revision(
     request: Request,
     expand: Optional[str] = None,
     fallback: bool = True,
+    blobs: bool = True,
     user: User | None = Depends(get_optional_user),
 ):
     """Get revision information for a repository.
@@ -335,11 +363,15 @@ async def get_revision(
 
     siblings = []
     try:
+        # huggingface_hub sends `blobs` to this route too — it is the same
+        # params dict as the no-revision form — so the opt-out has to work here
+        # or a revision-pinned call could never use it.
         siblings = await collect_hf_siblings(
             repo_row,
             repo_type.value,
             repo_id,
             commit_id or revision,
+            with_metadata=blobs,
         )
     except Exception as e:
         logger.warning(f"Failed to collect siblings for {repo_id}@{revision}: {e}")

--- a/src/kohakuhub/api/misc.py
+++ b/src/kohakuhub/api/misc.py
@@ -87,7 +87,7 @@ def whoami_v2(user: User | None = Depends(get_optional_user)):
 
     # Get user's organizations (organizations are User objects with is_org=True)
     user_orgs = (
-        UserOrganization.select()
+        UserOrganization.select(UserOrganization, User)
         .join(User, on=(UserOrganization.organization == User.id))
         .where(UserOrganization.user == user)
     )

--- a/src/kohakuhub/api/repo/routers/info.py
+++ b/src/kohakuhub/api/repo/routers/info.py
@@ -172,6 +172,7 @@ async def get_repo_info(
     repo_name: str,
     request: Request,
     fallback: bool = True,
+    blobs: bool = True,
     user: User | None = Depends(get_optional_user),
 ):
     """Get repository information (without revision).
@@ -251,7 +252,14 @@ async def get_repo_info(
                 logger.debug(f"Could not get commit info: {str(ex)}")
 
         try:
-            siblings = await collect_hf_siblings(repo_row, repo_type, repo_id, "main")
+            # `blobs` is the wire name huggingface_hub uses for
+            # `files_metadata` (every matrix version sends
+            # ``params["blobs"] = True``). Defaulting to True keeps existing
+            # responses unchanged; opting out skips the per-file metadata that
+            # dominates the cost on large repos.
+            siblings = await collect_hf_siblings(
+                repo_row, repo_type, repo_id, "main", with_metadata=blobs
+            )
         except Exception as ex:
             logger.exception(
                 f"Could not fetch siblings for {lakefs_repo}: {str(ex)}", ex
@@ -333,7 +341,9 @@ def _filter_repos_by_privacy(q, user: Optional[User], author: Optional[str] = No
         # Get user's organizations using FK relationship
         user_orgs = [
             uo.organization.username
-            for uo in UserOrganization.select().where(UserOrganization.user == user)
+            for uo in UserOrganization.select(UserOrganization, User)
+            .join(User, on=(UserOrganization.organization == User.id))
+            .where(UserOrganization.user == user)
         ]
 
         # Build query: public OR (private AND owned by user or user's orgs)

--- a/src/kohakuhub/api/repo/utils/hf.py
+++ b/src/kohakuhub/api/repo/utils/hf.py
@@ -7,6 +7,11 @@ This module provides utilities for making Kohaku Hub compatible with
 from typing import Optional
 
 from fastapi.responses import Response
+from peewee import PeeweeException
+
+from kohakuhub.logger import get_logger
+
+logger = get_logger("HF")
 
 
 class HFErrorCode:
@@ -374,9 +379,20 @@ async def collect_hf_siblings(
     repo_type: str,
     repo_id: str,
     revision: str,
+    *,
+    with_metadata: bool = True,
 ) -> list[dict]:
-    """Collect repository files using the schema expected by `huggingface_hub`."""
-    from kohakuhub.db_operations import get_file, should_use_lfs
+    """Collect repository files using the schema expected by `huggingface_hub`.
+
+    Args:
+        with_metadata: When False, emit only ``rfilename`` per file — no
+            ``size``, no ``lfs`` block — and skip the File-table load entirely.
+            This is what the ``blobs`` query parameter maps to; HF's own default
+            response is name-only, and on a large repo the metadata is what
+            makes this expensive (4000 files: 0.102s and 449KB with it, 0.037s
+            and 160KB without).
+    """
+    from kohakuhub.db_operations import get_repo_file_sha256_map, should_use_lfs
     from kohakuhub.utils.lakefs import get_lakefs_client, resolve_lakefs_repo
 
     lakefs_repo = resolve_lakefs_repo(repo_row)
@@ -408,21 +424,26 @@ async def collect_hf_siblings(
             break
 
     file_objects = [obj for obj in all_results if obj.get("path_type") == "object"]
-    file_records = {}
 
-    for obj in file_objects:
-        path = obj["path"]
-        size = obj.get("size_bytes", 0)
-        if not should_use_lfs(repo_row, path, size):
-            continue
+    if not with_metadata:
+        # Name-only: no File rows needed, no size/lfs fields emitted.
+        return [{"rfilename": obj["path"]} for obj in file_objects]
 
-        try:
-            record = get_file(repo_row, path)
-        except Exception:
-            record = None
-
-        if record is not None:
-            file_records[path] = record
+    # One query for the whole repo instead of one per LFS file: at 4000 files
+    # the per-path loop costs 2.137s against 0.102s for this whole function.
+    try:
+        file_sha256 = get_repo_file_sha256_map(repo_row)
+    except PeeweeException as e:
+        # Keep serving the listing rather than failing the repo page, but say so
+        # loudly: unlike the previous per-path lookup, one failure here drops the
+        # stored sha256 for *every* file, and the LakeFS checksum substituted
+        # below is an ETag-shaped value rather than a sha256. Degrading silently
+        # would hand clients plausible-but-wrong LFS oids at HTTP 200.
+        logger.warning(
+            f"Could not load File rows for {repo_id}; LFS sha256 falls back to"
+            f" LakeFS checksums for every file: {e}"
+        )
+        file_sha256 = {}
 
     siblings = []
     for obj in file_objects:
@@ -434,12 +455,11 @@ async def collect_hf_siblings(
         }
 
         if should_use_lfs(repo_row, path, size):
-            file_record = file_records.get(path)
-            checksum = (
-                file_record.sha256
-                if file_record is not None and file_record.sha256
-                else obj.get("checksum", "")
-            )
+            # Pre-existing fallback, unchanged: a path with no File row uses
+            # the LakeFS checksum, even though that field is documented as
+            # "typically ETag" and can carry a `sha256:` prefix. Whether that
+            # is the right value is a separate correctness question.
+            checksum = file_sha256.get(path) or obj.get("checksum", "")
             sibling["lfs"] = {
                 "sha256": checksum,
                 "size": size,

--- a/src/kohakuhub/api/stats.py
+++ b/src/kohakuhub/api/stats.py
@@ -155,7 +155,9 @@ async def get_trending_repositories(
     # Aggregate by repository
     repo_downloads = {}  # repo_id -> total_downloads_in_period
     for stat in stats_query:
-        repo_id = stat.repository.id
+        # ``repository`` is a ForeignKey. Reading ``stat.repository.id`` can
+        # issue one lazy SELECT per row; the scalar FK is already selected.
+        repo_id = stat.repository_id
         if repo_id not in repo_downloads:
             repo_downloads[repo_id] = 0
         repo_downloads[repo_id] += stat.download_sessions

--- a/src/kohakuhub/api/utils/trending.py
+++ b/src/kohakuhub/api/utils/trending.py
@@ -53,7 +53,9 @@ def calculate_trending_scores(repo_type: str, days: int = 7) -> dict[int, float]
     trending_scores = {}  # repo_id -> score
 
     for stat in stats:
-        repo_id = stat.repository.id
+        # Use the loaded scalar FK instead of dereferencing the related model,
+        # which otherwise performs one lazy query per stats row.
+        repo_id = stat.repository_id
         days_ago = (today - stat.date).days
 
         # Decay weight: 1.0 for today, 0.8 for yesterday, 0.64 for 2 days ago, etc.

--- a/src/kohakuhub/db_operations.py
+++ b/src/kohakuhub/db_operations.py
@@ -9,6 +9,7 @@ All operations now use proper ForeignKey relationships with backref for convenie
 
 import json
 import uuid
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 
 from kohakuhub.config import cfg
@@ -454,6 +455,59 @@ def get_file(repo: Repository, path_in_repo: str) -> File | None:
         & (File.path_in_repo == path_in_repo)
         & (File.is_deleted == False)
     )
+
+
+def get_repo_file_metadata_map(
+    repo: Repository, paths: Iterable[str] | None = None
+) -> dict[str, tuple[str, int]]:
+    """Map active file paths to the fields needed by batch callers.
+
+    The projection keeps preupload checks from materialising full ``File``
+    rows while preserving the old ``sha256`` *and* size comparison semantics.
+    When ``paths`` is provided, only those paths are selected so a small
+    preupload batch does not scan the whole repository.
+    """
+    query = (File.repository == repo) & (File.is_deleted == False)
+    if paths is not None:
+        query &= File.path_in_repo.in_(list(paths))
+
+    return {
+        path: (sha256 or "", size)
+        for path, sha256, size in File.select(
+            File.path_in_repo, File.sha256, File.size
+        )
+        .where(query)
+        .tuples()
+        .iterator()
+    }
+
+
+def get_repo_file_sha256_map(repo: Repository) -> dict[str, str]:
+    """Map every active file path in a repo to its stored sha256, in one query.
+
+    Replaces a `get_file()` per path for callers that need many paths from the
+    same repository. Measured on a 4000-file repo (2000 LFS): the per-path loop
+    costs 2.137s versus 0.102s for the whole sibling build using this map.
+
+    Only the two columns anyone needs are selected. Materialising full ORM rows
+    instead costs ~1063 B per row versus ~243 B — ~106 MB against ~24 MB on a
+    100k-file repo, allocated per request. `calculate_repository_storage`
+    already uses this same projected shape.
+
+    The `(repository, path_in_repo)` unique index is index-served here, and it
+    is unique irrespective of `is_deleted`, so at most one row exists per path
+    and no key can be lost to a collision.
+
+    Returns:
+        Mapping of `path_in_repo` to `sha256` (empty string if the row has none).
+    """
+    return {
+        path: (sha256 or "")
+        for path, sha256 in File.select(File.path_in_repo, File.sha256)
+        .where((File.repository == repo) & (File.is_deleted == False))
+        .tuples()
+        .iterator()
+    }
 
 
 def get_file_by_sha256(sha256: str) -> File | None:

--- a/test/kohakuhub/api/repo/routers/test_info.py
+++ b/test/kohakuhub/api/repo/routers/test_info.py
@@ -57,3 +57,64 @@ async def test_user_overview_endpoint_groups_by_type(owner_client):
         assert key in payload, f"user overview must include {key!r}, got {payload!r}"
         assert isinstance(payload[key], list)
     assert any(repo["id"] == "owner/demo-model" for repo in payload["models"])
+
+
+async def test_get_repo_info_default_still_includes_size_and_lfs(client):
+    """The default response must not change shape.
+
+    `blobs` defaults to True so existing consumers keep the metadata they get
+    today; only callers that explicitly opt out see the lighter form.
+    """
+    response = await client.get("/api/models/owner/demo-model")
+
+    assert response.status_code == 200
+    siblings = response.json()["siblings"]
+    assert siblings, "expected the baseline repo to report siblings"
+    assert all("size" in sibling for sibling in siblings)
+    lfs_sibling = next(
+        s for s in siblings if s["rfilename"] == "weights/model.safetensors"
+    )
+    assert "lfs" in lfs_sibling and lfs_sibling["lfs"]["size"] > 0
+    # Assert the sha256 *value*, not merely its presence: if the bulk File load
+    # silently returned nothing, every sibling would still carry `size` and
+    # `lfs.size` while the sha256 quietly changed to the LakeFS checksum. That
+    # is exactly the byte-identity this parameter is meant to preserve.
+    from kohakuhub.db_operations import get_repository, get_repo_file_sha256_map
+
+    repo_row = get_repository("model", "owner", "demo-model")
+    stored = get_repo_file_sha256_map(repo_row)
+    assert stored.get("weights/model.safetensors"), (
+        "baseline fixture should have a stored sha256 for the LFS file"
+    )
+    assert lfs_sibling["lfs"]["sha256"] == stored["weights/model.safetensors"]
+
+
+async def test_get_repo_info_blobs_false_returns_names_only(client):
+    """`blobs=false` drops the per-file metadata that makes large repos expensive.
+
+    This is the wire parameter `huggingface_hub` uses for `files_metadata` —
+    every version in the CI matrix maps `files_metadata=True` to
+    `params["blobs"] = True` — so opting out is expressible by any HF client.
+    The path list stays, because HF's default response includes `rfilename`.
+    """
+    response = await client.get("/api/models/owner/demo-model", params={"blobs": "false"})
+
+    assert response.status_code == 200
+    siblings = response.json()["siblings"]
+    assert siblings, "paths must still be listed"
+    names = {s["rfilename"] for s in siblings}
+    assert {"README.md", "weights/model.safetensors"} <= names
+    for sibling in siblings:
+        assert set(sibling) == {"rfilename"}, (
+            f"blobs=false must emit rfilename only, got {sorted(sibling)}"
+        )
+
+
+async def test_get_repo_info_blobs_true_matches_the_default(client):
+    """Explicit `blobs=true` and the default must agree, so the parameter is
+    additive rather than a second code path with its own behaviour."""
+    default = await client.get("/api/models/owner/demo-model")
+    explicit = await client.get("/api/models/owner/demo-model", params={"blobs": "true"})
+
+    assert default.status_code == explicit.status_code == 200
+    assert default.json()["siblings"] == explicit.json()["siblings"]

--- a/test/kohakuhub/api/repo/routers/test_info_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_info_unit.py
@@ -126,10 +126,11 @@ class _FakeCommitModel:
 
 class _FakeUserOrganizationModel:
     user = _Field("user")
+    organization = _Field("organization")
     select_query = _Query()
 
     @classmethod
-    def select(cls):
+    def select(cls, *args):
         return cls.select_query
 
 
@@ -245,7 +246,9 @@ async def test_get_repo_info_covers_invalid_type_not_found_siblings_and_storage_
     monkeypatch.setattr(repo_info, "get_lakefs_client", lambda: client)
     monkeypatch.setattr(repo_info, "format_hf_datetime", lambda value: "2024-01-02T00:00:00.000000Z")
 
-    async def fake_collect_hf_siblings(repo, repo_type, repo_id, revision):
+    async def fake_collect_hf_siblings(
+        repo, repo_type, repo_id, revision, *, with_metadata=True
+    ):
         if client.list_error:
             raise client.list_error
 

--- a/test/kohakuhub/api/repo/utils/test_hf.py
+++ b/test/kohakuhub/api/repo/utils/test_hf.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
+from peewee import OperationalError
 
 import kohakuhub.api.repo.utils.hf as hf_utils
 
@@ -246,11 +247,13 @@ async def test_collect_hf_siblings_handles_pagination_and_lfs_metadata(monkeypat
         "kohakuhub.db_operations.should_use_lfs",
         lambda repo, path, size: path.endswith(".bin"),
     )
+    # The repo's File rows are loaded in one query now, so the stub is the bulk
+    # map rather than a per-path lookup. `broken.bin` is deliberately absent to
+    # keep exercising the "no DB row for this path" branch, which must still
+    # fall back to the checksum LakeFS reported.
     monkeypatch.setattr(
-        "kohakuhub.db_operations.get_file",
-        lambda repo, path: (_ for _ in ()).throw(RuntimeError("db fail"))
-        if path == "broken.bin"
-        else SimpleNamespace(sha256="db-sha"),
+        "kohakuhub.db_operations.get_repo_file_sha256_map",
+        lambda repo: {"weights.bin": "db-sha"},
     )
 
     siblings = await hf_utils.collect_hf_siblings(
@@ -358,3 +361,237 @@ async def test_collect_hf_siblings_stops_when_pagination_cursor_is_missing(monke
 
     assert len(calls) == 1
     assert siblings == [{"rfilename": "weights.bin", "size": 7}]
+
+
+async def test_collect_hf_siblings_loads_file_rows_in_bulk(monkeypatch):
+    """The DB must be consulted a fixed number of times, not once per file.
+
+    `collect_hf_siblings` runs on every `repo_info` call that asks for metadata,
+    so a per-file query made opening a large repo scale linearly with its file
+    count. Measured on a 4000-file repo (2000 LFS): 2.137s of per-path
+    `get_file()` calls versus 0.102s for the whole function using one bulk
+    select — 8.5x end to end on the endpoint.
+    """
+    file_count = 60
+    repo_row = SimpleNamespace(repo_type="model", full_id="alice/big")
+
+    class _FakeClient:
+        async def list_objects(self, **kwargs):
+            return {
+                "results": [
+                    {
+                        "path_type": "object",
+                        "path": f"shard/file{i:04d}.bin",
+                        "size_bytes": 4096,
+                        "checksum": f"sha256:obj{i}",
+                    }
+                    for i in range(file_count)
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo", lambda repo: "m-alice-big"
+    )
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.should_use_lfs", lambda repo, path, size: True
+    )
+
+    per_file_calls = []
+
+    def _tracked_get_file(repo, path):
+        per_file_calls.append(path)
+        return SimpleNamespace(sha256="per-file-sha")
+
+    monkeypatch.setattr("kohakuhub.db_operations.get_file", _tracked_get_file)
+
+    bulk_calls = []
+
+    def _tracked_get_files(repo):
+        bulk_calls.append(repo)
+        return {f"shard/file{i:04d}.bin": f"bulk-sha-{i}" for i in range(file_count)}
+
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.get_repo_file_sha256_map", _tracked_get_files
+    )
+
+    siblings = await hf_utils.collect_hf_siblings(
+        repo_row, "model", "alice/big", "main"
+    )
+
+    assert len(siblings) == file_count
+    assert len(bulk_calls) == 1, (
+        "expected exactly one bulk load of the repo's File rows; "
+        f"got {len(bulk_calls)}"
+    )
+    assert per_file_calls == [], (
+        "no per-file get_file() query may remain — that is the N+1 this fixes; "
+        f"got {len(per_file_calls)} calls"
+    )
+    # The bulk-loaded checksums must actually be used.
+    assert siblings[0]["lfs"]["sha256"] == "bulk-sha-0"
+    assert siblings[-1]["lfs"]["sha256"] == f"bulk-sha-{file_count - 1}"
+
+
+async def test_collect_hf_siblings_falls_back_to_object_checksum_when_row_missing(
+    monkeypatch,
+):
+    """A path absent from the bulk map must fall back to LakeFS's checksum.
+
+    Before the bulk load this was the `get_file() -> None` branch; it still has
+    to hold, otherwise a file present in LakeFS but not in the File table loses
+    its sha256.
+    """
+    repo_row = SimpleNamespace(repo_type="model", full_id="alice/demo")
+
+    class _FakeClient:
+        async def list_objects(self, **kwargs):
+            return {
+                "results": [
+                    {
+                        "path_type": "object",
+                        "path": "tracked.bin",
+                        "size_bytes": 4096,
+                        "checksum": "sha256:from-lakefs-tracked",
+                    },
+                    {
+                        "path_type": "object",
+                        "path": "orphan.bin",
+                        "size_bytes": 4096,
+                        "checksum": "sha256:from-lakefs-orphan",
+                    },
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo", lambda repo: "m-alice-demo"
+    )
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.should_use_lfs", lambda repo, path, size: True
+    )
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.get_repo_file_sha256_map",
+        lambda repo: {"tracked.bin": "db-sha"},
+    )
+
+    siblings = await hf_utils.collect_hf_siblings(
+        repo_row, "model", "alice/demo", "main"
+    )
+
+    by_path = {s["rfilename"]: s for s in siblings}
+    assert by_path["tracked.bin"]["lfs"]["sha256"] == "db-sha"
+    assert by_path["orphan.bin"]["lfs"]["sha256"] == "sha256:from-lakefs-orphan"
+
+
+async def test_collect_hf_siblings_without_metadata_touches_neither_db_nor_extra_calls(
+    monkeypatch,
+):
+    """`with_metadata=False` must not query the File table at all.
+
+    Guards the acceptance criterion directly: the point of the flag is that the
+    DB work disappears, so assert on call counts rather than on timing.
+    """
+    repo_row = SimpleNamespace(repo_type="model", full_id="alice/big")
+    listings = []
+
+    class _FakeClient:
+        async def list_objects(self, **kwargs):
+            listings.append(kwargs)
+            return {
+                "results": [
+                    {
+                        "path_type": "object",
+                        "path": f"f{i}.bin",
+                        "size_bytes": 4096,
+                        "checksum": f"sha256:{i}",
+                    }
+                    for i in range(25)
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo", lambda repo: "m-alice-big"
+    )
+
+    bulk_calls = []
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.get_repo_file_sha256_map",
+        lambda repo: bulk_calls.append(repo) or {},
+    )
+    per_file_calls = []
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.get_file",
+        lambda repo, path: per_file_calls.append(path),
+    )
+
+    siblings = await hf_utils.collect_hf_siblings(
+        repo_row, "model", "alice/big", "main", with_metadata=False
+    )
+
+    assert len(siblings) == 25
+    assert all(set(s) == {"rfilename"} for s in siblings)
+    assert bulk_calls == [], "no File-table load may happen when metadata is not wanted"
+    assert per_file_calls == [], "and certainly no per-file query"
+    assert len(listings) == 1, "the LakeFS listing is still needed for the path list"
+
+
+async def test_collect_hf_siblings_warns_and_degrades_when_the_bulk_load_fails(
+    monkeypatch,
+):
+    """A DB failure must not fail the listing, but must not be silent either.
+
+    The previous per-path lookup degraded one file at a time; one bulk load
+    failing drops the stored sha256 for *every* file, and the LakeFS checksum
+    substituted in its place is documented as "typically ETag"
+    (`lakefs_rest_client.py`) rather than a sha256. Serving that silently at
+    HTTP 200 would hand clients plausible-but-wrong LFS oids, so the warning is
+    part of the contract here.
+    """
+    repo_row = SimpleNamespace(repo_type="model", full_id="alice/demo")
+
+    class _FakeClient:
+        async def list_objects(self, **kwargs):
+            return {
+                "results": [
+                    {
+                        "path_type": "object",
+                        "path": "weights.bin",
+                        "size_bytes": 4096,
+                        "checksum": "sha256:from-lakefs",
+                    }
+                ],
+                "pagination": {"has_more": False},
+            }
+
+    monkeypatch.setattr("kohakuhub.utils.lakefs.get_lakefs_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "kohakuhub.utils.lakefs.resolve_lakefs_repo", lambda repo: "m-alice-demo"
+    )
+    monkeypatch.setattr(
+        "kohakuhub.db_operations.should_use_lfs", lambda repo, path, size: True
+    )
+
+    def _boom(repo):
+        raise OperationalError("database unavailable")
+
+    monkeypatch.setattr("kohakuhub.db_operations.get_repo_file_sha256_map", _boom)
+
+    # Patch the module logger, matching how the rest of the suite asserts on
+    # log output (loguru does not route through pytest's caplog).
+    warnings: list[str] = []
+    monkeypatch.setattr(hf_utils.logger, "warning", warnings.append)
+
+    siblings = await hf_utils.collect_hf_siblings(
+        repo_row, "model", "alice/demo", "main"
+    )
+
+    assert len(siblings) == 1, "the listing must still be served"
+    assert siblings[0]["lfs"]["sha256"] == "sha256:from-lakefs"
+    assert any("database unavailable" in message for message in warnings), (
+        f"the degradation must be logged, not silent; got {warnings}"
+    )

--- a/test/kohakuhub/api/test_files_unit.py
+++ b/test/kohakuhub/api/test_files_unit.py
@@ -124,6 +124,87 @@ async def test_hash_and_sample_helpers_cover_match_failures_and_decode_errors(mo
 
 
 @pytest.mark.asyncio
+async def test_process_preupload_file_uses_batch_metadata_without_file_queries(
+    monkeypatch,
+):
+    repo = SimpleNamespace()
+
+    monkeypatch.setattr(files_api, "should_use_lfs", lambda repo_row, path, size: False)
+    monkeypatch.setattr(
+        files_api,
+        "get_file",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("preupload should use the batch map")
+        ),
+    )
+
+    result = await files_api.process_preupload_file(
+        {"path": "same.bin", "size": 4, "sha256": "sha"},
+        repo,
+        "owner/demo",
+        "lakefs-repo",
+        "main",
+        1024,
+        existing_files={"same.bin": ("sha", 4)},
+    )
+
+    assert result == {
+        "path": "same.bin",
+        "uploadMode": "regular",
+        "shouldIgnore": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_preupload_batch_load_is_limited_to_sha256_paths(monkeypatch):
+    repo = SimpleNamespace(
+        private=True,
+        created_at=None,
+        namespace="alice",
+        downloads=1,
+        likes_count=2,
+    )
+    captured = []
+
+    monkeypatch.setattr(files_api, "check_repo_write_permission", lambda *_args: None)
+    monkeypatch.setattr(files_api, "get_organization", lambda _namespace: None)
+    monkeypatch.setattr(files_api, "get_repository", lambda *_args: repo)
+    monkeypatch.setattr(files_api, "check_quota", lambda *_args: (True, None))
+    monkeypatch.setattr(files_api, "resolve_lakefs_repo", lambda _repo: "lakefs-repo")
+    monkeypatch.setattr(files_api, "get_effective_lfs_threshold", lambda _repo: 1024)
+
+    def _batch_map(_repo, paths):
+        captured.append(set(paths))
+        return {"same.bin": ("sha", 4)}
+
+    monkeypatch.setattr(files_api, "get_repo_file_metadata_map", _batch_map)
+    monkeypatch.setattr(
+        files_api,
+        "process_preupload_file",
+        _async_return({"path": "ok", "uploadMode": "regular", "shouldIgnore": True}),
+    )
+
+    response = await files_api.preupload(
+        files_api.RepoType.model,
+        "alice",
+        "demo",
+        "main",
+        _FakeRequest(
+            body={
+                "files": [
+                    {"path": "same.bin", "size": 4, "sha256": "sha"},
+                    {"path": "sample.txt", "size": 3, "sample": "YWJj"},
+                ]
+            }
+        ),
+        user=SimpleNamespace(username="alice"),
+    )
+
+    assert captured == [{"same.bin"}]
+    assert len(response["files"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_preupload_and_revision_cover_validation_quota_and_resolution_errors(
     monkeypatch,
 ):

--- a/test/kohakuhub/api/test_stats_unit.py
+++ b/test/kohakuhub/api/test_stats_unit.py
@@ -85,10 +85,10 @@ async def test_get_trending_repositories_filters_missing_mismatched_and_inaccess
     )
     repo_results = [repo_public, repo_private, None]
     stats_rows = [
-        SimpleNamespace(repository=SimpleNamespace(id=1), download_sessions=7),
-        SimpleNamespace(repository=SimpleNamespace(id=1), download_sessions=3),
-        SimpleNamespace(repository=SimpleNamespace(id=2), download_sessions=5),
-        SimpleNamespace(repository=SimpleNamespace(id=3), download_sessions=4),
+        SimpleNamespace(repository_id=1, download_sessions=7),
+        SimpleNamespace(repository_id=1, download_sessions=3),
+        SimpleNamespace(repository_id=2, download_sessions=5),
+        SimpleNamespace(repository_id=3, download_sessions=4),
     ]
 
     class _FakeDailyRepoStats:

--- a/test/kohakuhub/api/utils/test_trending.py
+++ b/test/kohakuhub/api/utils/test_trending.py
@@ -58,17 +58,17 @@ class _FrozenDatetime:
 def test_calculate_trending_scores_applies_decay_and_aggregates_multiple_days(monkeypatch):
     stats = [
         SimpleNamespace(
-            repository=SimpleNamespace(id=1),
+            repository_id=1,
             date=datetime(2026, 4, 20, tzinfo=timezone.utc).date(),
             download_sessions=10,
         ),
         SimpleNamespace(
-            repository=SimpleNamespace(id=1),
+            repository_id=1,
             date=datetime(2026, 4, 19, tzinfo=timezone.utc).date(),
             download_sessions=5,
         ),
         SimpleNamespace(
-            repository=SimpleNamespace(id=2),
+            repository_id=2,
             date=datetime(2026, 4, 18, tzinfo=timezone.utc).date(),
             download_sessions=1,
         ),


### PR DESCRIPTION
## Summary

This PR addresses the large-repository latency in Issue #97 by removing avoidable per-file database work from repository metadata and preupload paths.

## What Changed

- Build one projected `path -> sha256` map for Hugging Face repository siblings instead of querying `File` once per LFS path.
- Support the Hugging Face `blobs` parameter on repository-info and revision routes. The default remains metadata-enabled for compatibility; `blobs=false` returns only `rfilename` and skips the `File` query.
- Batch preupload metadata lookup and restrict it to the deduplicated SHA-bearing paths submitted in the request.
- Avoid lazy foreign-key queries in trending aggregation, `whoami-v2`, and organization visibility filtering.
- Preserve the existing LakeFS checksum fallback when a stored `File` row is unavailable, and log database degradation in the bulk metadata path.
- Add focused unit and endpoint coverage for the new behavior. No schema or migration changes are required.

## Performance Context

On the corrected local 4,000-file benchmark (2,000 LFS files), the endpoint p50 improved from 1.23 s with per-file lookups to 0.145 s with the bulk map. `blobs=false` measured 0.057 s and reduced the response from approximately 420 KB to 153 KB.

## Real 50k-File Benchmark

After the implementation was ready, I created six isolated repositories backed by real LakeFS objects and PostgreSQL `File` rows: 1,000, 2,500, 5,000, 10,000, 20,000, and 50,000 files. Every sample has exactly 50% LFS-classified files. To keep the experiment lightweight, the repository-specific LFS threshold was set to 2 bytes; LFS objects contain 2 bytes and regular objects contain 1 byte. This preserves the real listing, pagination, database, and checksum code paths without creating tens of gigabytes of payload data.

Each implementation was warmed once and measured three times; values below are medians from `time.perf_counter()`.

| Files | LFS files | Legacy per-file lookup | Bulk SHA map | `blobs=false` | Bulk speedup | Name-only speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,000 | 500 | 279.23 ms | 13.70 ms | 8.47 ms | 20.39x | 32.95x |
| 2,500 | 1,250 | 723.32 ms | 35.79 ms | 24.45 ms | 20.21x | 29.59x |
| 5,000 | 2,500 | 1,419.46 ms | 68.97 ms | 44.27 ms | 20.58x | 32.06x |
| 10,000 | 5,000 | 2,846.54 ms | 134.92 ms | 87.68 ms | 21.10x | 32.46x |
| 20,000 | 10,000 | 5,693.60 ms | 260.81 ms | 171.33 ms | 21.83x | 33.23x |
| 50,000 | 25,000 | 14,194.37 ms | 646.52 ms | 424.50 ms | 21.95x | 33.44x |

The six-point log-log fitted slopes are 1.002 for the legacy path, 0.978 for the bulk map, and 0.986 for `blobs=false`. Repository listing is inherently O(N), so this PR does not claim to make enumeration sublinear. It changes the database work from one `File` query per LFS path to one projected query per request, removing the N+1 round trips while retaining the unavoidable object enumeration. The measured constant-factor reduction remains approximately 22x for metadata-enabled responses and 33x for name-only responses at 50,000 files.

## Performance Curve

The following image is generated by Matplotlib from the raw measurements. The x-axis and y-axis are explicitly log-scaled; every point is labelled with its measured median in milliseconds, and optimized-path labels include speedup versus the legacy path.

![Issue #97 repository metadata scaling](https://gist.githubusercontent.com/narugo1992/d3fb622896c4c088f836332b2b9e2644/raw/benchmark.png)

## Benchmark Artifacts

The reproducible Matplotlib script, raw CSV/JSON data, English methodology, and vector chart are available in this public Gist:

https://gist.github.com/narugo1992/d3fb622896c4c088f836332b2b9e2644

Direct image fallback: https://gist.githubusercontent.com/narugo1992/d3fb622896c4c088f836332b2b9e2644/raw/benchmark.png

## Validation

- `27 passed` in the changed unit and Hugging Face compatibility tests.
- `6 passed` in the repository-info endpoint tests.
- `git diff --check` passed.
- Real LakeFS/PostgreSQL benchmark completed for all six repository sizes above, including 20,000 and 50,000 files.
- The benchmark script generates both `benchmark.png` and `benchmark.svg` with Matplotlib from the same measured data.

The previously attempted full backend suite reported failures in shared admin credential/bootstrap and PostgreSQL reset behavior (including deadlocks and missing seeded relations), while the changed-file and endpoint tests passed. The full CI matrix remains the final environment-level gate.

Closes #97
