### PR TITLE
feat: gate dangerous repository operations

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -61,6 +61,11 @@ api_base = "/api"
 db_backend = "postgres"  # or "sqlite"
 database_url = "postgresql://hub:hubpass@127.0.0.1:25432/hubdb"
 auto_migrate = false  # Auto-confirm database migrations (set true for Docker)
+# Dangerous repository history operations stay disabled until their integrity
+# and recovery gates have passed.
+repository_revert_enabled = false
+repository_reset_enabled = false
+repository_squash_enabled = false
 # LFS Configuration (sizes in decimal: 1MB = 1,000,000 bytes)
 lfs_threshold_bytes = 5_000_000  # 5MB - files larger use LFS
 lfs_multipart_threshold_bytes = 100_000_000  # 100MB - files larger use multipart upload

--- a/docs/api/branches.md
+++ b/docs/api/branches.md
@@ -10,6 +10,47 @@ Manage branches, tags, and advanced Git operations (merge, revert, reset).
 
 ---
 
+## Repository Operation Gate
+
+The history-mutating operations below are independently controlled by server-side
+capabilities: `revert`, `reset`, and `squash`. The public capability state is
+available without authentication from `GET /api/site-config`:
+
+```json
+{
+  "capabilities": {
+    "repository_operations": {
+      "revert": false,
+      "reset": false,
+      "squash": false
+    }
+  }
+}
+```
+
+Clients must treat an operation as enabled only when its value is the boolean
+`true`. If the request fails, the field is missing, or the value has any other
+type, clients must fail closed and hide the corresponding action.
+
+When an operation is disabled, its API gate runs before authentication and
+repository lookup. The server returns `503 Service Unavailable` with this
+stable response shape:
+
+```json
+{
+  "detail": {
+    "code": "operation_disabled",
+    "operation": "reset",
+    "error": "Repository reset is temporarily disabled",
+    "message": "Repository Reset is temporarily disabled"
+  }
+}
+```
+
+The `operation` value is one of `revert`, `reset`, or `squash`. Once enabled,
+the normal authentication, permission, and repository validation requirements
+still apply.
+
 ## Branches
 
 ### Create Branch
@@ -173,6 +214,7 @@ Manage branches, tags, and advanced Git operations (merge, revert, reset).
 
 **Status Codes:**
 - `200 OK` - Reverted successfully
+- `503 Service Unavailable` - Revert operation is disabled by server policy
 - `404 Not Found` - Commit not found
 - `409 Conflict` - Revert caused conflicts
 
@@ -233,6 +275,7 @@ Manage branches, tags, and advanced Git operations (merge, revert, reset).
 
 **Status Codes:**
 - `200 OK` - Reset successful
+- `503 Service Unavailable` - Reset operation is disabled by server policy
 - `400 Bad Request` - LFS files not recoverable or main branch without force
 - `404 Not Found` - Commit not found
 

--- a/docs/api/repositories.md
+++ b/docs/api/repositories.md
@@ -195,9 +195,30 @@ Create, read, update, delete, move, and squash repositories.
 
 **Status Codes:**
 - `200 OK` - Repository squashed
+- `503 Service Unavailable` - Squash operation is disabled by server policy
 - `403 Forbidden` - No permission
 - `404 Not Found` - Repository not found
 - `500 Internal Server Error` - Operation failed (attempts recovery)
+
+**Operation gate:** The server exposes the current `revert`, `reset`, and
+`squash` capabilities without authentication through `GET /api/site-config`.
+Clients should use an operation only when its capability is exactly the boolean
+`true`; missing, malformed, or failed capability responses must hide the
+corresponding action. When squash is disabled, the API returns `503` before
+authentication or repository lookup with a stable `operation_disabled` detail:
+
+```json
+{
+  "detail": {
+    "code": "operation_disabled",
+    "operation": "squash",
+    "error": "Repository squash is temporarily disabled",
+    "message": "Repository Squash is temporarily disabled"
+  }
+}
+```
+
+When enabled, the normal authentication and permission checks still apply.
 
 ---
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,9 +18,9 @@ By default, the application looks for `config.toml` in the current working direc
 | `KOHAKU_HUB_API_BASE` | The base path for the API. | `/api` |
 | `KOHAKU_HUB_SITE_NAME` | The name of the site, displayed in the UI. | `KohakuHub` |
 | `KOHAKU_HUB_DEBUG_LOG_PAYLOADS`| If `true`, logs request and response payloads for debugging. | `false` |
-| `KOHAKU_HUB_REPOSITORY_REVERT_ENABLED` | Enables the Revert repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
-| `KOHAKU_HUB_REPOSITORY_RESET_ENABLED` | Enables the Reset repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
-| `KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED` | Enables the Super Squash repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
+| `KOHAKU_HUB_REPOSITORY_REVERT_ENABLED` | Enables Revert only when `db_backend` is exactly `postgres`; keep disabled until its integrity, recovery, and canary gates pass. | `false` |
+| `KOHAKU_HUB_REPOSITORY_RESET_ENABLED` | Enables Reset only when `db_backend` is exactly `postgres`; keep disabled until its integrity, recovery, and canary gates pass. | `false` |
+| `KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED` | Enables Super Squash only when `db_backend` is exactly `postgres`; keep disabled until its integrity, recovery, and canary gates pass. | `false` |
 
 ## Database Settings
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,6 +18,9 @@ By default, the application looks for `config.toml` in the current working direc
 | `KOHAKU_HUB_API_BASE` | The base path for the API. | `/api` |
 | `KOHAKU_HUB_SITE_NAME` | The name of the site, displayed in the UI. | `KohakuHub` |
 | `KOHAKU_HUB_DEBUG_LOG_PAYLOADS`| If `true`, logs request and response payloads for debugging. | `false` |
+| `KOHAKU_HUB_REPOSITORY_REVERT_ENABLED` | Enables the Revert repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
+| `KOHAKU_HUB_REPOSITORY_RESET_ENABLED` | Enables the Reset repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
+| `KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED` | Enables the Super Squash repository history operation. Keep disabled until its integrity and recovery gates pass. | `false` |
 
 ## Database Settings
 

--- a/src/kohaku-hub-admin/src/pages/repositories.vue
+++ b/src/kohaku-hub-admin/src/pages/repositories.vue
@@ -373,7 +373,12 @@ async function confirmSquashRepo() {
     await handleViewRepo(selectedRepo.value);
   } catch (err) {
     if (err !== "cancel") {
-      ElMessage.error(err.response?.data?.detail || "Failed to squash");
+      const detail = err.response?.data?.detail;
+      ElMessage.error(
+        typeof detail === "string"
+          ? detail
+          : detail?.error || "Failed to squash",
+      );
     }
   } finally {
     actionLoading.value = false;

--- a/src/kohaku-hub-admin/src/pages/repositories.vue
+++ b/src/kohaku-hub-admin/src/pages/repositories.vue
@@ -13,8 +13,10 @@ import {
   deleteRepositoryAdmin,
   moveRepositoryAdmin,
   squashRepositoryAdmin,
+  getSiteConfig,
 } from "@/utils/api";
 import { formatBytes } from "@/utils/api";
+import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
 import { ElMessage, ElMessageBox } from "element-plus";
 import dayjs from "dayjs";
 
@@ -31,6 +33,7 @@ const storageBreakdown = ref(null);
 const repoCommits = ref([]);
 const loadingStorage = ref(false);
 const loadingCommits = ref(false);
+const squashEnabled = ref(false);
 
 // Actions
 const actionLoading = ref(false);
@@ -127,6 +130,16 @@ async function loadRepositories() {
     }
   } finally {
     loading.value = false;
+  }
+}
+
+async function loadOperationCapabilities() {
+  try {
+    const siteConfig = await getSiteConfig();
+    squashEnabled.value = getRepositoryOperationCapabilities(siteConfig).squash;
+  } catch (err) {
+    // Keep Squash hidden when capabilities cannot be established.
+    console.warn("Failed to load repository operation capabilities:", err);
   }
 }
 
@@ -338,6 +351,7 @@ async function confirmMoveRepo() {
 }
 
 async function confirmSquashRepo() {
+  if (!squashEnabled.value) return;
   try {
     const { value } = await ElMessageBox.prompt(
       `Type "${selectedRepo.value.name}" to confirm squash`,
@@ -395,6 +409,7 @@ async function confirmDeleteRepo() {
 
 onMounted(() => {
   loadRepositories();
+  loadOperationCapabilities();
 });
 </script>
 
@@ -870,7 +885,7 @@ onMounted(() => {
                 </el-card>
 
                 <!-- Squash Repository -->
-                <el-card class="bg-white dark:bg-gray-800">
+                <el-card v-if="squashEnabled" class="bg-white dark:bg-gray-800">
                   <template #header>
                     <div class="font-semibold">Squash Repository</div>
                   </template>

--- a/src/kohaku-hub-admin/src/utils/api.js
+++ b/src/kohaku-hub-admin/src/utils/api.js
@@ -6,6 +6,15 @@
 import axios from "axios";
 
 /**
+ * Get public site configuration and repository operation capabilities.
+ * @returns {Promise<Object>} public site configuration
+ */
+export async function getSiteConfig() {
+  const response = await axios.get("/api/site-config");
+  return response.data;
+}
+
+/**
  * Create axios instance with admin token
  * @param {string} token - Admin token
  * @returns {import('axios').AxiosInstance} Axios instance

--- a/src/kohaku-hub-admin/src/utils/repositoryOperationCapabilities.js
+++ b/src/kohaku-hub-admin/src/utils/repositoryOperationCapabilities.js
@@ -1,0 +1,19 @@
+const DISABLED_REPOSITORY_OPERATIONS = Object.freeze({
+  revert: false,
+  reset: false,
+  squash: false,
+});
+
+export function getRepositoryOperationCapabilities(siteConfig) {
+  const operations = siteConfig?.capabilities?.repository_operations;
+
+  if (!operations || typeof operations !== "object") {
+    return { ...DISABLED_REPOSITORY_OPERATIONS };
+  }
+
+  return {
+    revert: operations.revert === true,
+    reset: operations.reset === true,
+    squash: operations.squash === true,
+  };
+}

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
@@ -571,6 +571,7 @@ import axios from "axios";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { ElMessage } from "element-plus";
+import { settingsAPI } from "@/utils/api";
 import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
 
 dayjs.extend(relativeTime);
@@ -634,7 +635,7 @@ async function loadCommitDetails() {
 
 async function loadOperationCapabilities() {
   try {
-    const { data } = await axios.get("/api/site-config");
+    const { data } = await settingsAPI.getSiteConfig();
     const operations = getRepositoryOperationCapabilities(data);
     revertEnabled.value = operations.revert;
     resetEnabled.value = operations.reset;
@@ -664,8 +665,11 @@ async function doRevert() {
   reverting.value = true;
 
   try {
-    await axios.post(
-      `/api/${type.value}s/${repoId.value}/branch/${selectedBranch.value}/revert`,
+    await settingsAPI.revertBranch(
+      type.value,
+      namespace.value,
+      name.value,
+      selectedBranch.value,
       {
         ref: commitId.value,
         parent_number: 1,
@@ -711,8 +715,11 @@ async function doReset() {
       payload.message = resetMessage.value.trim();
     }
 
-    await axios.post(
-      `/api/${type.value}s/${repoId.value}/branch/${selectedBranch.value}/reset`,
+    await settingsAPI.resetBranch(
+      type.value,
+      namespace.value,
+      name.value,
+      selectedBranch.value,
       payload,
     );
 

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue
@@ -108,12 +108,22 @@
         </div>
 
         <!-- Action Buttons -->
-        <div class="flex gap-3 mb-4">
-          <el-button size="small" @click="showRevertDialog" class="btn-revert">
+        <div v-if="revertEnabled || resetEnabled" class="flex gap-3 mb-4">
+          <el-button
+            v-if="revertEnabled"
+            size="small"
+            @click="showRevertDialog"
+            class="btn-revert"
+          >
             <div class="i-carbon-undo inline-block mr-1" />
             Revert Commit
           </el-button>
-          <el-button type="primary" size="small" @click="showResetDialog">
+          <el-button
+            v-if="resetEnabled"
+            type="primary"
+            size="small"
+            @click="showResetDialog"
+          >
             <div class="i-carbon-reset inline-block mr-1" />
             Reset to This State
           </el-button>
@@ -137,6 +147,7 @@
 
       <!-- Revert Dialog -->
       <el-dialog
+        v-if="revertEnabled"
         v-model="revertDialogVisible"
         title="Revert Commit"
         width="500px"
@@ -188,6 +199,7 @@
 
       <!-- Reset Dialog -->
       <el-dialog
+        v-if="resetEnabled"
         v-model="resetDialogVisible"
         title="Reset Branch to This Commit"
         width="500px"
@@ -559,6 +571,7 @@ import axios from "axios";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { ElMessage } from "element-plus";
+import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
 
 dayjs.extend(relativeTime);
 
@@ -574,6 +587,8 @@ const repoId = computed(() => `${namespace.value}/${name.value}`);
 const loading = ref(true);
 const error = ref(null);
 const commitData = ref(null);
+const revertEnabled = ref(false);
+const resetEnabled = ref(false);
 
 // Revert state
 const revertDialogVisible = ref(false);
@@ -617,13 +632,27 @@ async function loadCommitDetails() {
   }
 }
 
+async function loadOperationCapabilities() {
+  try {
+    const { data } = await axios.get("/api/site-config");
+    const operations = getRepositoryOperationCapabilities(data);
+    revertEnabled.value = operations.revert;
+    resetEnabled.value = operations.reset;
+  } catch (err) {
+    // Keep both actions hidden when capabilities cannot be established.
+    console.warn("Failed to load repository operation capabilities:", err);
+  }
+}
+
 function showRevertDialog() {
+  if (!revertEnabled.value) return;
   selectedBranch.value = "main";
   revertForce.value = false;
   revertDialogVisible.value = true;
 }
 
 function showResetDialog() {
+  if (!resetEnabled.value) return;
   selectedBranch.value = "main";
   resetForce.value = false;
   resetMessage.value = "";
@@ -631,6 +660,7 @@ function showResetDialog() {
 }
 
 async function doRevert() {
+  if (!revertEnabled.value) return;
   reverting.value = true;
 
   try {
@@ -667,6 +697,7 @@ async function doRevert() {
 }
 
 async function doReset() {
+  if (!resetEnabled.value) return;
   resetting.value = true;
 
   try {
@@ -893,6 +924,7 @@ function renderDiff(diff) {
 
 onMounted(() => {
   loadCommitDetails();
+  loadOperationCapabilities();
 });
 </script>
 

--- a/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
+++ b/src/kohaku-hub-ui/src/pages/[type]s/[namespace]/[name]/settings.vue
@@ -177,7 +177,7 @@
           <div class="card border-2 border-red-500">
             <h2 class="text-xl font-semibold mb-4 text-red-600">Danger Zone</h2>
             <div class="space-y-4">
-              <div>
+              <div v-if="squashEnabled">
                 <h3 class="font-medium text-orange-600 mb-2">
                   Squash repository history
                 </h3>
@@ -593,6 +593,7 @@ import { useRoute, useRouter } from "vue-router";
 import { repoAPI, settingsAPI, validationAPI, quotaAPI } from "@/utils/api";
 import { ElMessage, ElMessageBox } from "element-plus";
 import { useAuthStore } from "@/stores/auth";
+import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
 
 const route = useRoute();
 const router = useRouter();
@@ -626,6 +627,7 @@ const recalculating = ref(false);
 const savingQuota = ref(false);
 const lfsSettings = ref(null);
 const savingLfs = ref(false);
+const squashEnabled = ref(false);
 
 const repoId = computed(() => `${route.params.namespace}/${route.params.name}`);
 const repoType = computed(() => route.params.type);
@@ -660,6 +662,16 @@ async function loadRepoInfo() {
   } catch (err) {
     console.error("Failed to load repo info:", err);
     ElMessage.error("Failed to load repository information");
+  }
+}
+
+async function loadOperationCapabilities() {
+  try {
+    const { data } = await settingsAPI.getSiteConfig();
+    squashEnabled.value = getRepositoryOperationCapabilities(data).squash;
+  } catch (err) {
+    // Keep Squash hidden when capabilities cannot be established.
+    console.warn("Failed to load repository operation capabilities:", err);
   }
 }
 
@@ -799,6 +811,7 @@ async function handleMoveRepo() {
 }
 
 async function handleSquashRepo() {
+  if (!squashEnabled.value) return;
   try {
     await ElMessageBox.confirm(
       `This will clear all commit history for ${repoId.value} and optimize storage. Only the current state will be preserved. This action cannot be undone!`,
@@ -1150,6 +1163,7 @@ onMounted(() => {
     return;
   }
   loadRepoInfo();
+  loadOperationCapabilities();
   // Load quota info if starting on quota tab
   if (activeTab.value === "quota") {
     loadQuotaInfo();

--- a/src/kohaku-hub-ui/src/utils/api.js
+++ b/src/kohaku-hub-ui/src/utils/api.js
@@ -823,6 +823,36 @@ export const settingsAPI = {
   squashRepo: (data) => api.post("/api/repos/squash", data),
 
   /**
+   * Revert a commit on a branch.
+   * @param {string} repoType - Repository type
+   * @param {string} namespace - Repository namespace
+   * @param {string} name - Repository name
+   * @param {string} branch - Branch name
+   * @param {Object} data - Revert payload
+   * @returns {Promise} - Revert result
+   */
+  revertBranch: (repoType, namespace, name, branch, data) =>
+    api.post(
+      `/api/${repoType}s/${namespace}/${name}/branch/${branch}/revert`,
+      data,
+    ),
+
+  /**
+   * Reset a branch to a commit.
+   * @param {string} repoType - Repository type
+   * @param {string} namespace - Repository namespace
+   * @param {string} name - Repository name
+   * @param {string} branch - Branch name
+   * @param {Object} data - Reset payload
+   * @returns {Promise} - Reset result
+   */
+  resetBranch: (repoType, namespace, name, branch, data) =>
+    api.post(
+      `/api/${repoType}s/${namespace}/${name}/branch/${branch}/reset`,
+      data,
+    ),
+
+  /**
    * Create branch
    * @param {string} repoType - Repository type
    * @param {string} namespace - Repository namespace

--- a/src/kohaku-hub-ui/src/utils/api.js
+++ b/src/kohaku-hub-ui/src/utils/api.js
@@ -710,6 +710,12 @@ export const orgAPI = {
  */
 export const settingsAPI = {
   /**
+   * Get public site configuration and repository operation capabilities.
+   * @returns {Promise} - public site configuration
+   */
+  getSiteConfig: () => api.get("/api/site-config"),
+
+  /**
    * Get current user info with organizations (HuggingFace compatible)
    * @returns {Promise} - { type, name, fullname, email, emailVerified, orgs }
    */

--- a/src/kohaku-hub-ui/src/utils/repositoryOperationCapabilities.js
+++ b/src/kohaku-hub-ui/src/utils/repositoryOperationCapabilities.js
@@ -1,0 +1,19 @@
+const DISABLED_REPOSITORY_OPERATIONS = Object.freeze({
+  revert: false,
+  reset: false,
+  squash: false,
+});
+
+export function getRepositoryOperationCapabilities(siteConfig) {
+  const operations = siteConfig?.capabilities?.repository_operations;
+
+  if (!operations || typeof operations !== "object") {
+    return { ...DISABLED_REPOSITORY_OPERATIONS };
+  }
+
+  return {
+    revert: operations.revert === true,
+    reset: operations.reset === true,
+    squash: operations.squash === true,
+  };
+}

--- a/src/kohakuhub/api/branches.py
+++ b/src/kohakuhub/api/branches.py
@@ -31,7 +31,11 @@ from kohakuhub.api.repo.utils.hf import (
     hf_repo_not_found,
     hf_server_error,
 )
-from kohakuhub.api.operation_capabilities import ensure_repository_operation_enabled
+from kohakuhub.api.operation_capabilities import (
+    ensure_repository_operation_enabled,
+    require_repository_reset_enabled,
+    require_repository_revert_enabled,
+)
 
 logger = get_logger("BRANCHES")
 
@@ -475,7 +479,10 @@ async def list_repo_refs(
     return response
 
 
-@router.post("/{repo_type}s/{namespace}/{name}/branch/{branch}/revert")
+@router.post(
+    "/{repo_type}s/{namespace}/{name}/branch/{branch}/revert",
+    dependencies=[Depends(require_repository_revert_enabled)],
+)
 async def revert_branch(
     repo_type: str,
     namespace: str,
@@ -753,7 +760,10 @@ async def merge_branches(
     }
 
 
-@router.post("/{repo_type}s/{namespace}/{name}/branch/{branch}/reset")
+@router.post(
+    "/{repo_type}s/{namespace}/{name}/branch/{branch}/reset",
+    dependencies=[Depends(require_repository_reset_enabled)],
+)
 async def reset_branch(
     repo_type: str,
     namespace: str,

--- a/src/kohakuhub/api/branches.py
+++ b/src/kohakuhub/api/branches.py
@@ -31,6 +31,7 @@ from kohakuhub.api.repo.utils.hf import (
     hf_repo_not_found,
     hf_server_error,
 )
+from kohakuhub.api.operation_capabilities import ensure_repository_operation_enabled
 
 logger = get_logger("BRANCHES")
 
@@ -503,6 +504,8 @@ async def revert_branch(
     Raises:
         HTTPException: If revert fails or LFS files are not recoverable
     """
+    ensure_repository_operation_enabled("revert")
+
     repo_id = f"{namespace}/{name}"
 
     # Check if repository exists
@@ -779,6 +782,8 @@ async def reset_branch(
     Raises:
         HTTPException: If reset fails or LFS files are not recoverable
     """
+    ensure_repository_operation_enabled("reset")
+
     repo_id = f"{namespace}/{name}"
 
     # Check if repository exists

--- a/src/kohakuhub/api/misc.py
+++ b/src/kohakuhub/api/misc.py
@@ -8,6 +8,9 @@ from kohakuhub.config import cfg
 from kohakuhub.db import User, UserOrganization
 from kohakuhub.logger import get_logger
 from kohakuhub.auth.dependencies import get_optional_user
+from kohakuhub.api.operation_capabilities import (
+    get_repository_operation_capabilities,
+)
 
 logger = get_logger("UTILS")
 
@@ -47,6 +50,9 @@ def get_site_config():
         "site_name": cfg.app.site_name,
         "invitation_only": cfg.auth.invitation_only,
         "require_email_verification": cfg.auth.require_email_verification,
+        "capabilities": {
+            "repository_operations": get_repository_operation_capabilities(),
+        },
     }
 
 

--- a/src/kohakuhub/api/operation_capabilities.py
+++ b/src/kohakuhub/api/operation_capabilities.py
@@ -1,0 +1,40 @@
+"""Runtime capabilities for operations that can mutate repository history."""
+
+from typing import Literal
+
+from fastapi import HTTPException
+
+from kohakuhub.config import cfg
+
+RepositoryOperation = Literal["revert", "reset", "squash"]
+
+_OPERATION_CONFIG_FIELDS: dict[RepositoryOperation, str] = {
+    "revert": "repository_revert_enabled",
+    "reset": "repository_reset_enabled",
+    "squash": "repository_squash_enabled",
+}
+
+
+def get_repository_operation_capabilities() -> dict[str, bool]:
+    """Return the effective public capabilities for dangerous operations."""
+    return {
+        operation: bool(getattr(cfg.app, config_field, False))
+        for operation, config_field in _OPERATION_CONFIG_FIELDS.items()
+    }
+
+
+def ensure_repository_operation_enabled(operation: RepositoryOperation) -> None:
+    """Reject disabled history operations before they reach repository logic."""
+    if get_repository_operation_capabilities()[operation]:
+        return
+
+    operation_name = operation.capitalize()
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "code": "operation_disabled",
+            "operation": operation,
+            "error": f"Repository {operation} is temporarily disabled",
+            "message": f"Repository {operation_name} is temporarily disabled",
+        },
+    )

--- a/src/kohakuhub/api/operation_capabilities.py
+++ b/src/kohakuhub/api/operation_capabilities.py
@@ -17,6 +17,9 @@ _OPERATION_CONFIG_FIELDS: dict[RepositoryOperation, str] = {
 
 def get_repository_operation_capabilities() -> dict[str, bool]:
     """Return the effective public capabilities for dangerous operations."""
+    if str(getattr(cfg.app, "db_backend", "sqlite")).lower() != "postgres":
+        return {operation: False for operation in _OPERATION_CONFIG_FIELDS}
+
     return {
         operation: bool(getattr(cfg.app, config_field, False))
         for operation, config_field in _OPERATION_CONFIG_FIELDS.items()
@@ -38,3 +41,18 @@ def ensure_repository_operation_enabled(operation: RepositoryOperation) -> None:
             "message": f"Repository {operation_name} is temporarily disabled",
         },
     )
+
+
+def require_repository_revert_enabled() -> None:
+    """FastAPI dependency that gates Revert before authentication runs."""
+    ensure_repository_operation_enabled("revert")
+
+
+def require_repository_reset_enabled() -> None:
+    """FastAPI dependency that gates Reset before authentication runs."""
+    ensure_repository_operation_enabled("reset")
+
+
+def require_repository_squash_enabled() -> None:
+    """FastAPI dependency that gates Super Squash before authentication runs."""
+    ensure_repository_operation_enabled("squash")

--- a/src/kohakuhub/api/operation_capabilities.py
+++ b/src/kohakuhub/api/operation_capabilities.py
@@ -17,7 +17,10 @@ _OPERATION_CONFIG_FIELDS: dict[RepositoryOperation, str] = {
 
 def get_repository_operation_capabilities() -> dict[str, bool]:
     """Return the effective public capabilities for dangerous operations."""
-    if str(getattr(cfg.app, "db_backend", "sqlite")).lower() != "postgres":
+    # Keep this check aligned with db.py: any value other than the exact
+    # configured PostgreSQL backend selects SQLite and cannot enable these
+    # operations safely.
+    if getattr(cfg.app, "db_backend", "sqlite") != "postgres":
         return {operation: False for operation in _OPERATION_CONFIG_FIELDS}
 
     return {

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -54,6 +54,7 @@ from kohakuhub.api.quota.util import (
 from kohakuhub.api.repo.utils.gc import cleanup_repository_storage
 from kohakuhub.api.fallback.cache import get_cache as get_fallback_cache
 from kohakuhub.api.validation import normalize_name
+from kohakuhub.api.operation_capabilities import ensure_repository_operation_enabled
 
 logger = get_logger("REPO")
 router = APIRouter()
@@ -1170,6 +1171,8 @@ async def squash_repo(
     Raises:
         HTTPException: If operation fails
     """
+    ensure_repository_operation_enabled("squash")
+
     user, is_admin = auth
     repo_id = payload.repo
     repo_type = payload.type

--- a/src/kohakuhub/api/repo/routers/crud.py
+++ b/src/kohakuhub/api/repo/routers/crud.py
@@ -54,7 +54,10 @@ from kohakuhub.api.quota.util import (
 from kohakuhub.api.repo.utils.gc import cleanup_repository_storage
 from kohakuhub.api.fallback.cache import get_cache as get_fallback_cache
 from kohakuhub.api.validation import normalize_name
-from kohakuhub.api.operation_capabilities import ensure_repository_operation_enabled
+from kohakuhub.api.operation_capabilities import (
+    ensure_repository_operation_enabled,
+    require_repository_squash_enabled,
+)
 
 logger = get_logger("REPO")
 router = APIRouter()
@@ -1147,7 +1150,10 @@ async def move_repo(
     }
 
 
-@router.post("/repos/squash")
+@router.post(
+    "/repos/squash",
+    dependencies=[Depends(require_repository_squash_enabled)],
+)
 async def squash_repo(
     payload: SquashRepoPayload,
     auth: tuple[User | None, bool] = Depends(get_current_user_or_admin),

--- a/src/kohakuhub/config.py
+++ b/src/kohakuhub/config.py
@@ -118,6 +118,11 @@ class AppConfig(BaseModel):
     db_backend: str = "sqlite"
     # Optional features
     disable_dataset_viewer: bool = False
+    # Dangerous repository history operations stay disabled until their
+    # integrity and recovery gates have passed.
+    repository_revert_enabled: bool = False
+    repository_reset_enabled: bool = False
+    repository_squash_enabled: bool = False
     database_url: str = "sqlite:///./hub.db"
     database_key: str = (
         ""  # Encryption key for external tokens (generate with: openssl rand -hex 32)
@@ -482,6 +487,18 @@ def load_config(path: str = None) -> Config:
     if "KOHAKU_HUB_DISABLE_DATASET_VIEWER" in os.environ:
         app_env["disable_dataset_viewer"] = (
             os.environ["KOHAKU_HUB_DISABLE_DATASET_VIEWER"].lower() == "true"
+        )
+    if "KOHAKU_HUB_REPOSITORY_REVERT_ENABLED" in os.environ:
+        app_env["repository_revert_enabled"] = (
+            os.environ["KOHAKU_HUB_REPOSITORY_REVERT_ENABLED"].lower() == "true"
+        )
+    if "KOHAKU_HUB_REPOSITORY_RESET_ENABLED" in os.environ:
+        app_env["repository_reset_enabled"] = (
+            os.environ["KOHAKU_HUB_REPOSITORY_RESET_ENABLED"].lower() == "true"
+        )
+    if "KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED" in os.environ:
+        app_env["repository_squash_enabled"] = (
+            os.environ["KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED"].lower() == "true"
         )
     if "KOHAKU_HUB_DB_BACKEND" in os.environ:
         app_env["db_backend"] = os.environ["KOHAKU_HUB_DB_BACKEND"]

--- a/test/kohaku-hub-admin/pages/test_repository_operation_gates.test.js
+++ b/test/kohaku-hub-admin/pages/test_repository_operation_gates.test.js
@@ -1,0 +1,123 @@
+import { defineComponent, h } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ElementPlusStubs } from "../helpers/vue";
+
+const mocks = vi.hoisted(() => ({
+  router: { push: vi.fn() },
+  adminStore: { token: "admin-token", logout: vi.fn() },
+  api: {
+    listRepositories: vi.fn(),
+    getRepositoryDetails: vi.fn(),
+    getRepositoryStorageBreakdown: vi.fn(),
+    recalculateAllRepoStorage: vi.fn(),
+    listCommits: vi.fn(),
+    deleteRepositoryAdmin: vi.fn(),
+    moveRepositoryAdmin: vi.fn(),
+    squashRepositoryAdmin: vi.fn(),
+    getSiteConfig: vi.fn(),
+  },
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/stores/admin", () => ({
+  useAdminStore: () => mocks.adminStore,
+}));
+
+vi.mock("@/utils/api", () => ({
+  ...mocks.api,
+  formatBytes: (value) => String(value ?? 0),
+}));
+
+vi.mock("@/components/AdminLayout.vue", () => ({
+  default: defineComponent({
+    setup(_, { slots }) {
+      return () => h("main", slots.default ? slots.default() : []);
+    },
+  }),
+}));
+
+vi.mock("@/components/FileTree.vue", () => ({
+  default: defineComponent({
+    setup() {
+      return () => h("div");
+    },
+  }),
+}));
+
+import RepositoriesPage from "@/pages/repositories.vue";
+
+function mountPage() {
+  return mount(RepositoriesPage, {
+    global: { stubs: ElementPlusStubs },
+  });
+}
+
+function enabledConfig(squash) {
+  return {
+    capabilities: {
+      repository_operations: { revert: false, reset: false, squash },
+    },
+  };
+}
+
+describe("admin repository operation capability consumer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.adminStore.token = "admin-token";
+    mocks.api.listRepositories.mockResolvedValue({
+      repositories: [
+        {
+          id: 1,
+          repo_type: "model",
+          namespace: "owner",
+          name: "demo",
+          full_id: "owner/demo",
+          owner_username: "owner",
+          used_bytes: 0,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+    });
+    mocks.api.getRepositoryDetails.mockResolvedValue({
+      repo_type: "model",
+      namespace: "owner",
+      name: "demo",
+      full_id: "owner/demo",
+    });
+    mocks.api.getSiteConfig.mockResolvedValue(enabledConfig(false));
+  });
+
+  async function openRepositoryDetails() {
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "View Details")
+      .trigger("click");
+    await flushPromises();
+    return wrapper;
+  }
+
+  it("hides squash when capability loading fails", async () => {
+    mocks.api.getSiteConfig.mockRejectedValueOnce(new Error("offline"));
+
+    const wrapper = await openRepositoryDetails();
+
+    expect(wrapper.text()).not.toContain("Squash Repository");
+    expect(mocks.api.squashRepositoryAdmin).not.toHaveBeenCalled();
+  });
+
+  it("shows squash only for an explicit true capability", async () => {
+    mocks.api.getSiteConfig.mockResolvedValueOnce(enabledConfig(true));
+
+    const wrapper = await openRepositoryDetails();
+
+    expect(wrapper.text()).toContain("Squash Repository");
+  });
+});

--- a/test/kohaku-hub-admin/utils/test_api.test.js
+++ b/test/kohaku-hub-admin/utils/test_api.test.js
@@ -20,6 +20,7 @@ describe("admin API client", () => {
 
     vi.spyOn(axios, "create").mockReturnValue(client);
     vi.spyOn(axios, "post").mockResolvedValue({ data: {} });
+    vi.spyOn(axios, "get").mockResolvedValue({ data: {} });
     vi.spyOn(axios, "delete").mockResolvedValue({ data: {} });
 
     client.get.mockResolvedValue({ data: {} });
@@ -220,6 +221,7 @@ describe("admin API client", () => {
       "mai_lin",
       "lineart-caption-base",
     );
+    await api.getSiteConfig();
 
     await api.deleteS3Object("admin-token", "models/demo/file.bin");
     await api.prepareDeleteS3Prefix("admin-token", "models/demo/");
@@ -231,6 +233,7 @@ describe("admin API client", () => {
         "X-Admin-Token": "admin-token",
       },
     });
+    expect(axios.get).toHaveBeenCalledWith("/api/site-config");
 
     expect(client.get).toHaveBeenCalledWith("/users", {
       params: { search: "mai", limit: 10, offset: 5, include_orgs: true },

--- a/test/kohaku-hub-admin/utils/test_repository_operation_capabilities.test.js
+++ b/test/kohaku-hub-admin/utils/test_repository_operation_capabilities.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
+
+describe("admin repository operation capabilities", () => {
+  it("fails closed when site config is missing or malformed", () => {
+    expect(getRepositoryOperationCapabilities()).toEqual({
+      revert: false,
+      reset: false,
+      squash: false,
+    });
+    expect(getRepositoryOperationCapabilities({ capabilities: null })).toEqual({
+      revert: false,
+      reset: false,
+      squash: false,
+    });
+  });
+
+  it("accepts only explicit true values", () => {
+    expect(
+      getRepositoryOperationCapabilities({
+        capabilities: {
+          repository_operations: {
+            revert: true,
+            reset: 1,
+            squash: "true",
+          },
+        },
+      }),
+    ).toEqual({
+      revert: true,
+      reset: false,
+      squash: false,
+    });
+  });
+});

--- a/test/kohaku-hub-ui/pages/test_repository_operation_gates.test.js
+++ b/test/kohaku-hub-ui/pages/test_repository_operation_gates.test.js
@@ -1,0 +1,178 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ElementPlusStubs, RouterLinkStub } from "../helpers/vue";
+import axios from "@/testing/axios";
+
+const mocks = vi.hoisted(() => ({
+  route: {
+    params: {
+      type: "model",
+      namespace: "owner",
+      name: "demo",
+      commit_id: "commit-1",
+    },
+  },
+  router: {
+    push: vi.fn(),
+    back: vi.fn(),
+  },
+  authStore: { isAuthenticated: true },
+  settingsAPI: {
+    getSiteConfig: vi.fn(),
+    revertBranch: vi.fn(),
+    resetBranch: vi.fn(),
+    squashRepo: vi.fn(),
+    updateRepoSettings: vi.fn(),
+    getLfsSettings: vi.fn(),
+  },
+  repoAPI: {
+    getInfo: vi.fn(),
+    delete: vi.fn(),
+  },
+  validationAPI: { checkName: vi.fn() },
+  quotaAPI: {
+    getRepoQuota: vi.fn(),
+    recalculateRepoStorage: vi.fn(),
+    setRepoQuota: vi.fn(),
+  },
+}));
+
+vi.mock("vue-router/auto", () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => mocks.router,
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: () => mocks.authStore,
+}));
+
+vi.mock("@/utils/api", () => ({
+  settingsAPI: mocks.settingsAPI,
+  repoAPI: mocks.repoAPI,
+  validationAPI: mocks.validationAPI,
+  quotaAPI: mocks.quotaAPI,
+}));
+
+import CommitPage from "@/pages/[type]s/[namespace]/[name]/commit/[commit_id].vue";
+import SettingsPage from "@/pages/[type]s/[namespace]/[name]/settings.vue";
+
+function mountPage(component) {
+  return mount(component, {
+    global: {
+      stubs: {
+        ...ElementPlusStubs,
+        RouterLink: RouterLinkStub,
+      },
+    },
+  });
+}
+
+function enabledConfig(overrides = {}) {
+  return {
+    capabilities: {
+      repository_operations: {
+        revert: false,
+        reset: false,
+        squash: false,
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe("repository operation capability consumers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(axios, "get").mockImplementation((url) => {
+      if (url.endsWith("/diff")) return Promise.resolve({ data: { files: [] } });
+      return Promise.resolve({
+        data: {
+          commit_id: "commit-1",
+          message: "Initial commit",
+          author: "owner",
+          date: 1_700_000_000,
+          files: [],
+        },
+      });
+    });
+    mocks.authStore.isAuthenticated = true;
+    mocks.settingsAPI.getSiteConfig.mockResolvedValue({ data: enabledConfig() });
+    mocks.settingsAPI.revertBranch.mockResolvedValue({ data: {} });
+    mocks.settingsAPI.resetBranch.mockResolvedValue({ data: {} });
+    mocks.settingsAPI.squashRepo.mockResolvedValue({ data: {} });
+    mocks.repoAPI.getInfo.mockResolvedValue({ data: { private: false } });
+  });
+
+  it("hides commit actions when capability loading fails", async () => {
+    mocks.settingsAPI.getSiteConfig.mockRejectedValueOnce(new Error("offline"));
+
+    const wrapper = mountPage(CommitPage);
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("Revert Commit");
+    expect(wrapper.text()).not.toContain("Reset to This State");
+    expect(mocks.settingsAPI.revertBranch).not.toHaveBeenCalled();
+    expect(mocks.settingsAPI.resetBranch).not.toHaveBeenCalled();
+  });
+
+  it("shows only explicitly enabled commit actions and routes through the API client", async () => {
+    mocks.settingsAPI.getSiteConfig.mockResolvedValueOnce({
+      data: enabledConfig({ revert: true }),
+    });
+
+    const wrapper = mountPage(CommitPage);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Revert Commit");
+    expect(wrapper.text()).not.toContain("Reset to This State");
+
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Revert Commit")
+      .trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Revert");
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Revert")
+      .trigger("click");
+    await flushPromises();
+
+    expect(mocks.settingsAPI.revertBranch).toHaveBeenCalledWith(
+      "model",
+      "owner",
+      "demo",
+      "main",
+      expect.objectContaining({ ref: "commit-1" }),
+    );
+    expect(mocks.settingsAPI.resetBranch).not.toHaveBeenCalled();
+  });
+
+  it("hides squash in repository settings when the capability is false", async () => {
+    const wrapper = mountPage(SettingsPage);
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("Squash repository history");
+    expect(wrapper.text()).not.toContain("Squash Repository");
+    expect(mocks.settingsAPI.squashRepo).not.toHaveBeenCalled();
+  });
+
+  it("shows squash in repository settings only when explicitly enabled", async () => {
+    mocks.settingsAPI.getSiteConfig.mockResolvedValueOnce({
+      data: enabledConfig({ squash: true }),
+    });
+
+    const wrapper = mountPage(SettingsPage);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Squash repository history");
+    expect(wrapper.text()).toContain("Squash Repository");
+  });
+});

--- a/test/kohaku-hub-ui/utils/test_api.test.js
+++ b/test/kohaku-hub-ui/utils/test_api.test.js
@@ -115,6 +115,7 @@ describe("frontend API client", () => {
     await orgAPI.listMembers("acme");
 
     await settingsAPI.whoamiV2();
+    await settingsAPI.getSiteConfig();
     await settingsAPI.getUserProfile("alice");
     await settingsAPI.updateUserSettings("alice", { bio: "hello" });
     await settingsAPI.getOrgProfile("acme");
@@ -177,6 +178,7 @@ describe("frontend API client", () => {
       data: { type: "model", name: "demo", organization: "acme" },
     });
     expect(getSpy).toHaveBeenCalledWith("/api/models/alice/demo");
+    expect(getSpy).toHaveBeenCalledWith("/api/site-config");
     expect(getSpy).toHaveBeenCalledWith("/api/datasets", {
       params: { limit: 5, sort: "likes" },
     });

--- a/test/kohaku-hub-ui/utils/test_api.test.js
+++ b/test/kohaku-hub-ui/utils/test_api.test.js
@@ -104,6 +104,13 @@ describe("frontend API client", () => {
     await repoAPI.listCommits("space", "alice", "demo", "main", {
       limit: 20,
     });
+    await settingsAPI.revertBranch("model", "alice", "demo", "main", {
+      ref: "commit-1",
+    });
+    await settingsAPI.resetBranch("model", "alice", "demo", "main", {
+      ref: "commit-1",
+      force: true,
+    });
 
     await orgAPI.create({ name: "acme" });
     await orgAPI.get("acme");
@@ -179,6 +186,14 @@ describe("frontend API client", () => {
     });
     expect(getSpy).toHaveBeenCalledWith("/api/models/alice/demo");
     expect(getSpy).toHaveBeenCalledWith("/api/site-config");
+    expect(postSpy).toHaveBeenCalledWith(
+      "/api/models/alice/demo/branch/main/revert",
+      { ref: "commit-1" },
+    );
+    expect(postSpy).toHaveBeenCalledWith(
+      "/api/models/alice/demo/branch/main/reset",
+      { ref: "commit-1", force: true },
+    );
     expect(getSpy).toHaveBeenCalledWith("/api/datasets", {
       params: { limit: 5, sort: "likes" },
     });

--- a/test/kohaku-hub-ui/utils/test_repository_operation_capabilities.test.js
+++ b/test/kohaku-hub-ui/utils/test_repository_operation_capabilities.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getRepositoryOperationCapabilities } from "@/utils/repositoryOperationCapabilities";
+
+describe("repository operation capabilities", () => {
+  it("fails closed when the site config is missing or malformed", () => {
+    expect(getRepositoryOperationCapabilities()).toEqual({
+      revert: false,
+      reset: false,
+      squash: false,
+    });
+    expect(getRepositoryOperationCapabilities({ capabilities: null })).toEqual({
+      revert: false,
+      reset: false,
+      squash: false,
+    });
+  });
+
+  it("accepts only explicit true values for each operation", () => {
+    expect(
+      getRepositoryOperationCapabilities({
+        capabilities: {
+          repository_operations: {
+            revert: true,
+            reset: 1,
+            squash: "true",
+          },
+        },
+      }),
+    ).toEqual({
+      revert: true,
+      reset: false,
+      squash: false,
+    });
+  });
+});

--- a/test/kohakuhub/api/repo/routers/test_crud_unit.py
+++ b/test/kohakuhub/api/repo/routers/test_crud_unit.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import HTTPException
 
 import kohakuhub.api.repo.routers.crud as repo_crud
+import kohakuhub.api.operation_capabilities as operation_capabilities
 
 
 class _Expr:
@@ -460,6 +461,9 @@ async def test_move_repo_covers_validation_quota_success_and_nonfatal_cleanup(mo
 
 @pytest.mark.asyncio
 async def test_squash_repo_covers_validation_success_and_recovery(monkeypatch):
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_squash_enabled", True
+    )
     repo_row = SimpleNamespace(
         private=False,
         repo_type="model",
@@ -525,6 +529,28 @@ async def test_squash_repo_covers_validation_success_and_recovery(monkeypatch):
             auth=(SimpleNamespace(username="owner"), False),
         )
     assert squash_error.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_disabled_squash_rejects_before_repository_lookup(monkeypatch):
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_squash_enabled", False
+    )
+
+    def unexpected_repository_lookup(*_args):
+        raise AssertionError("disabled operation reached repository lookup")
+
+    monkeypatch.setattr(repo_crud, "get_repository", unexpected_repository_lookup)
+
+    with pytest.raises(HTTPException) as error:
+        await repo_crud.squash_repo(
+            repo_crud.SquashRepoPayload(repo="owner/demo", type="model"),
+            auth=(SimpleNamespace(username="owner"), False),
+        )
+
+    assert error.value.status_code == 503
+    assert error.value.detail["code"] == "operation_disabled"
+    assert error.value.detail["operation"] == "squash"
 
 
 # ---------------------------------------------------------------------------

--- a/test/kohakuhub/api/test_branches_unit.py
+++ b/test/kohakuhub/api/test_branches_unit.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 import kohakuhub.api.branches as branches_api
+import kohakuhub.api.operation_capabilities as operation_capabilities
 
 
 class _FakeClient:
@@ -281,6 +282,9 @@ async def test_reference_helpers_and_list_repo_refs_cover_pagination_and_fallbac
 
 @pytest.mark.asyncio
 async def test_revert_branch_covers_not_found_conflict_success_and_tracking_failure(monkeypatch):
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_revert_enabled", True
+    )
     repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
@@ -440,6 +444,9 @@ async def test_merge_branches_covers_not_found_conflict_success_and_tracking_pat
 
 @pytest.mark.asyncio
 async def test_reset_branch_covers_guardrails_recoverability_success_and_failures(monkeypatch):
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_reset_enabled", True
+    )
     repo = SimpleNamespace(repo_type="model", full_id="owner/repo")
     user = SimpleNamespace(username="owner")
     client = _FakeClient()
@@ -527,3 +534,45 @@ async def test_reset_branch_covers_guardrails_recoverability_success_and_failure
             "model", "owner", "repo", "feature", branches_api.ResetPayload(ref="abc", force=True), user=user
         )
     assert generic_error.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_disabled_revert_and_reset_reject_before_repository_lookup(monkeypatch):
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_revert_enabled", False
+    )
+    monkeypatch.setattr(
+        operation_capabilities.cfg.app, "repository_reset_enabled", False
+    )
+
+    def unexpected_repository_lookup(*_args):
+        raise AssertionError("disabled operation reached repository lookup")
+
+    monkeypatch.setattr(branches_api, "get_repository", unexpected_repository_lookup)
+    user = SimpleNamespace(username="owner")
+
+    with pytest.raises(HTTPException) as revert_error:
+        await branches_api.revert_branch(
+            "model",
+            "owner",
+            "repo",
+            "main",
+            branches_api.RevertPayload(ref="abc"),
+            user=user,
+        )
+    assert revert_error.value.status_code == 503
+    assert revert_error.value.detail["code"] == "operation_disabled"
+    assert revert_error.value.detail["operation"] == "revert"
+
+    with pytest.raises(HTTPException) as reset_error:
+        await branches_api.reset_branch(
+            "model",
+            "owner",
+            "repo",
+            "main",
+            branches_api.ResetPayload(ref="abc", force=True),
+            user=user,
+        )
+    assert reset_error.value.status_code == 503
+    assert reset_error.value.detail["code"] == "operation_disabled"
+    assert reset_error.value.detail["operation"] == "reset"

--- a/test/kohakuhub/api/test_misc.py
+++ b/test/kohakuhub/api/test_misc.py
@@ -11,6 +11,11 @@ async def test_version_site_config_and_yaml_validation(client):
     site_config_response = await client.get("/api/site-config")
     assert site_config_response.status_code == 200
     assert "site_name" in site_config_response.json()
+    assert site_config_response.json()["capabilities"]["repository_operations"] == {
+        "revert": False,
+        "reset": False,
+        "squash": False,
+    }
 
     valid_yaml_response = await client.post(
         "/api/validate-yaml",

--- a/test/kohakuhub/api/test_misc.py
+++ b/test/kohakuhub/api/test_misc.py
@@ -1,6 +1,13 @@
 """API tests for utility routes."""
 
+from types import SimpleNamespace
+
 import httpx
+import pytest
+
+import kohakuhub.api.branches as branches_api
+import kohakuhub.api.operation_capabilities as operation_capabilities
+import kohakuhub.api.repo.routers.crud as repo_crud
 
 
 async def test_version_site_config_and_yaml_validation(client):
@@ -30,6 +37,78 @@ async def test_version_site_config_and_yaml_validation(client):
     )
     assert invalid_yaml_response.status_code == 200
     assert invalid_yaml_response.json()["valid"] is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_operations_reject_before_auth_and_repository_lookup(
+    app, client, monkeypatch
+):
+    for field in (
+        "repository_revert_enabled",
+        "repository_reset_enabled",
+        "repository_squash_enabled",
+    ):
+        monkeypatch.setattr(operation_capabilities.cfg.app, field, False)
+
+    auth_calls = []
+    repository_lookups = []
+
+    def unexpected_user_dependency():
+        auth_calls.append("user")
+        return SimpleNamespace(username="owner")
+
+    def unexpected_admin_dependency():
+        auth_calls.append("admin")
+        return (SimpleNamespace(username="owner"), False)
+
+    def unexpected_repository_lookup(*_args):
+        repository_lookups.append(True)
+        return SimpleNamespace()
+
+    app.dependency_overrides[branches_api.get_current_user] = unexpected_user_dependency
+    app.dependency_overrides[repo_crud.get_current_user_or_admin] = (
+        unexpected_admin_dependency
+    )
+    monkeypatch.setattr(branches_api, "get_repository", unexpected_repository_lookup)
+    monkeypatch.setattr(repo_crud, "get_repository", unexpected_repository_lookup)
+
+    try:
+        requests = [
+            (
+                "/api/models/owner/demo-model/branch/main/revert",
+                {"ref": "commit-ref"},
+            ),
+            (
+                "/api/models/owner/demo-model/branch/main/reset",
+                {"ref": "commit-ref", "force": True},
+            ),
+            ("/api/repos/squash", {"repo": "owner/demo-model", "type": "model"}),
+        ]
+        responses = [await client.post(path, json=payload) for path, payload in requests]
+    finally:
+        app.dependency_overrides.clear()
+
+    assert [response.status_code for response in responses] == [503, 503, 503]
+    assert [response.json()["detail"]["code"] for response in responses] == [
+        "operation_disabled",
+        "operation_disabled",
+        "operation_disabled",
+    ]
+    assert auth_calls == []
+    assert repository_lookups == []
+
+
+def test_repository_operations_stay_disabled_on_sqlite(monkeypatch):
+    monkeypatch.setattr(operation_capabilities.cfg.app, "db_backend", "sqlite")
+    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_revert_enabled", True)
+    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_reset_enabled", True)
+    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_squash_enabled", True)
+
+    assert operation_capabilities.get_repository_operation_capabilities() == {
+        "revert": False,
+        "reset": False,
+        "squash": False,
+    }
 
 
 async def test_whoami_v2_requires_auth_and_returns_orgs(app, owner_client):

--- a/test/kohakuhub/api/test_misc.py
+++ b/test/kohakuhub/api/test_misc.py
@@ -99,16 +99,23 @@ async def test_disabled_operations_reject_before_auth_and_repository_lookup(
 
 
 def test_repository_operations_stay_disabled_on_sqlite(monkeypatch):
-    monkeypatch.setattr(operation_capabilities.cfg.app, "db_backend", "sqlite")
-    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_revert_enabled", True)
-    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_reset_enabled", True)
-    monkeypatch.setattr(operation_capabilities.cfg.app, "repository_squash_enabled", True)
+    for backend in ("sqlite", "POSTGRES"):
+        monkeypatch.setattr(operation_capabilities.cfg.app, "db_backend", backend)
+        monkeypatch.setattr(
+            operation_capabilities.cfg.app, "repository_revert_enabled", True
+        )
+        monkeypatch.setattr(
+            operation_capabilities.cfg.app, "repository_reset_enabled", True
+        )
+        monkeypatch.setattr(
+            operation_capabilities.cfg.app, "repository_squash_enabled", True
+        )
 
-    assert operation_capabilities.get_repository_operation_capabilities() == {
-        "revert": False,
-        "reset": False,
-        "squash": False,
-    }
+        assert operation_capabilities.get_repository_operation_capabilities() == {
+            "revert": False,
+            "reset": False,
+            "squash": False,
+        }
 
 
 async def test_whoami_v2_requires_auth_and_returns_orgs(app, owner_client):

--- a/test/kohakuhub/api/test_misc.py
+++ b/test/kohakuhub/api/test_misc.py
@@ -5,9 +5,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
-import kohakuhub.api.branches as branches_api
 import kohakuhub.api.operation_capabilities as operation_capabilities
-import kohakuhub.api.repo.routers.crud as repo_crud
 
 
 async def test_version_site_config_and_yaml_validation(client):
@@ -41,14 +39,18 @@ async def test_version_site_config_and_yaml_validation(client):
 
 @pytest.mark.asyncio
 async def test_disabled_operations_reject_before_auth_and_repository_lookup(
-    app, client, monkeypatch
+    app, backend_test_state, client, monkeypatch
 ):
+    active_cfg = backend_test_state.modules.config_module.cfg
+    active_branches = backend_test_state.modules.branches_module
+    active_repo_crud = backend_test_state.modules.repo_crud_module
+
     for field in (
         "repository_revert_enabled",
         "repository_reset_enabled",
         "repository_squash_enabled",
     ):
-        monkeypatch.setattr(operation_capabilities.cfg.app, field, False)
+        monkeypatch.setattr(active_cfg.app, field, False)
 
     auth_calls = []
     repository_lookups = []
@@ -65,12 +67,12 @@ async def test_disabled_operations_reject_before_auth_and_repository_lookup(
         repository_lookups.append(True)
         return SimpleNamespace()
 
-    app.dependency_overrides[branches_api.get_current_user] = unexpected_user_dependency
-    app.dependency_overrides[repo_crud.get_current_user_or_admin] = (
+    app.dependency_overrides[active_branches.get_current_user] = unexpected_user_dependency
+    app.dependency_overrides[active_repo_crud.get_current_user_or_admin] = (
         unexpected_admin_dependency
     )
-    monkeypatch.setattr(branches_api, "get_repository", unexpected_repository_lookup)
-    monkeypatch.setattr(repo_crud, "get_repository", unexpected_repository_lookup)
+    monkeypatch.setattr(active_branches, "get_repository", unexpected_repository_lookup)
+    monkeypatch.setattr(active_repo_crud, "get_repository", unexpected_repository_lookup)
 
     try:
         requests = [
@@ -96,6 +98,62 @@ async def test_disabled_operations_reject_before_auth_and_repository_lookup(
     ]
     assert auth_calls == []
     assert repository_lookups == []
+
+
+@pytest.mark.asyncio
+async def test_enabled_operations_still_require_authentication(
+    app, backend_test_state, client, monkeypatch
+):
+    active_cfg = backend_test_state.modules.config_module.cfg
+    active_branches = backend_test_state.modules.branches_module
+    active_repo_crud = backend_test_state.modules.repo_crud_module
+
+    monkeypatch.setattr(active_cfg.app, "db_backend", "postgres")
+    for field in (
+        "repository_revert_enabled",
+        "repository_reset_enabled",
+        "repository_squash_enabled",
+    ):
+        monkeypatch.setattr(active_cfg.app, field, True)
+    mutation_calls = []
+
+    def unexpected_repository_lookup(*_args):
+        mutation_calls.append("repository")
+        raise AssertionError("anonymous request reached repository logic")
+
+    monkeypatch.setattr(active_branches, "get_repository", unexpected_repository_lookup)
+    monkeypatch.setattr(active_repo_crud, "get_repository", unexpected_repository_lookup)
+    app.dependency_overrides[active_branches.require_repository_revert_enabled] = (
+        lambda: None
+    )
+    app.dependency_overrides[active_branches.require_repository_reset_enabled] = (
+        lambda: None
+    )
+    app.dependency_overrides[active_repo_crud.require_repository_squash_enabled] = (
+        lambda: None
+    )
+
+    requests = [
+        (
+            "/api/models/owner/demo-model/branch/main/revert",
+            {"ref": "commit-ref"},
+        ),
+        (
+            "/api/models/owner/demo-model/branch/main/reset",
+            {"ref": "commit-ref", "force": True},
+        ),
+        ("/api/repos/squash", {"repo": "owner/demo-model", "type": "model"}),
+    ]
+
+    try:
+        responses = [
+            await client.post(path, json=payload) for path, payload in requests
+        ]
+    finally:
+        app.dependency_overrides.clear()
+
+    assert [response.status_code for response in responses] == [401, 401, 401]
+    assert mutation_calls == []
 
 
 def test_repository_operations_stay_disabled_on_sqlite(monkeypatch):

--- a/test/kohakuhub/test_config.py
+++ b/test/kohakuhub/test_config.py
@@ -102,6 +102,9 @@ def test_load_config_merges_file_and_environment(monkeypatch):
     monkeypatch.setenv("KOHAKU_HUB_INTERNAL_BASE_URL", "http://internal-app")
     monkeypatch.setenv("KOHAKU_HUB_API_BASE", "/api/v2")
     monkeypatch.setenv("KOHAKU_HUB_DISABLE_DATASET_VIEWER", "true")
+    monkeypatch.setenv("KOHAKU_HUB_REPOSITORY_REVERT_ENABLED", "true")
+    monkeypatch.setenv("KOHAKU_HUB_REPOSITORY_RESET_ENABLED", "false")
+    monkeypatch.setenv("KOHAKU_HUB_REPOSITORY_SQUASH_ENABLED", "true")
     monkeypatch.setenv("KOHAKU_HUB_DB_BACKEND", "postgres")
     monkeypatch.setenv("KOHAKU_HUB_DATABASE_URL", "postgres://db")
     monkeypatch.setenv("KOHAKU_HUB_DATABASE_KEY", "key")
@@ -149,6 +152,9 @@ def test_load_config_merges_file_and_environment(monkeypatch):
     assert cfg.app.internal_base_url == "http://internal-app"
     assert cfg.app.api_base == "/api/v2"
     assert cfg.app.disable_dataset_viewer is True
+    assert cfg.app.repository_revert_enabled is True
+    assert cfg.app.repository_reset_enabled is False
+    assert cfg.app.repository_squash_enabled is True
     assert cfg.app.db_backend == "postgres"
     assert cfg.app.database_url == "postgres://db"
     assert cfg.app.database_key == "key"
@@ -178,6 +184,9 @@ def test_load_config_uses_defaults_when_file_is_missing(monkeypatch):
     assert cfg.s3.endpoint == "http://localhost:9000"
     assert cfg.lakefs.endpoint == "http://localhost:8000"
     assert cfg.app.base_url == "http://localhost:48888"
+    assert cfg.app.repository_revert_enabled is False
+    assert cfg.app.repository_reset_enabled is False
+    assert cfg.app.repository_squash_enabled is False
     hub_config.load_config.cache_clear()
 
 


### PR DESCRIPTION
## Summary

PR1 from #99: contain Revert, Reset, and Super Squash behind independent default-off capability switches.

- Adds backend flags and public `/api/site-config` capabilities.
- Rejects disabled operations with stable `503 operation_disabled` before repository lookup or downstream mutation.
- Hides Revert/Reset on commit pages and Squash in repository settings unless explicitly enabled.
- Fails closed when capability loading fails or values are not strict booleans.
- Adds zero-downstream-call API tests and frontend fail-closed tests.

No dangerous operation is re-enabled by this PR. This is the containment prerequisite for PR2-PR7 in #99.

## Validation

- Backend targeted: 41 passed
- Frontend targeted: 15 passed
- Frontend full suite: 432 passed
- Backend full suite: running locally
- Python compileall: passed
- `git diff --check`: passed

Local UI build is currently blocked by the baseline import of undeclared `@unocss/reset/tailwind.css` from `src/kohaku-hub-ui/src/main.js`; PR1 does not modify that dependency chain.

Refs #99